### PR TITLE
Adds intensity targets requirement and Strava data filter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,10 @@ Stateless. Each message: `agent.chat(text, mcp_token=user.mcp_token)` → Claude
 
 **Distance-based workouts:** `WorkoutStep` supports `distance` (meters) as alternative to `duration` (seconds). Mutually exclusive. `target: "PACE"` set for Swim/Run.
 
+**Intensity target mandate:** `PlannedWorkoutDTO._check_steps_have_targets` rejects any terminal (non-repeat-group) step without `hr` / `power` / `pace`. Garmin/Wahoo watches only alert on the target corridor when a numeric target is present, so text-only steps (`"Z2" label + duration`) are forbidden. Per-sport convention: Run → `hr` with `%lthr` units, Ride → `power` with `%ftp`, Swim → `pace` with `%pace`. Use `value` (low) + `end` (high) for a corridor. The `suggest_workout` MCP tool docstring and `SYSTEM_PROMPT_CHAT` (workout-generation section) both enforce this contract — the validator is the backstop if the model forgets.
+
+**Strava source filter:** Intervals.icu returns 422 `Cannot read Strava activities via the API` for `source == STRAVA` activities (licensing). `actor_fetch_user_activities` drops them **before** `Activity.save_bulk` so they never enter the DB or trigger downstream pipelines. `ActivityDTO.source` carries `GARMIN_CONNECT` / `OAUTH_CLIENT` / `STRAVA` / etc. from Intervals.icu.
+
 ---
 
 ## Bot Commands (bot/main.py)

--- a/bot/prompts.py
+++ b/bot/prompts.py
@@ -223,6 +223,18 @@ target date first. If any activity is already completed that day, reflect it in 
 and load estimate (don't stack a fresh session on top of a finished one). If the request
 arrives after 19:00 local time, default `target_date` to tomorrow unless the athlete
 explicitly asks for today.
+
+**Every step must carry an intensity target** so Garmin/Wahoo watches alert on the HR/power/pace
+corridor. Never emit text-only steps (`Z2` label + duration with nothing else) — the watch will
+run the step without beeping and the athlete runs blind.
+  - **Run**: use `hr` with `%lthr` units. LTHR for run is {lthr_run}. Ranges per zone:
+    Z1 0-72%, Z2 72-82%, Z3 82-87%, Z4 87-92%, Z5 92-100%. Example Z2 step:
+    `{{"text": "Z2", "duration": 900, "hr": {{"units": "%lthr", "value": 72, "end": 82}}}}`.
+  - **Ride**: use `power` with `%ftp` units. FTP = {ftp}. Example Z2:
+    `"power": {{"units": "%ftp", "value": 65, "end": 75}}`.
+  - **Swim**: use `pace` with `%pace` units. CSS = {css}. Example:
+    `"pace": {{"units": "%pace", "value": 95, "end": 100}}`.
+  - For repeat groups (`reps` + sub-`steps`), the target goes on each sub-step, not the wrapper.
 """
 
 

--- a/data/intervals/client.py
+++ b/data/intervals/client.py
@@ -166,7 +166,7 @@ class IntervalsClientBase:
         params = {
             "oldest": oldest.strftime("%Y-%m-%d"),
             "newest": newest.strftime("%Y-%m-%d"),
-            "fields": "id,start_date_local,type,icu_training_load,moving_time,average_heartrate,race,sub_type",
+            "fields": "id,start_date_local,type,icu_training_load,moving_time,average_heartrate,race,sub_type,source",
         }
         return RequestSpec(
             "GET",

--- a/data/intervals/dto.py
+++ b/data/intervals/dto.py
@@ -150,7 +150,7 @@ class ActivityDTO(BaseModel):
     average_hr: float | None = None  # average heart rate (from average_heartrate API field)
     is_race: bool = Field(False, alias="race")
     sub_type: str | None = None
-    source: str | None = None  # e.g. "STRAVA", "GARMIN", "ZWIFT"
+    source: str | None = None  # e.g. "GARMIN_CONNECT", "OAUTH_CLIENT", "STRAVA"
 
     @field_validator("type", mode="before")
     @classmethod

--- a/data/intervals/dto.py
+++ b/data/intervals/dto.py
@@ -238,6 +238,37 @@ class PlannedWorkoutDTO(BaseModel):
     suffix: str = "generated"  # "generated" | "adapted"
 
     @model_validator(mode="after")
+    def _check_steps_have_targets(self) -> "PlannedWorkoutDTO":
+        """Every terminal step must carry at least one intensity target.
+
+        Garmin/Wahoo watches alert on HR/power/pace corridors only when the step
+        defines them. Text-only steps ('Z2' label + duration) leave the athlete
+        running blind, so we reject them here rather than silently pushing a
+        useless workout to Intervals.icu.
+        """
+
+        def _walk(steps: list[WorkoutStepDTO], trail: str) -> None:
+            for i, s in enumerate(steps):
+                label = f"{trail}[{i}]{' ' + s.text if s.text else ''}"
+                if s.reps:
+                    if not s.steps:
+                        raise ValueError(
+                            f"Step {label!r} sets reps={s.reps} but has no sub-steps. "
+                            f"Repeat groups must contain a non-empty steps list."
+                        )
+                    _walk(s.steps, label)
+                    continue
+                if not (s.hr or s.power or s.pace):
+                    raise ValueError(
+                        f"Step {label!r} has no intensity target. Every non-repeat "
+                        f"step must include hr/power/pace so watches can alert the "
+                        f"athlete on the target corridor."
+                    )
+
+        _walk(self.steps, "steps")
+        return self
+
+    @model_validator(mode="after")
     def _check_steps_duration_consistency(self) -> "PlannedWorkoutDTO":
         """Guard against unit-mismatch where Claude passes step durations in minutes.
 

--- a/data/intervals/dto.py
+++ b/data/intervals/dto.py
@@ -150,6 +150,7 @@ class ActivityDTO(BaseModel):
     average_hr: float | None = None  # average heart rate (from average_heartrate API field)
     is_race: bool = Field(False, alias="race")
     sub_type: str | None = None
+    source: str | None = None  # e.g. "STRAVA", "GARMIN", "ZWIFT"
 
     @field_validator("type", mode="before")
     @classmethod

--- a/mcp_server/tools/ai_workouts.py
+++ b/mcp_server/tools/ai_workouts.py
@@ -98,11 +98,23 @@ async def suggest_workout(
       - `distance` is in **METERS** (Swim/Run only). Mutually exclusive with `duration`.
       - `reps` is repeat count for a repeat group (group has `steps` sub-list, no own `duration`).
 
-    Example step (10-minute Z2): {"text": "Z2", "duration": 600, "power": {"units": "%ftp", "value": 70}}
-    Example repeat (3x5min tempo w/ 2min rest):
+    MANDATORY — every terminal (non-repeat-group) step MUST carry at least one intensity target
+    (`hr`, `power`, or `pace`). Text-only steps like `{"text": "Z2", "duration": 600}` are rejected:
+    Garmin/Wahoo watches cannot alert on the target corridor without an explicit target, so the
+    athlete runs blind. Derive the numeric target from athlete thresholds (LTHR/FTP/CSS) provided
+    in the system prompt. Use a range via `value` (low) + `end` (high) to get HR-corridor beeps.
+
+    Sport-specific examples:
+      Run   (HR-driven):  {"text": "Z2",   "duration": 900, "hr":    {"units": "%lthr", "value": 72, "end": 82}}
+      Run   (tempo Z3):   {"text": "Temp", "duration": 480, "hr":    {"units": "%lthr", "value": 82, "end": 87}}
+      Ride  (power Z2):   {"text": "Z2",   "duration": 600, "power": {"units": "%ftp",  "value": 65, "end": 75}}
+      Ride  (threshold):  {"text": "FTP",  "duration": 480, "power": {"units": "%ftp",  "value": 95, "end": 105}}
+      Swim  (CSS pace):   {"text": "Main", "distance": 400, "pace":  {"units": "%pace", "value": 95, "end": 100}}
+
+    Example repeat (3x5min tempo + 2min recovery):
       {"reps": 3, "text": "Tempo", "steps": [
-         {"text": "On",  "duration": 300, "power": {"units": "%ftp", "value": 88}},
-         {"text": "Off", "duration": 120, "power": {"units": "%ftp", "value": 55}}
+         {"text": "On",  "duration": 300, "hr": {"units": "%lthr", "value": 82, "end": 87}},
+         {"text": "Off", "duration": 120, "hr": {"units": "%lthr", "value": 60, "end": 72}}
       ]}
 
     Total step seconds must approximately match `duration_minutes * 60`, otherwise the workout

--- a/tasks/actors/activities.py
+++ b/tasks/actors/activities.py
@@ -387,6 +387,10 @@ def actor_fetch_user_activities(
     with IntervalsSyncClient.for_user(user) as client:
         activities: list[ActivityDTO] = client.get_activities(oldest=_oldest, newest=_newest)
 
+    # Strava activities cannot be read via Intervals.icu API (licensing).
+    # Skip them entirely so they never enter the DB or trigger downstream fetches.
+    activities = [a for a in activities if (a.source or "").upper() != "STRAVA"]
+
     if not activities:
         return
 

--- a/tasks/actors/activities.py
+++ b/tasks/actors/activities.py
@@ -389,7 +389,11 @@ def actor_fetch_user_activities(
 
     # Strava activities cannot be read via Intervals.icu API (licensing).
     # Skip them entirely so they never enter the DB or trigger downstream fetches.
+    before = len(activities)
     activities = [a for a in activities if (a.source or "").upper() != "STRAVA"]
+    skipped = before - len(activities)
+    if skipped:
+        logger.info("Skipped %d Strava activity(ies) for user %s — Intervals.icu API blocks them", skipped, user.id)
 
     if not activities:
         return

--- a/tests/db/test_ai_workouts.py
+++ b/tests/db/test_ai_workouts.py
@@ -2,6 +2,9 @@
 
 from datetime import date
 
+import pytest
+from pydantic import ValidationError
+
 from data.intervals.dto import PlannedWorkoutDTO, WorkoutStepDTO
 
 # ---------------------------------------------------------------------------
@@ -126,11 +129,49 @@ class TestPlannedWorkout:
         event = w.to_intervals_event()
         assert event.description is None
 
+    def test_rejects_step_without_target(self):
+        """Targetless terminal steps leave watches unable to alert — must raise."""
+        with pytest.raises(ValidationError, match="no intensity target"):
+            PlannedWorkoutDTO(
+                sport="Run",
+                name="Test",
+                steps=[WorkoutStepDTO(text="Z2", duration=1200)],
+                duration_minutes=20,
+            )
+
+    def test_rejects_repeat_substep_without_target(self):
+        """Sub-steps of a repeat group must also carry targets."""
+        with pytest.raises(ValidationError, match="no intensity target"):
+            PlannedWorkoutDTO(
+                sport="Run",
+                name="Test",
+                steps=[
+                    WorkoutStepDTO(
+                        text="Intervals",
+                        reps=3,
+                        steps=[
+                            WorkoutStepDTO(duration=300),  # missing target
+                            WorkoutStepDTO(duration=120, hr={"units": "%lthr", "value": 60}),
+                        ],
+                    ),
+                ],
+                duration_minutes=20,
+            )
+
+    def test_accepts_pace_target(self):
+        """Swim steps with pace target are valid."""
+        PlannedWorkoutDTO(
+            sport="Swim",
+            name="Test",
+            steps=[WorkoutStepDTO(text="Main", distance=400, pace={"units": "%pace", "value": 95})],
+            duration_minutes=15,
+        )
+
     def test_default_date_is_today(self):
         w = PlannedWorkoutDTO(
             sport="Run",
             name="Test",
-            steps=[WorkoutStepDTO(text="Run", duration=1200)],
+            steps=[WorkoutStepDTO(text="Run", duration=1200, hr={"units": "%lthr", "value": 72, "end": 82})],
             duration_minutes=20,
         )
         assert w.target_date == date.today()

--- a/tests/tasks/test_activity_actors.py
+++ b/tests/tasks/test_activity_actors.py
@@ -31,6 +31,7 @@ def _activity_dto(
     dt: date = date(2026, 4, 1),
     type: str = "Run",
     moving_time: int = 3600,
+    source: str | None = "GARMIN_CONNECT",
 ) -> MagicMock:
     """Create a minimal ActivityDTO mock."""
     from data.intervals.dto import ActivityDTO
@@ -42,6 +43,7 @@ def _activity_dto(
         icu_training_load=80.0,
         moving_time=moving_time,
         average_hr=145.0,
+        source=source,
     )
 
 
@@ -189,6 +191,31 @@ class TestActorFetchUserActivities:
         messages = mock_group_cls.call_args[0][0]
         assert len(messages) == 1
         mock_group.run.assert_called_once()
+
+    def test_filters_strava_activities(self):
+        """Strava-sourced activities must be dropped before save_bulk — Intervals.icu API
+        rejects /intervals reads for them, which would crash the downstream actor."""
+        from tasks.actors import actor_fetch_user_activities
+
+        user = _user()
+        activities = [
+            _activity_dto(id="a001", source="GARMIN_CONNECT"),
+            _activity_dto(id="a002", source="STRAVA"),
+            _activity_dto(id="a003", source="strava"),  # case-insensitive
+            _activity_dto(id="a004", source=None),
+        ]
+        mock_client = _mock_client()
+        mock_client.get_activities.return_value = activities
+
+        with (
+            patch("tasks.actors.activities.IntervalsSyncClient.for_user", return_value=mock_client),
+            patch("tasks.actors.activities.Activity.save_bulk", return_value=[]) as mock_save,
+        ):
+            actor_fetch_user_activities(user.model_dump())
+
+        saved = mock_save.call_args[1]["activities"]
+        saved_ids = [a.id for a in saved]
+        assert saved_ids == ["a001", "a004"]
 
     def test_default_range_is_30_days(self):
         """Default oldest is today - 30 days when not specified."""

--- a/tests/tasks/test_activity_actors.py
+++ b/tests/tasks/test_activity_actors.py
@@ -15,6 +15,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from data.db.user import UserDTO
+from data.intervals.dto import ActivityDTO
 
 # ---------------------------------------------------------------------------
 # Shared helpers
@@ -32,10 +33,8 @@ def _activity_dto(
     type: str = "Run",
     moving_time: int = 3600,
     source: str | None = "GARMIN_CONNECT",
-) -> MagicMock:
-    """Create a minimal ActivityDTO mock."""
-    from data.intervals.dto import ActivityDTO
-
+) -> ActivityDTO:
+    """Create a minimal ActivityDTO."""
     return ActivityDTO(
         id=id,
         start_date_local=dt,


### PR DESCRIPTION
### Summary
- Enforces the requirement for every workout step to include an intensity target (heart rate, power, or pace) to ensure compatibility with Garmin/Wahoo watches for alerting in workouts.
- Filters out activities sourced from Strava due to licensing restrictions from the Intervals.icu API, preventing them from entering the database or affecting downstream processes.

### Details
- Implements validation to reject terminal steps in workouts that lack target intensity values.
- Updates documentation and examples to reflect new intensity target requirements.
- Modifies the data handling workflow to exclude Strava activities early in the data pipeline, ensuring compliance with API constraints.

### Checklists
- [X] Unit tests have been added or updated to cover new requirements.
- [X] Documentation has been appropriately updated to describe the changes (CLAUDE.md, suggest_workout docstring, SYSTEM_PROMPT_CHAT).

This relates to the 'versions/multi-tenant' update.