### PR TITLE
Fix /workout push button replay via direct MCP call (#131)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,6 +152,7 @@ All commands use `@athlete_required` decorator — resolves `User` from Telegram
 /start      — welcome message + create User in DB + Mini App button
 /morning    — trigger morning report via dramatiq actor
 /dashboard  — dashboard link (Mini App)
+/workout    — interactive workout generation: sport picker → dry-run preview → "Отправить в Intervals" button
 /web        — one-time code for desktop login (5 min TTL)
 /stick      — increment IQOS stick counter for today (owner only)
 /health     — server diagnostics: DB, Redis, queues, Intervals.icu, Anthropic (owner only)
@@ -163,7 +164,9 @@ All commands use `@athlete_required` decorator — resolves `User` from Telegram
 <reply>     — reply context included as "[В ответ на: ...]"
 ```
 
-**Callback handlers:** `ramp_test:{sport}` — create ramp test, `update_zones` — update HR zones.
+**Callback handlers:** `ramp_test:{sport}` — create ramp test, `update_zones` — update HR zones, `workout:{sport}` / `workout_push` / `workout_cancel` — `/workout` ConversationHandler states.
+
+**`/workout` two-phase flow:** generation calls `suggest_workout` (or `compose_workout` for fitness) with `dry_run=True` / `push_to_intervals=False`. `bot/agent.py:chat()` accepts `tool_calls_out: list[dict] | None` — when provided, every tool invocation is appended as `{"name", "input"}`. The handler stashes the last previewable call in `context.user_data["pending_workout"]`. On "✅ Отправить в Intervals" tap, `workout_push` pops the draft, flips the preview flag, and calls `MCPClient.call_tool` directly **without** re-invoking Claude — so what lands in Intervals.icu is bit-for-bit identical to the preview. Prevents prompt-injection on the state-mutating step and saves one inference round per push. See `bot/main.py:_PREVIEWABLE_TOOLS` for the flag-name mapping.
 
 ---
 

--- a/bot/agent.py
+++ b/bot/agent.py
@@ -4,6 +4,7 @@ Tools are fetched dynamically from MCP server and tool calls are proxied via HTT
 """
 
 import base64
+import copy
 import json
 import logging
 
@@ -35,10 +36,16 @@ class ClaudeAgent:
         tools: list[dict],
         max_tokens: int = 4096,
         max_iterations: int = 10,
+        tool_calls_out: list[dict] | None = None,
     ) -> tuple[str, dict]:
         """Run Claude API with tool-use loop. Returns (text, usage_totals).
 
         Tool calls are proxied to MCP server via HTTP.
+
+        If ``tool_calls_out`` is provided, every tool invocation is appended as
+        ``{"name": str, "input": dict}`` in order. Callers use this to recover
+        the exact args Claude passed, e.g. to replay a dry-run as a real push
+        without re-inference.
         """
         total_usage = {"input_tokens": 0, "output_tokens": 0, "cache_read_tokens": 0, "cache_creation_tokens": 0}
 
@@ -58,6 +65,11 @@ class ClaudeAgent:
             tool_results = []
             for block in response.content:
                 if block.type == "tool_use":
+                    if tool_calls_out is not None:
+                        # Deep copy so later tool-side or caller-side mutations
+                        # of either `block.input` or the recorded snapshot can't
+                        # cause drift between what we saw and what we replay.
+                        tool_calls_out.append({"name": block.name, "input": copy.deepcopy(block.input)})
                     result = await mcp.call_tool(block.name, block.input)
                     tool_results.append(
                         {
@@ -99,11 +111,14 @@ class ClaudeAgent:
         image_data: bytes | None = None,
         image_media_type: str = "image/jpeg",
         image_url: str | None = None,
+        tool_calls_out: list[dict] | None = None,
     ) -> str:
         """Handle a free-form chat message. Stateless: no conversation history.
 
         Tools are fetched dynamically from MCP server.
         mcp_token: per-user MCP Bearer token. Falls back to global MCP_AUTH_TOKEN.
+        tool_calls_out: if provided, each tool invocation is appended as
+            ``{"name": str, "input": dict}`` in call order.
         """
         mcp = MCPClient(token=mcp_token)
         system = await get_system_prompt_chat(user_id=user_id, language=language)
@@ -138,7 +153,9 @@ class ClaudeAgent:
         else:
             messages = [{"role": "user", "content": user_message}]
 
-        text, usage = await self._run_tool_use_loop(mcp, system, messages, tools, max_tokens=2048)
+        text, usage = await self._run_tool_use_loop(
+            mcp, system, messages, tools, max_tokens=2048, tool_calls_out=tool_calls_out
+        )
 
         try:
             await ApiUsageDaily.increment(user_id=user_id, **usage)

--- a/bot/agent.py
+++ b/bot/agent.py
@@ -37,15 +37,21 @@ class ClaudeAgent:
         max_tokens: int = 4096,
         max_iterations: int = 10,
         tool_calls_out: list[dict] | None = None,
+        tool_calls_filter: set[str] | None = None,
     ) -> tuple[str, dict]:
         """Run Claude API with tool-use loop. Returns (text, usage_totals).
 
         Tool calls are proxied to MCP server via HTTP.
 
-        If ``tool_calls_out`` is provided, every tool invocation is appended as
+        If ``tool_calls_out`` is provided, each tool invocation is appended as
         ``{"name": str, "input": dict}`` in order. Callers use this to recover
         the exact args Claude passed, e.g. to replay a dry-run as a real push
         without re-inference.
+
+        ``tool_calls_filter`` narrows which tool names are recorded — pass a
+        small set (e.g. ``{"suggest_workout", "compose_workout"}``) to avoid
+        deep-copying large unrelated inputs like ``list_exercise_cards``. When
+        ``None``, every tool call is recorded (legacy behaviour).
         """
         total_usage = {"input_tokens": 0, "output_tokens": 0, "cache_read_tokens": 0, "cache_creation_tokens": 0}
 
@@ -65,7 +71,7 @@ class ClaudeAgent:
             tool_results = []
             for block in response.content:
                 if block.type == "tool_use":
-                    if tool_calls_out is not None:
+                    if tool_calls_out is not None and (tool_calls_filter is None or block.name in tool_calls_filter):
                         # Deep copy so later tool-side or caller-side mutations
                         # of either `block.input` or the recorded snapshot can't
                         # cause drift between what we saw and what we replay.
@@ -112,6 +118,7 @@ class ClaudeAgent:
         image_media_type: str = "image/jpeg",
         image_url: str | None = None,
         tool_calls_out: list[dict] | None = None,
+        tool_calls_filter: set[str] | None = None,
     ) -> str:
         """Handle a free-form chat message. Stateless: no conversation history.
 
@@ -119,6 +126,8 @@ class ClaudeAgent:
         mcp_token: per-user MCP Bearer token. Falls back to global MCP_AUTH_TOKEN.
         tool_calls_out: if provided, each tool invocation is appended as
             ``{"name": str, "input": dict}`` in call order.
+        tool_calls_filter: optional set of tool names — only matching calls
+            are recorded. Use to avoid deep-copying unrelated large inputs.
         """
         mcp = MCPClient(token=mcp_token)
         system = await get_system_prompt_chat(user_id=user_id, language=language)
@@ -154,7 +163,13 @@ class ClaudeAgent:
             messages = [{"role": "user", "content": user_message}]
 
         text, usage = await self._run_tool_use_loop(
-            mcp, system, messages, tools, max_tokens=2048, tool_calls_out=tool_calls_out
+            mcp,
+            system,
+            messages,
+            tools,
+            max_tokens=2048,
+            tool_calls_out=tool_calls_out,
+            tool_calls_filter=tool_calls_filter,
         )
 
         try:

--- a/bot/main.py
+++ b/bot/main.py
@@ -1,10 +1,12 @@
 import asyncio
+import copy
 import logging
 import os
 import time
 import uuid
 import zoneinfo
 from datetime import datetime
+from typing import Callable, NamedTuple
 
 import httpx
 import psutil
@@ -28,6 +30,7 @@ from bot.decorator import athlete_required
 from bot.i18n import _
 from bot.i18n import set_language as _set_lang
 from bot.scheduler import create_scheduler
+from bot.tools import MCPClient
 from config import settings
 from data.db import IqosDaily, User, UserDTO, Wellness, get_session
 from data.redis_client import close_redis, get_redis, init_redis
@@ -380,6 +383,69 @@ async def handle_photo_message(update: Update, context: ContextTypes.DEFAULT_TYP
 WORKOUT_CHOOSE_SPORT, WORKOUT_DIALOG = range(2)
 
 
+class PreviewableTool(NamedTuple):
+    """Contract for tools that support a two-phase preview/push flow.
+
+    is_preview(input) returns True if the tool invocation was a preview
+    (safe to replay as a push). apply_push(input) mutates the input dict
+    in place to flip whichever boolean flag turns preview into a real push.
+    """
+
+    is_preview: Callable[[dict], bool]
+    apply_push: Callable[[dict], None]
+
+
+def _suggest_workout_is_preview(inp: dict) -> bool:
+    # suggest_workout: dry_run=True means preview, default False pushes.
+    return inp.get("dry_run") is True
+
+
+def _suggest_workout_apply_push(inp: dict) -> None:
+    inp["dry_run"] = False
+
+
+def _compose_workout_is_preview(inp: dict) -> bool:
+    # compose_workout: push_to_intervals=False (or absent) means preview,
+    # True pushes. Default in the tool signature is False.
+    return inp.get("push_to_intervals") is not True
+
+
+def _compose_workout_apply_push(inp: dict) -> None:
+    inp["push_to_intervals"] = True
+
+
+_PREVIEWABLE_TOOLS: dict[str, PreviewableTool] = {
+    "suggest_workout": PreviewableTool(_suggest_workout_is_preview, _suggest_workout_apply_push),
+    "compose_workout": PreviewableTool(_compose_workout_is_preview, _compose_workout_apply_push),
+}
+
+
+def _extract_pending_workout(tool_calls: list[dict]) -> dict | None:
+    """Find the most recent previewed workout tool call that can be replayed as a push.
+
+    Scans in reverse order so that if Claude revised the workout twice in one
+    turn, we pick the final version. Returns ``{"name", "input"}`` where
+    ``input`` is a fresh deep copy — safe to mutate without touching the
+    agent's tool-use history.
+    """
+    for call in reversed(tool_calls):
+        name = call.get("name")
+        tool_cfg = _PREVIEWABLE_TOOLS.get(name) if isinstance(name, str) else None
+        if tool_cfg is None:
+            continue
+        if tool_cfg.is_preview(call.get("input", {})):
+            return {"name": name, "input": copy.deepcopy(call.get("input", {}))}
+    return None
+
+
+def _apply_push_flag(pending: dict) -> None:
+    """Flip the preview flag in place so the tool executes as a real push."""
+    tool_cfg = _PREVIEWABLE_TOOLS.get(pending["name"])
+    if tool_cfg is None:
+        return
+    tool_cfg.apply_push(pending["input"])
+
+
 @athlete_required
 async def workout_start(update: Update, context: ContextTypes.DEFAULT_TYPE, user: User) -> int:
     """Entry point: /workout → show sport selection."""
@@ -421,15 +487,20 @@ async def workout_sport_chosen(update: Update, context: ContextTypes.DEFAULT_TYP
         prompt = (
             "Сгенерируй фитнес-тренировку на сегодня. "
             "Сначала вызови get_animation_guidelines, затем list_exercise_cards, "
-            "и собери тренировку через compose_workout с dry_run=True."
+            "и собери тренировку через compose_workout с push_to_intervals=False "
+            "(это preview-режим, не пушим сразу — пользователь подтвердит через кнопку)."
         )
 
+    tool_calls: list[dict] = []
     try:
-        response = await agent.chat(prompt, mcp_token=user.mcp_token, user_id=user.id)
+        response = await agent.chat(prompt, mcp_token=user.mcp_token, user_id=user.id, tool_calls_out=tool_calls)
         context.user_data["workout_messages"].append({"role": "assistant", "content": response})
     except Exception:
         logger.exception("Workout generation failed")
         response = "Ошибка при генерации. Попробуй ещё раз или /cancel."
+
+    # Always replace so a previous draft can't linger if the new turn produced none.
+    context.user_data["pending_workout"] = _extract_pending_workout(tool_calls)
 
     keyboard = InlineKeyboardMarkup(
         [
@@ -457,12 +528,16 @@ async def workout_dialog_text(update: Update, context: ContextTypes.DEFAULT_TYPE
 
     await update.message.chat.send_action("typing")
 
+    tool_calls: list[dict] = []
     try:
-        response = await agent.chat(prompt, mcp_token=user.mcp_token, user_id=user.id)
+        response = await agent.chat(prompt, mcp_token=user.mcp_token, user_id=user.id, tool_calls_out=tool_calls)
         context.user_data["workout_messages"].append({"role": "assistant", "content": response})
     except Exception:
         logger.exception("Workout dialog error")
         response = "Ошибка. Попробуй ещё раз или /cancel."
+
+    # Always replace so a previous draft can't linger if the new turn produced none.
+    context.user_data["pending_workout"] = _extract_pending_workout(tool_calls)
 
     keyboard = InlineKeyboardMarkup(
         [
@@ -481,24 +556,45 @@ async def workout_dialog_text(update: Update, context: ContextTypes.DEFAULT_TYPE
 
 @athlete_required
 async def workout_push(update: Update, context: ContextTypes.DEFAULT_TYPE, user: User) -> int:
-    """Push the generated workout to Intervals.icu via Claude tool-use."""
+    """Push the cached dry-run workout to Intervals.icu via direct MCP call.
+
+    Replays the exact tool invocation Claude made during the dry-run with
+    ``dry_run=False`` — no second Claude inference pass, so the workout that
+    reaches Intervals.icu is bit-for-bit what the user saw in the preview.
+    """
     query = update.callback_query
     await query.answer()
     await query.edit_message_reply_markup(reply_markup=None)
 
-    sport = context.user_data.get("workout_sport", "Run")
+    # Consume-on-read: pop immediately so a duplicate tap (or a follow-up
+    # tap from an older message's inline button) cannot replay the draft.
+    pending = context.user_data.pop("pending_workout", None)
+    if not pending:
+        await query.message.reply_text("Не нашёл черновик тренировки — сгенерируй её заново через /workout.")
+        context.user_data.pop("workout_sport", None)
+        context.user_data.pop("workout_messages", None)
+        return ConversationHandler.END
+
     await query.message.chat.send_action("typing")
 
-    prompt = (
-        f"Отправь последнюю сгенерированную тренировку ({sport}) в Intervals. "
-        f"Вызови suggest_workout с теми же параметрами но dry_run=False."
-    )
+    tool_name = pending["name"]
+    _apply_push_flag(pending)  # flip dry_run / push_to_intervals in place
 
     try:
-        response = await agent.chat(prompt, mcp_token=user.mcp_token, user_id=user.id)
+        mcp = MCPClient(token=user.mcp_token)
+        result = await mcp.call_tool(tool_name, pending["input"])
+        # MCPClient.call_tool returns a dict. Tools that respond with plain
+        # text get wrapped as {"text": "..."}. JSON-RPC errors → {"error": "..."}.
+        if isinstance(result, dict) and result.get("error"):
+            logger.warning("MCP tool %s returned error: %s", tool_name, result["error"])
+            response = f"Ошибка при отправке: {result['error']}"
+        elif isinstance(result, dict) and result.get("text"):
+            response = result["text"]
+        else:
+            response = "Тренировка отправлена в Intervals.icu."
     except Exception:
-        logger.exception("Workout push failed")
-        response = "Ошибка при отправке."
+        logger.exception("Workout push failed (tool=%s)", tool_name)
+        response = "Ошибка при отправке в Intervals.icu. Попробуй ещё раз или /cancel."
 
     try:
         await query.message.reply_text(response, parse_mode="Markdown")
@@ -520,6 +616,7 @@ async def workout_cancel(update: Update, context: ContextTypes.DEFAULT_TYPE, use
 
     context.user_data.pop("workout_sport", None)
     context.user_data.pop("workout_messages", None)
+    context.user_data.pop("pending_workout", None)
     return ConversationHandler.END
 
 
@@ -528,6 +625,7 @@ async def workout_cancel_command(update: Update, context: ContextTypes.DEFAULT_T
     await update.message.reply_text(_("Создание тренировки отменено."))
     context.user_data.pop("workout_sport", None)
     context.user_data.pop("workout_messages", None)
+    context.user_data.pop("pending_workout", None)
     return ConversationHandler.END
 
 

--- a/bot/main.py
+++ b/bot/main.py
@@ -439,10 +439,19 @@ def _extract_pending_workout(tool_calls: list[dict]) -> dict | None:
 
 
 def _apply_push_flag(pending: dict) -> None:
-    """Flip the preview flag in place so the tool executes as a real push."""
-    tool_cfg = _PREVIEWABLE_TOOLS.get(pending["name"])
+    """Flip the preview flag in place so the tool executes as a real push.
+
+    Raises KeyError if the pending draft references a tool we don't know how
+    to push. This should not happen in practice because
+    :func:`_extract_pending_workout` only stores tools from
+    ``_PREVIEWABLE_TOOLS``, but the guard prevents a silent no-op in which
+    the caller would re-run the tool still in preview mode and show a
+    misleading success message to the user.
+    """
+    name = pending["name"]
+    tool_cfg = _PREVIEWABLE_TOOLS.get(name)
     if tool_cfg is None:
-        return
+        raise KeyError(f"No push flag config for tool {name!r}")
     tool_cfg.apply_push(pending["input"])
 
 
@@ -493,7 +502,13 @@ async def workout_sport_chosen(update: Update, context: ContextTypes.DEFAULT_TYP
 
     tool_calls: list[dict] = []
     try:
-        response = await agent.chat(prompt, mcp_token=user.mcp_token, user_id=user.id, tool_calls_out=tool_calls)
+        response = await agent.chat(
+            prompt,
+            mcp_token=user.mcp_token,
+            user_id=user.id,
+            tool_calls_out=tool_calls,
+            tool_calls_filter=set(_PREVIEWABLE_TOOLS.keys()),
+        )
         context.user_data["workout_messages"].append({"role": "assistant", "content": response})
     except Exception:
         logger.exception("Workout generation failed")
@@ -530,7 +545,13 @@ async def workout_dialog_text(update: Update, context: ContextTypes.DEFAULT_TYPE
 
     tool_calls: list[dict] = []
     try:
-        response = await agent.chat(prompt, mcp_token=user.mcp_token, user_id=user.id, tool_calls_out=tool_calls)
+        response = await agent.chat(
+            prompt,
+            mcp_token=user.mcp_token,
+            user_id=user.id,
+            tool_calls_out=tool_calls,
+            tool_calls_filter=set(_PREVIEWABLE_TOOLS.keys()),
+        )
         context.user_data["workout_messages"].append({"role": "assistant", "content": response})
     except Exception:
         logger.exception("Workout dialog error")
@@ -578,7 +599,16 @@ async def workout_push(update: Update, context: ContextTypes.DEFAULT_TYPE, user:
     await query.message.chat.send_action("typing")
 
     tool_name = pending["name"]
-    _apply_push_flag(pending)  # flip dry_run / push_to_intervals in place
+    try:
+        _apply_push_flag(pending)  # flip dry_run / push_to_intervals in place
+    except KeyError:
+        logger.error("workout_push: unknown tool %s cached in pending_workout", tool_name)
+        await query.message.reply_text(
+            "Не могу отправить: внутренняя ошибка (неизвестный тип тренировки). " "Сгенерируй заново через /workout."
+        )
+        context.user_data.pop("workout_sport", None)
+        context.user_data.pop("workout_messages", None)
+        return ConversationHandler.END
 
     try:
         mcp = MCPClient(token=user.mcp_token)
@@ -596,10 +626,11 @@ async def workout_push(update: Update, context: ContextTypes.DEFAULT_TYPE, user:
         logger.exception("Workout push failed (tool=%s)", tool_name)
         response = "Ошибка при отправке в Intervals.icu. Попробуй ещё раз или /cancel."
 
-    try:
-        await query.message.reply_text(response, parse_mode="Markdown")
-    except Exception:
-        await query.message.reply_text(response)
+    # No parse_mode: the response comes straight from an MCP tool and may
+    # contain user-controlled strings (workout name, rationale, upstream
+    # error payloads) with Markdown special chars like _ * [ ] ( ). Sending
+    # as plain text avoids broken formatting and fake clickable links.
+    await query.message.reply_text(response)
 
     context.user_data.pop("workout_sport", None)
     context.user_data.pop("workout_messages", None)


### PR DESCRIPTION
## Summary

Closes #131. The "✅ Отправить в Intervals" button after a dry-run workout preview silently did nothing — `workout_push` invoked the stateless Claude agent with a vague "send the last workout" prompt, and Claude had no memory of the previous tool call.

**Fix:** capture the dry-run tool-call args during generation, then on button tap call MCP directly with the exact same args + flipped preview flag. Zero Claude re-inference on the push path.

## Changes

- `bot/agent.py` — new optional `tool_calls_out: list[dict] | None` on `chat()` / `_run_tool_use_loop()`. When provided, every tool invocation is deep-copied and appended as `{name, input}`. Existing callers unchanged (backward-compat).
- `bot/main.py` — typed `PreviewableTool` NamedTuple with named `is_preview` / `apply_push` functions covering both `suggest_workout` (uses `dry_run`) and `compose_workout` (uses `push_to_intervals`).
- `bot/main.py` — `_extract_pending_workout` scans tool calls in reverse, returns a deep-copied snapshot of the last previewable call.
- `bot/main.py` — `workout_sport_chosen` / `workout_dialog_text` always replace `context.user_data["pending_workout"]` so stale drafts can't linger.
- `bot/main.py` — `workout_push` rewritten: consume-on-read pop (guards against double-tap / stale inline buttons), flip preview flag, direct `MCPClient.call_tool` with per-user `mcp_token`.
- `bot/main.py` — `workout_cancel` / `workout_cancel_command` also clear `pending_workout`.
- `bot/main.py` — WeightTraining prompt corrected: `compose_workout` uses `push_to_intervals=False` for preview, not `dry_run=True`.
- `CLAUDE.md` — documents `/workout` command and the two-phase preview pattern.

## Security

Push path no longer runs Claude inference → eliminates prompt-injection vector on the state-mutating step (writing to Intervals.icu calendar). Per-user MCP token preserved; `context.user_data` is per-telegram-user by PTB design. Security review: **clean**, zero new findings.

## Perf

Saves one Claude API call per successful workout push.

## Test plan

- [x] 32/32 regression tests pass: `poetry run pytest tests/tasks/test_agent_usage.py tests/ai/test_chat.py`
- [x] Manual coverage of `_extract_pending_workout` and `_apply_push_flag`: suggest_workout / compose_workout / last-wins / deep-copy isolation / unknown tool / empty payload
- [ ] Manual E2E on staging: `/workout` → sport picker → dry-run preview → tap "Отправить в Intervals" → verify workout appears in Intervals.icu calendar
- [ ] Double-tap: second tap shows "Не нашёл черновик" (consume-on-read works)
- [ ] Cancel → old-button tap: shows "Не нашёл черновик" (cancel clears pending)
- [ ] Fitness flow: `/workout` → 💪 Фитнес → `compose_workout` dry-run → push via `push_to_intervals=True`

🤖 Generated with [Claude Code](https://claude.com/claude-code)