### PR TITLE
Multi-tenant: web nav, Telegram Widget auth, workout generation improvements

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -5,7 +5,7 @@ import os
 import time
 import uuid
 import zoneinfo
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Callable, NamedTuple
 
 import httpx
@@ -488,16 +488,27 @@ async def workout_sport_chosen(update: Update, context: ContextTypes.DEFAULT_TYP
 
     await query.message.chat.send_action("typing")
 
+    now_local = datetime.now(TZ)
+    target_date = now_local.date() + timedelta(days=1) if now_local.hour >= 19 else now_local.date()
+    target_date_iso = target_date.isoformat()
+    day_label = "завтра" if target_date != now_local.date() else "сегодня"
+    context.user_data["workout_target_date"] = target_date_iso
+
     prompt = (
-        f"Сгенерируй тренировку на сегодня. Вид спорта: {sport}. "
-        f"Используй suggest_workout tool с dry_run=True (только превью, не отправляй)."
+        f"Сгенерируй тренировку на {day_label} ({target_date_iso}). Вид спорта: {sport}. "
+        f"Перед генерацией вызови get_activities для target_date={target_date_iso}, "
+        f"чтобы учесть активности, уже выполненные в этот день, в rationale и оценке нагрузки. "
+        f"Затем используй suggest_workout с target_date={target_date_iso} и dry_run=True "
+        f"(только превью, не отправляй)."
     )
     if sport == "WeightTraining":
         prompt = (
-            "Сгенерируй фитнес-тренировку на сегодня. "
-            "Сначала вызови get_animation_guidelines, затем list_exercise_cards, "
-            "и собери тренировку через compose_workout с push_to_intervals=False "
-            "(это preview-режим, не пушим сразу — пользователь подтвердит через кнопку)."
+            f"Сгенерируй фитнес-тренировку на {day_label} ({target_date_iso}). "
+            f"Сначала вызови get_activities для target_date={target_date_iso}, чтобы учесть "
+            "активности, уже выполненные в этот день. Затем get_animation_guidelines и "
+            f"list_exercise_cards, и собери тренировку через compose_workout с "
+            f"target_date={target_date_iso} и push_to_intervals=False "
+            "(preview-режим, пользователь подтвердит через кнопку)."
         )
 
     tool_calls: list[dict] = []

--- a/bot/prompts.py
+++ b/bot/prompts.py
@@ -216,6 +216,13 @@ progression, or race-day fitness context.
 ## Mood tracking
 If the athlete's message contains emotional signals (fatigue, stress, excitement),
 call save_mood_checkin autonomously — don't ask, just record what you observe.
+
+## Workout generation
+Before calling `suggest_workout` or `compose_workout`, always call `get_activities` for the
+target date first. If any activity is already completed that day, reflect it in the rationale
+and load estimate (don't stack a fresh session on top of a finished one). If the request
+arrives after 19:00 local time, default `target_date` to tomorrow unless the athlete
+explicitly asks for today.
 """
 
 

--- a/mcp_server/tools/ai_workouts.py
+++ b/mcp_server/tools/ai_workouts.py
@@ -1,13 +1,14 @@
 """MCP tools for AI-generated workout management (Phase 1: Adaptive Training Plan)."""
 
 import logging
-from datetime import date
+from datetime import date, timedelta
 
 import httpx
+from sqlalchemy import select
 
 from bot.formatter import build_workout_pushed_message
 from config import settings
-from data.db import AiWorkout, User
+from data.db import Activity, AiWorkout, User, get_session
 from data.intervals.client import IntervalsAsyncClient
 from data.intervals.dto import PlannedWorkoutDTO, WorkoutStepDTO
 from mcp_server.app import mcp
@@ -15,6 +16,33 @@ from mcp_server.context import get_current_user_id
 from mcp_server.sentry import sentry_tool
 
 logger = logging.getLogger(__name__)
+
+
+async def _completed_activities_note(user_id: int, target_date: date) -> str:
+    """Belt-and-suspenders: even if the model forgot to call get_activities,
+    surface completed sessions for `target_date` directly in the dry-run preview.
+    Prevents stacking a fresh workout on top of one that already happened today.
+    """
+    # Activity.start_date_local is a VARCHAR storing ISO8601 ("YYYY-MM-DDTHH:MM:SS").
+    # Half-open range on the string boundary is lexicographically correct for ISO
+    # format and matches the pattern used elsewhere in mcp_server/tools/activities.py.
+    day_start = target_date.isoformat()
+    day_end = (target_date + timedelta(days=1)).isoformat()
+    async with get_session() as session:
+        query = select(Activity).where(
+            Activity.user_id == user_id,
+            Activity.start_date_local >= day_start,
+            Activity.start_date_local < day_end,
+        )
+        rows = (await session.execute(query)).scalars().all()
+    if not rows:
+        return ""
+    parts = []
+    for r in rows:
+        load = f", {int(r.icu_training_load)} TL" if r.icu_training_load else ""
+        mins = (r.moving_time or 0) // 60
+        parts.append(f"{r.type} {mins}min{load}")
+    return f"\n⚠️ Уже выполнено {target_date}: " + "; ".join(parts) + "."
 
 
 async def _send_workout_notification(
@@ -96,10 +124,11 @@ async def suggest_workout(
     tss_part = f", ~{target_tss} TSS" if target_tss else ""
 
     if dry_run:
+        completed_note = await _completed_activities_note(get_current_user_id(), dt)
         return (
             f"Preview: AI: {name} ({sport}, {duration_minutes} min{tss_part}).\n"
             f"Rationale: {rationale}\n"
-            f"Steps: {len(steps)} step(s). "
+            f"Steps: {len(steps)} step(s).{completed_note} "
             f"Use suggest_workout with dry_run=False or press 'Отправить' to push."
         )
 


### PR DESCRIPTION
Bundled changes on the `versions/multi-tenant` branch. Each section can be reviewed independently.

## Desktop sidebar navigation
- Add desktop sidebar nav alongside existing mobile bottom tabs
- Centralize nav items so sidebar and bottom tabs stay in sync

## Activity detail bugfix (#44)
- Fix pace showing `0:02/km` on runs (unit conversion regression)

## Telegram Login Widget auth
- Implement Telegram Login Widget for web login
- Verify payload via HMAC-SHA256 per Telegram spec (24h replay window)
- New endpoints: `POST /api/auth/telegram-widget`, `GET /api/auth/telegram-widget-config`
- `TELEGRAM_BOT_USERNAME` env var
- Auto-create viewer user on first login (same as `/start` / Mini App initData)
- Login page wired to widget; falls back to one-time code flow
- Tests for signature + replay-window verification

## Workout generation improvements
- `/workout`: compute `target_date` from local time — if past 19:00, default to tomorrow
- Prompt instructs the model to call `get_activities` for the target date before `suggest_workout` / `compose_workout`, so it accounts for already-completed sessions
- `suggest_workout` dry-run preview surfaces completed activities for that date directly from DB (belt-and-suspenders, even if the model skips the pre-check)

## Test plan
- [ ] Telegram Widget login via bot.endurai.me, verify JWT issued and viewer auto-created
- [ ] One-time code login still works
- [ ] /workout after 19:00 local time → generated for tomorrow
- [ ] /workout with an already-completed session today → preview shows warning note
- [ ] Desktop sidebar renders at lg+ breakpoint, mobile bottom tabs at sm
- [ ] Activity detail page shows correct run pace