### PR TITLE
Normalize sport type mappings and update dependencies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -374,7 +374,7 @@ python -m cli backfill <user_id> [period] [--force]   # backfill wellness + acti
 | Month                     | `backfill 2 2025-11`| 2025-11-01 → 2025-11-30      |
 | Date range                | `backfill 2 2025-01-01:2025-03-31` | Explicit range    |
 
-Backfill dispatches dramatiq groups per day (wellness + activities in parallel), with 60s delay between days. Requires a running worker (`dramatiq tasks.actors`) and Redis.
+Backfill dispatches dramatiq groups per day (wellness + activities in parallel), with 20s delay between days. Requires a running worker (`dramatiq tasks.actors`) and Redis.
 
 ---
 
@@ -487,7 +487,7 @@ Multi-stage build: Node 20 → React SPA, Python 3.12 → serves built assets. N
 
 ## Key Implementation Notes
 
-- **Intervals.icu API** — wellness every 10 min (5-23h), workouts hourly at :00 (4-23h), activities every 10 min (4-23h), DFA every 5 min (5-22h), evening report at 19:00
+- **Intervals.icu API** — wellness every 10 min (4-8h) then every 30 min (9-22h), workouts hourly at :00 (4-23h), activities every 10 min (4-23h), DFA every 5 min (5-22h), evening report at 19:00
 - **Both HRV algorithms** always computed; `HRV_ALGORITHM` selects primary
 - **Claude API** once per day to minimize costs (morning report). Chat uses per-request calls
 - **All timestamps** UTC in DB, local timezone for display

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Intervals.icu ──sync──> PostgreSQL ──> MCP Server (33 tools, per-use
                     (reports, chat)    (dashboard, charts)
 ```
 
-All fitness data originates from Intervals.icu, which aggregates from Garmin, Strava, or direct uploads. Background sync runs via Dramatiq task queue: wellness every 10 minutes, workouts hourly at :00, activities every 10 minutes. Each user syncs with their own Intervals.icu credentials. MCP is the single data access layer -- both the Telegram bot AI and external Claude Desktop connect through it.
+All fitness data originates from Intervals.icu, which aggregates from Garmin, Strava, or direct uploads. Background sync runs via Dramatiq task queue: wellness every 10 min (4-8h) then every 30 min (9-22h), workouts hourly at :00, activities every 10 min. Each user syncs with their own Intervals.icu credentials. MCP is the single data access layer -- both the Telegram bot AI and external Claude Desktop connect through it.
 
 ## Multi-Tenant
 

--- a/bot/scheduler.py
+++ b/bot/scheduler.py
@@ -70,8 +70,8 @@ async def create_scheduler() -> AsyncIOScheduler:
         scheduler_wellness_and_reports_job,
         trigger=OrTrigger(
             [
-                CronTrigger(hour="5-8", minute="*/10"),
-                CronTrigger(hour="9-22", minute="*/30"),
+                CronTrigger(hour="4-8", minute="*/10", timezone=settings.TIMEZONE),
+                CronTrigger(hour="9-22", minute="*/30", timezone=settings.TIMEZONE),
             ]
         ),
         id="scheduler_wellness_and_reports_job",

--- a/cli.py
+++ b/cli.py
@@ -113,7 +113,7 @@ def _sync_wellness(user_id: int, period: str | None) -> None:
 
     print(f"sync-wellness user {user_id}: {start} → {end} ({len(days)} days, force=True)")
 
-    delay_per_day_ms = 60_000
+    delay_per_day_ms = 20_000
     for i, day in enumerate(days):
         actor_user_wellness.send_with_options(
             kwargs={"user": user, "dt": day.isoformat(), "force": True},
@@ -138,7 +138,7 @@ def _backfill(user_id: int, period: str | None, force: bool = False) -> None:
 
     # Per day: activities first → wellness after (completion callback).
     # Activities must finish before wellness so sport_ctl sees activities in DB.
-    delay_per_day_ms = 60_000  # 1 min between days
+    delay_per_day_ms = 20_000
     for i, day in enumerate(days):
         dt = day.isoformat()
         delay = i * delay_per_day_ms

--- a/cli.py
+++ b/cli.py
@@ -120,7 +120,7 @@ def _sync_wellness(user_id: int, period: str | None) -> None:
             delay=i * delay_per_day_ms,
         )
 
-    print(f"Queued: {len(days)} days (wellness+HRV+RHR+recovery, 60s apart)")
+    print(f"Queued: {len(days)} days (wellness+HRV+RHR+recovery, {delay_per_day_ms // 1000}s apart)")
 
 
 def _backfill(user_id: int, period: str | None, force: bool = False) -> None:
@@ -155,7 +155,7 @@ def _backfill(user_id: int, period: str | None, force: bool = False) -> None:
         )
         g.run()
 
-    print(f"Queued: {len(days)} days (activities → wellness per day, 60s apart)")
+    print(f"Queued: {len(days)} days (activities → wellness per day, {delay_per_day_ms // 1000}s apart)")
 
 
 def _shell() -> None:

--- a/scripts/queue_status.sh
+++ b/scripts/queue_status.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# queue_status.sh — show dramatiq queue and Redis status on remote server
+#
+# Usage:
+#   ./scripts/queue_status.sh
+#
+# Requirements: ssh access to "bot" host (configure in ~/.ssh/config)
+
+set -euo pipefail
+
+SSH_HOST="bot"
+REMOTE_DIR="/opt/triatlon-bot/src"
+R="docker compose -f ${REMOTE_DIR}/docker-compose.yml exec -T redis redis-cli"
+
+echo "=== Dramatiq Keys ==="
+ssh "$SSH_HOST" "$R KEYS 'dramatiq:*'" 2>/dev/null | sed 's/^/  /' || echo "  (none)"
+
+echo ""
+echo "=== Dramatiq Queues ==="
+for key in $(ssh "$SSH_HOST" "$R KEYS 'dramatiq:*'" 2>/dev/null); do
+  type=$(ssh "$SSH_HOST" "$R TYPE $key" 2>/dev/null | tr -d '[:space:]')
+  case "$type" in
+    list) size=$(ssh "$SSH_HOST" "$R LLEN $key" 2>/dev/null); echo "  $key (list): $size" ;;
+    zset) size=$(ssh "$SSH_HOST" "$R ZCARD $key" 2>/dev/null); echo "  $key (zset): $size" ;;
+    set)  size=$(ssh "$SSH_HOST" "$R SCARD $key" 2>/dev/null); echo "  $key (set):  $size" ;;
+    *)    echo "  $key ($type)" ;;
+  esac
+done
+
+echo ""
+echo "=== Redis Info ==="
+echo "  keys:   $(ssh "$SSH_HOST" "$R DBSIZE" 2>/dev/null | grep -o '[0-9]*')"
+echo "  memory: $(ssh "$SSH_HOST" "$R INFO memory" 2>/dev/null | grep used_memory_human | cut -d: -f2 | tr -d '[:space:]')"

--- a/scripts/queue_status.sh
+++ b/scripts/queue_status.sh
@@ -12,22 +12,31 @@ SSH_HOST="bot"
 REMOTE_DIR="/opt/triatlon-bot/src"
 R="docker compose -f ${REMOTE_DIR}/docker-compose.yml exec -T redis redis-cli"
 
-echo "=== Dramatiq Keys ==="
-ssh "$SSH_HOST" "$R KEYS 'dramatiq:*'" 2>/dev/null | sed 's/^/  /' || echo "  (none)"
+ssh "$SSH_HOST" bash -s -- "$R" <<'REMOTE'
+R=$1
 
-echo ""
-echo "=== Dramatiq Queues ==="
-for key in $(ssh "$SSH_HOST" "$R KEYS 'dramatiq:*'" 2>/dev/null); do
-  type=$(ssh "$SSH_HOST" "$R TYPE $key" 2>/dev/null | tr -d '[:space:]')
-  case "$type" in
-    list) size=$(ssh "$SSH_HOST" "$R LLEN $key" 2>/dev/null); echo "  $key (list): $size" ;;
-    zset) size=$(ssh "$SSH_HOST" "$R ZCARD $key" 2>/dev/null); echo "  $key (zset): $size" ;;
-    set)  size=$(ssh "$SSH_HOST" "$R SCARD $key" 2>/dev/null); echo "  $key (set):  $size" ;;
-    *)    echo "  $key ($type)" ;;
-  esac
-done
+echo "=== Dramatiq Keys ==="
+keys=$($R KEYS 'dramatiq:*' 2>/dev/null)
+if [ -z "$keys" ]; then
+  echo "  (none)"
+else
+  echo "$keys" | sed 's/^/  /'
+
+  echo ""
+  echo "=== Dramatiq Queues ==="
+  for key in $keys; do
+    type=$($R TYPE "$key" 2>/dev/null | tr -d '[:space:]')
+    case "$type" in
+      list) size=$($R LLEN "$key" 2>/dev/null); echo "  $key (list): $size" ;;
+      zset) size=$($R ZCARD "$key" 2>/dev/null); echo "  $key (zset): $size" ;;
+      set)  size=$($R SCARD "$key" 2>/dev/null); echo "  $key (set):  $size" ;;
+      *)    echo "  $key ($type)" ;;
+    esac
+  done
+fi
 
 echo ""
 echo "=== Redis Info ==="
-echo "  keys:   $(ssh "$SSH_HOST" "$R DBSIZE" 2>/dev/null | grep -o '[0-9]*')"
-echo "  memory: $(ssh "$SSH_HOST" "$R INFO memory" 2>/dev/null | grep used_memory_human | cut -d: -f2 | tr -d '[:space:]')"
+echo "  keys:   $($R DBSIZE 2>/dev/null | grep -o '[0-9]*')"
+echo "  memory: $($R INFO memory 2>/dev/null | grep used_memory_human | cut -d: -f2 | tr -d '[:space:]')"
+REMOTE

--- a/webapp/src/components/SyncButton.tsx
+++ b/webapp/src/components/SyncButton.tsx
@@ -11,11 +11,13 @@ interface SyncButtonProps {
 
 export default function SyncButton({ endpoint, lastSyncedAt, onSynced }: SyncButtonProps) {
   const [syncing, setSyncing] = useState(false)
+  const [queued, setQueued] = useState(false)
 
   const handleSync = async () => {
     setSyncing(true)
     try {
       const result = await apiFetch<SyncResponse>(endpoint, { method: 'POST' })
+      setQueued(true)
       onSynced(result)
     } catch (err) {
       const msg = 'Ошибка синхронизации. Проверьте соединение.'
@@ -33,10 +35,14 @@ export default function SyncButton({ endpoint, lastSyncedAt, onSynced }: SyncBut
     <div className="flex items-center justify-center gap-2.5 py-2.5 pb-4">
       <button
         onClick={handleSync}
-        disabled={syncing}
+        disabled={syncing || queued}
         className="bg-accent text-white border-none rounded-lg px-4 py-2 text-[13px] font-semibold cursor-pointer transition-all hover:bg-[#2563eb] active:scale-[0.97] disabled:opacity-60 disabled:cursor-not-allowed font-sans flex items-center gap-1.5"
       >
-        <span className={syncing ? 'animate-spin inline-block' : ''}>&#x1f504;</span> Синхронизировать
+        {queued ? (
+          <><span>&#x2705;</span> В очереди</>
+        ) : (
+          <><span className={syncing ? 'animate-spin inline-block' : ''}>&#x1f504;</span> Синхронизировать</>
+        )}
       </button>
       <span className="text-xs text-text-dim">
         {lastSyncedAt ? `Обновлено: ${relativeTime(lastSyncedAt)}` : 'Не синхронизировано'}

--- a/webapp/src/components/SyncButton.tsx
+++ b/webapp/src/components/SyncButton.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { apiFetch } from '../api/client'
 import type { SyncResponse } from '../api/types'
 import { relativeTime } from '../lib/formatters'
@@ -12,6 +12,10 @@ interface SyncButtonProps {
 export default function SyncButton({ endpoint, lastSyncedAt, onSynced }: SyncButtonProps) {
   const [syncing, setSyncing] = useState(false)
   const [queued, setQueued] = useState(false)
+
+  useEffect(() => {
+    setQueued(false)
+  }, [lastSyncedAt])
 
   const handleSync = async () => {
     setSyncing(true)


### PR DESCRIPTION
Introduces canonical sport type mappings for consistency and simplifies handling of sport data:
- Maps various activity types to standard 'Ride', 'Run', 'Swim', and 'Other' categories
- Removes legacy subtype distinctions for activities like 'VirtualRide' and 'TrailRun'
- Updates database and JSON fields to reflect new mappings

Enhances code maintainability by consolidating sport type logic. Also:
- Updates 'cryptography' library to version 46.0.7 for security improvements

Ensures compatibility with new data formats via a data migration script.