### PR TITLE
Removes credentials from UserDTO for security

### DIFF
--- a/data/db/dto.py
+++ b/data/db/dto.py
@@ -9,14 +9,22 @@ from pydantic import BaseModel, ConfigDict
 
 
 class UserDTO(BaseModel):
-    model_config = ConfigDict(from_attributes=True)
+    """Lightweight user snapshot for cross-boundary transport (dramatiq, logs).
+
+    Credentials (api_key, mcp_token) are deliberately excluded — they must NOT
+    cross the dramatiq broker or Sentry boundary. Issue #147: leaked secrets
+    in #146 came from dramatiq serializing `repr(UserDTO)` into an exception
+    message. Callers that need credentials re-fetch the ORM `User` by `id`.
+    """
+
+    # `extra="forbid"` hard-rejects any attempt to reintroduce credentials
+    # (api_key, mcp_token, etc.) via the constructor — regression guard for #147.
+    model_config = ConfigDict(from_attributes=True, extra="forbid")
 
     id: int
     chat_id: str
     username: str | None = None
     athlete_id: str | None = None
-    api_key: str | None = None
-    mcp_token: str | None = None
     language: str = "ru"
     is_silent: bool = False
 

--- a/data/intervals/client.py
+++ b/data/intervals/client.py
@@ -265,10 +265,15 @@ class IntervalsAsyncClient(IntervalsClientBase):
     @classmethod
     @asynccontextmanager
     async def for_user(cls, user: int | User | UserDTO):
-        """Create a session with per-user credentials from the DB."""
-        if isinstance(user, int):
+        """Create a session with per-user credentials from the DB.
+
+        UserDTO no longer carries credentials (issue #147), so it's re-fetched
+        from the DB to get the decrypted api_key — same path as passing an int.
+        """
+        if isinstance(user, (int, UserDTO)):
+            user_id = user if isinstance(user, int) else user.id
             async with get_session() as session:
-                user = await session.get(User, user)
+                user = await session.get(User, user_id)
         async with cls(api_key=user.api_key, athlete_id=user.athlete_id) as session:
             yield session
 
@@ -355,10 +360,15 @@ class IntervalsSyncClient(IntervalsClientBase):
     @classmethod
     @contextmanager
     def for_user(cls, user: int | User | UserDTO):
-        """Create a session with per-user credentials from the DB."""
-        if isinstance(user, int):
+        """Create a session with per-user credentials from the DB.
+
+        UserDTO no longer carries credentials (issue #147), so it's re-fetched
+        from the DB to get the decrypted api_key — same path as passing an int.
+        """
+        if isinstance(user, (int, UserDTO)):
+            user_id = user if isinstance(user, int) else user.id
             with get_sync_session() as session:
-                user = session.get(User, user)
+                user = session.get(User, user_id)
         with cls(api_key=user.api_key, athlete_id=user.athlete_id) as session:
             yield session
 

--- a/data/intervals/client.py
+++ b/data/intervals/client.py
@@ -274,6 +274,8 @@ class IntervalsAsyncClient(IntervalsClientBase):
             user_id = user if isinstance(user, int) else user.id
             async with get_session() as session:
                 user = await session.get(User, user_id)
+            if user is None:
+                raise LookupError(f"User {user_id} not found")
         async with cls(api_key=user.api_key, athlete_id=user.athlete_id) as session:
             yield session
 
@@ -369,6 +371,8 @@ class IntervalsSyncClient(IntervalsClientBase):
             user_id = user if isinstance(user, int) else user.id
             with get_sync_session() as session:
                 user = session.get(User, user_id)
+            if user is None:
+                raise LookupError(f"User {user_id} not found")
         with cls(api_key=user.api_key, athlete_id=user.athlete_id) as session:
             yield session
 

--- a/sentry_config.py
+++ b/sentry_config.py
@@ -47,6 +47,36 @@ _SENSITIVE_BEARER = re.compile(
 # custom repr or manual unwrap leaking a SecretStr('realvalue') literal.
 _SENSITIVE_SECRETSTR = re.compile(r"SecretStr\(\s*['\"][^'\"]+['\"]\s*\)")
 
+# Cheap pre-check: if none of these markers appear anywhere in the serialized
+# event, there is no credential-shaped substring to redact and we can skip the
+# recursive walk entirely. Markers mirror the key-name alternation in
+# `_SENSITIVE_KV` plus `bearer` / `secretstr` literals. Case-insensitive via
+# lowercasing the haystack before the `in` checks.
+_CREDENTIAL_MARKERS: tuple[str, ...] = (
+    "api_key",
+    "apikey",
+    "api-key",
+    "mcp_token",
+    "mcptoken",
+    "mcp-token",
+    "access_token",
+    "accesstoken",
+    "access-token",
+    "refresh_token",
+    "refreshtoken",
+    "refresh-token",
+    "bearer",
+    "secret",
+    "password",
+    "passwd",
+    "encryption_key",
+    "encryptionkey",
+    "encryption-key",
+    "fernet",
+    "jwt",
+    "secretstr(",
+)
+
 
 def _scrub_text(text):
     """Redact credential-shaped substrings. Passes through non-strings untouched."""
@@ -67,8 +97,13 @@ def _before_send(event, hint):
          value shape (e.g. `api_key='real'`). Catches secrets embedded inside
          exception messages, log strings, and free-form text fields where
          the key-based pass can't see.
+
+    Performance: the regex walk is skipped entirely when a cheap substring
+    probe over a serialized event finds no credential markers — the common
+    case for application errors that carry no secrets.
     """
-    _walk_strings(event)
+    if _event_has_credential_markers(event):
+        _walk_strings(event)
 
     for section in ("extra", "contexts"):
         data = event.get(section, {})
@@ -95,6 +130,21 @@ def _before_send(event, hint):
                 _scrub_dict(frame["vars"])
 
     return event
+
+
+def _event_has_credential_markers(event) -> bool:
+    """Cheap gate before running the recursive regex walk.
+
+    `repr(event)` over a Sentry event dict is a single C-level string build;
+    scanning the result for a handful of literal substrings is O(n) with a
+    tiny constant. If none match, there is nothing the regex could redact and
+    we skip the walk entirely — the hot path for errors that carry no secrets.
+    """
+    try:
+        blob = repr(event).lower()
+    except Exception:
+        return True  # if repr fails for some reason, err on the safe side
+    return any(marker in blob for marker in _CREDENTIAL_MARKERS)
 
 
 def _walk_strings(node) -> None:

--- a/sentry_config.py
+++ b/sentry_config.py
@@ -1,5 +1,7 @@
 """Sentry SDK initialization — single entry point for all components."""
 
+import re
+
 import sentry_sdk
 from sentry_sdk.integrations.dramatiq import DramatiqIntegration
 from sentry_sdk.integrations.fastapi import FastApiIntegration
@@ -21,9 +23,53 @@ SENSITIVE_KEYS = {
     "cookie",
 }
 
+# Defence-in-depth for issue #147: scrub credential-shaped substrings inside
+# free-form text fields (exception values, log messages, breadcrumb messages).
+# These fire even if the structured-dict scrubber misses — e.g. when dramatiq
+# serializes actor args via repr() into an exception string.
+_REDACT = "[REDACTED]"
+# Group 1 = key name + separator (preserved), group 2 = value (redacted).
+# Matches quoted values with spaces via `'[^']*'` / `"[^"]*"`, and bare values
+# via `[^'"\s,}\)\]]+`. Key alternation covers the credential shapes used in
+# this repo — extend when adding new ones.
+_SENSITIVE_KV = re.compile(
+    r"""(['"]?(?:api[_-]?key|mcp[_-]?token|access[_-]?token|refresh[_-]?token|"""
+    r"""bearer[_-]?token|auth[_-]?token|secret|password|passwd|"""
+    r"""encryption[_-]?key|fernet[_-]?key|jwt)['"]?\s*[:=]\s*)"""
+    r"""(?:'[^']*'|"[^"]*"|[^'"\s,}\)\]]+)""",
+    re.IGNORECASE,
+)
+_SENSITIVE_BEARER = re.compile(
+    r"(Authorization\s*:\s*Bearer\s+)[\w\-\.=+/]+",
+    re.IGNORECASE,
+)
+# Pydantic's SecretStr already masks via repr(), but catch the rare case of a
+# custom repr or manual unwrap leaking a SecretStr('realvalue') literal.
+_SENSITIVE_SECRETSTR = re.compile(r"SecretStr\(\s*['\"][^'\"]+['\"]\s*\)")
+
+
+def _scrub_text(text):
+    """Redact credential-shaped substrings. Passes through non-strings untouched."""
+    if not isinstance(text, str) or not text:
+        return text
+    text = _SENSITIVE_KV.sub(rf"\1{_REDACT}", text)
+    text = _SENSITIVE_BEARER.sub(rf"\1{_REDACT}", text)
+    text = _SENSITIVE_SECRETSTR.sub(f"SecretStr({_REDACT})", text)
+    return text
+
 
 def _before_send(event, hint):
-    """Scrub sensitive data from Sentry events."""
+    """Scrub sensitive data from Sentry events.
+
+    Two complementary passes:
+      1. Key-based dict scrubber (`_scrub_dict`) — redacts by key name.
+      2. Regex string scrubber (`_walk_strings` + `_scrub_text`) — redacts by
+         value shape (e.g. `api_key='real'`). Catches secrets embedded inside
+         exception messages, log strings, and free-form text fields where
+         the key-based pass can't see.
+    """
+    _walk_strings(event)
+
     for section in ("extra", "contexts"):
         data = event.get(section, {})
         if isinstance(data, dict):
@@ -37,13 +83,39 @@ def _before_send(event, hint):
     for crumb in event.get("breadcrumbs", {}).get("values", []):
         _scrub_dict(crumb.get("data", {}))
 
-    # Scrub local variables in exception stackframes
+    # Stackframe vars — keyed dict scrub (plus the string walk above already
+    # rewrote any sensitive values that appeared as raw strings).
     for exc_info in event.get("exception", {}).get("values", []):
         for frame in exc_info.get("stacktrace", {}).get("frames", []):
             if frame.get("vars"):
                 _scrub_dict(frame["vars"])
+    for thread in event.get("threads", {}).get("values", []):
+        for frame in thread.get("stacktrace", {}).get("frames", []):
+            if frame.get("vars"):
+                _scrub_dict(frame["vars"])
 
     return event
+
+
+def _walk_strings(node) -> None:
+    """Recursively rewrite every string leaf in the event tree through `_scrub_text`.
+
+    Covers exception.values[*].value, event.message, logentry.message,
+    breadcrumb messages, extra dict values, threads frames — every leak path
+    at once, instead of hand-listing known keys that decay as Sentry evolves.
+    """
+    if isinstance(node, dict):
+        for k, v in node.items():
+            if isinstance(v, str):
+                node[k] = _scrub_text(v)
+            elif isinstance(v, (dict, list)):
+                _walk_strings(v)
+    elif isinstance(node, list):
+        for i, v in enumerate(node):
+            if isinstance(v, str):
+                node[i] = _scrub_text(v)
+            elif isinstance(v, (dict, list)):
+                _walk_strings(v)
 
 
 def _scrub_dict(d: dict):

--- a/tasks/actors/reports.py
+++ b/tasks/actors/reports.py
@@ -190,9 +190,12 @@ def actor_compose_user_morning_report(
         if not _wellness_row or not _wellness_row.sleep_score or _wellness_row.ai_recommendation:
             return
 
-        # Generate morning report: sync Claude API + MCP tools (per-user token)
+        # Generate morning report: sync Claude API + MCP tools (per-user token).
+        # UserDTO no longer carries credentials (issue #147), so we re-fetch
+        # the ORM User inside the worker to get the plaintext mcp_token.
+        _user_orm = session.get(User, user.id)
         try:
-            mcp = MCPTool(token=user.mcp_token, user_id=user.id, language=user.language)
+            mcp = MCPTool(token=_user_orm.mcp_token, user_id=user.id, language=user.language)
             text = mcp.generate_morning_report_via_mcp(_dt)
         except Exception as e:
             sentry_sdk.capture_exception(e)
@@ -223,7 +226,11 @@ def actor_compose_user_morning_report(
 @validate_call
 def actor_compose_weekly_report(user: UserDTO):
     """Generate weekly training summary via Claude + MCP tools."""
-    mcp = MCPTool(token=user.mcp_token, user_id=user.id, language=user.language)
+    # UserDTO carries no credentials (issue #147) — re-fetch ORM for mcp_token.
+    with get_sync_session() as session:
+        _user_orm = session.get(User, user.id)
+        mcp_token = _user_orm.mcp_token if _user_orm else None
+    mcp = MCPTool(token=mcp_token, user_id=user.id, language=user.language)
     text = mcp.generate_weekly_report_via_mcp()
 
     if not text:

--- a/tasks/actors/reports.py
+++ b/tasks/actors/reports.py
@@ -194,6 +194,9 @@ def actor_compose_user_morning_report(
         # UserDTO no longer carries credentials (issue #147), so we re-fetch
         # the ORM User inside the worker to get the plaintext mcp_token.
         _user_orm = session.get(User, user.id)
+        if _user_orm is None:
+            logger.warning("Morning report skipped: user %d no longer exists", user.id)
+            return
         try:
             mcp = MCPTool(token=_user_orm.mcp_token, user_id=user.id, language=user.language)
             text = mcp.generate_morning_report_via_mcp(_dt)
@@ -229,8 +232,10 @@ def actor_compose_weekly_report(user: UserDTO):
     # UserDTO carries no credentials (issue #147) — re-fetch ORM for mcp_token.
     with get_sync_session() as session:
         _user_orm = session.get(User, user.id)
-        mcp_token = _user_orm.mcp_token if _user_orm else None
-    mcp = MCPTool(token=mcp_token, user_id=user.id, language=user.language)
+    if _user_orm is None:
+        logger.warning("Weekly report skipped: user %d no longer exists", user.id)
+        return
+    mcp = MCPTool(token=_user_orm.mcp_token, user_id=user.id, language=user.language)
     text = mcp.generate_weekly_report_via_mcp()
 
     if not text:

--- a/tests/db/test_activity_save_bulk.py
+++ b/tests/db/test_activity_save_bulk.py
@@ -31,7 +31,7 @@ def _make_activity(
 
 
 def _user_dto(*, id: int = 1) -> UserDTO:
-    return UserDTO(id=id, chat_id="111", username="tester", athlete_id="i001", api_key="key1")
+    return UserDTO(id=id, chat_id="111", username="tester", athlete_id="i001")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/db/test_user_dto.py
+++ b/tests/db/test_user_dto.py
@@ -1,0 +1,50 @@
+"""UserDTO credential exclusion — regression for issue #147.
+
+Dramatiq serializes actor args via `model_dump(mode='json')` / `repr()` into
+messages that flow to Redis, exception strings, Sentry, and GitHub issues.
+Plaintext credentials leaked that way in #146. The fix is to keep credentials
+out of UserDTO entirely — actors re-fetch the ORM User when they need them.
+"""
+
+import pytest
+
+from data.db import UserDTO
+
+
+class TestUserDTOExcludesCredentials:
+    def test_no_api_key_field(self):
+        """UserDTO must not define api_key — credentials stay on ORM only."""
+        assert "api_key" not in UserDTO.model_fields
+
+    def test_no_mcp_token_field(self):
+        assert "mcp_token" not in UserDTO.model_fields
+
+    def test_construction_rejects_api_key(self):
+        """Passing api_key to constructor must fail — protects against regressions
+        where someone re-adds the field without thinking about the leak path."""
+        with pytest.raises(ValueError):
+            UserDTO.model_validate(
+                {"id": 1, "chat_id": "x", "api_key": "leaked"},
+                strict=False,
+                context=None,
+            )
+
+    def test_repr_contains_no_credential_keys(self):
+        u = UserDTO(id=1, chat_id="111", username="tester")
+        r = repr(u)
+        assert "api_key" not in r
+        assert "mcp_token" not in r
+
+    def test_model_dump_json_roundtrip_preserves_identity(self):
+        """Critical path: dramatiq serializes via model_dump(mode='json') and
+        re-parses via model_validate. The DTO must round-trip cleanly."""
+        u = UserDTO(id=42, chat_id="555", username="athlete", language="en", is_silent=True)
+        payload = u.model_dump(mode="json")
+        u2 = UserDTO.model_validate(payload)
+        assert u2.id == 42
+        assert u2.chat_id == "555"
+        assert u2.username == "athlete"
+        assert u2.language == "en"
+        assert u2.is_silent is True
+        assert "api_key" not in payload
+        assert "mcp_token" not in payload

--- a/tests/db/test_user_dto.py
+++ b/tests/db/test_user_dto.py
@@ -7,6 +7,7 @@ out of UserDTO entirely — actors re-fetch the ORM User when they need them.
 """
 
 import pytest
+from pydantic import ValidationError
 
 from data.db import UserDTO
 
@@ -22,12 +23,18 @@ class TestUserDTOExcludesCredentials:
     def test_construction_rejects_api_key(self):
         """Passing api_key to constructor must fail — protects against regressions
         where someone re-adds the field without thinking about the leak path."""
-        with pytest.raises(ValueError):
-            UserDTO.model_validate(
-                {"id": 1, "chat_id": "x", "api_key": "leaked"},
-                strict=False,
-                context=None,
-            )
+        with pytest.raises(ValidationError) as exc_info:
+            UserDTO(id=1, chat_id="x", api_key="leaked")
+        # Assert the failure is specifically about the forbidden extra field,
+        # not some other incidental validation error.
+        errors = exc_info.value.errors()
+        assert any(e["type"] == "extra_forbidden" and "api_key" in e["loc"] for e in errors)
+
+    def test_construction_rejects_mcp_token(self):
+        with pytest.raises(ValidationError) as exc_info:
+            UserDTO(id=1, chat_id="x", mcp_token="leaked")
+        errors = exc_info.value.errors()
+        assert any(e["type"] == "extra_forbidden" and "mcp_token" in e["loc"] for e in errors)
 
     def test_repr_contains_no_credential_keys(self):
         u = UserDTO(id=1, chat_id="111", username="tester")

--- a/tests/tasks/test_activity_actors.py
+++ b/tests/tasks/test_activity_actors.py
@@ -23,7 +23,7 @@ from data.intervals.dto import ActivityDTO
 
 
 def _user(*, id: int = 1, chat_id: str = "111") -> UserDTO:
-    return UserDTO(id=id, chat_id=chat_id, username="tester", athlete_id="i001", api_key="key1")
+    return UserDTO(id=id, chat_id=chat_id, username="tester", athlete_id="i001")
 
 
 def _activity_dto(

--- a/tests/tasks/test_actors.py
+++ b/tests/tasks/test_actors.py
@@ -69,7 +69,6 @@ class TestSyncUserWellness:
             chat_id=os.environ["TELEGRAM_CHAT_ID"],
             username=os.environ.get("TELEGRAM_USERNAME", "test"),
             athlete_id=os.environ["INTERVALS_ATHLETE_ID"],
-            api_key=os.environ["INTERVALS_API_KEY"],
         )
         result = actor_user_wellness(user)
         assert result is None
@@ -84,7 +83,7 @@ _DT_STR = "2026-04-06"
 
 
 def _user(*, id: int = 1) -> UserDTO:
-    return UserDTO(id=id, chat_id="111", username="tester", athlete_id="i001", api_key="key1")
+    return UserDTO(id=id, chat_id="111", username="tester", athlete_id="i001")
 
 
 def _trend(direction: str = "stable") -> TrendResultDTO:

--- a/tests/tasks/test_athlete_actors.py
+++ b/tests/tasks/test_athlete_actors.py
@@ -9,7 +9,7 @@ from data.intervals.dto import ScheduledWorkoutDTO, SportSettingsDTO
 
 
 def _user(id: int = 1, chat_id: str = "test_user") -> UserDTO:
-    return UserDTO(id=id, chat_id=chat_id, athlete_id="i123", api_key="key123")
+    return UserDTO(id=id, chat_id=chat_id, athlete_id="i123")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tasks/test_pipeline.py
+++ b/tests/tasks/test_pipeline.py
@@ -19,7 +19,7 @@ from data.intervals.dto import ScheduledWorkoutDTO
 # ---------------------------------------------------------------------------
 
 
-def _make_user(*, id: int = 1, chat_id: str = "111", athlete_id: str = "i001", api_key: str = "key1"):
+def _make_user(*, id: int = 1, chat_id: str = "111", athlete_id: str = "i001"):
     """Create a mock User-like object that TypeAdapter(list[UserDTO]).validate_python can handle."""
     from unittest.mock import MagicMock
 
@@ -28,8 +28,8 @@ def _make_user(*, id: int = 1, chat_id: str = "111", athlete_id: str = "i001", a
     user.chat_id = chat_id
     user.username = "tester"
     user.athlete_id = athlete_id
-    user.api_key = api_key
-    user.mcp_token = f"token-{id}"
+    user.language = "ru"
+    user.is_silent = False
     user.role = "athlete"
     user.is_active = True
     return user
@@ -57,7 +57,7 @@ class TestSchedulerDispatch:
     @pytest.mark.asyncio
     async def test_dispatches_group_for_active_users(self):
         """Should create a dramatiq group with one message per active user."""
-        users = [_make_user(id=1), _make_user(id=2, chat_id="222", athlete_id="i002", api_key="key2")]
+        users = [_make_user(id=1), _make_user(id=2, chat_id="222", athlete_id="i002")]
 
         mock_group_instance = MagicMock()
 
@@ -105,7 +105,7 @@ class TestActorUserScheduledWorkouts:
         """Actor calls IntervalsSyncClient.get_events and ScheduledWorkout.save_bulk."""
         from data.db.user import UserDTO
 
-        user = UserDTO(id=1, chat_id="111", athlete_id="i001", api_key="key1")
+        user = UserDTO(id=1, chat_id="111", athlete_id="i001")
 
         workouts = [_make_dto(id=9001), _make_dto(id=9002, name="Swim")]
 
@@ -133,7 +133,7 @@ class TestActorUserScheduledWorkouts:
         """Actor passes today → today+14 as oldest/newest."""
         from data.db.user import UserDTO
 
-        user = UserDTO(id=1, chat_id="111", athlete_id="i001", api_key="key1")
+        user = UserDTO(id=1, chat_id="111", athlete_id="i001")
 
         workouts = [_make_dto(id=9001)]
         mock_client = MagicMock()

--- a/tests/tasks/test_ramp_suggestion.py
+++ b/tests/tasks/test_ramp_suggestion.py
@@ -26,7 +26,6 @@ def _user(*, id: int = 1) -> UserDTO:
         chat_id="111",
         username="tester",
         athlete_id="i001",
-        api_key="key1",
     )
 
 

--- a/tests/tasks/test_training_log_actors.py
+++ b/tests/tasks/test_training_log_actors.py
@@ -11,7 +11,7 @@ _MODULE = "tasks.actors.training_log"
 
 
 def _user(*, id: int = 1) -> UserDTO:
-    return UserDTO(id=id, chat_id="111", username="tester", athlete_id="i001", api_key="key1")
+    return UserDTO(id=id, chat_id="111", username="tester", athlete_id="i001")
 
 
 def _wellness_row(**overrides):

--- a/tests/test_sentry_config.py
+++ b/tests/test_sentry_config.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import patch
 
-from sentry_config import _before_send, _scrub_dict, _traces_sampler, init_sentry
+from sentry_config import _before_send, _scrub_dict, _scrub_text, _traces_sampler, init_sentry
 
 
 class TestScrubDict:
@@ -103,6 +103,112 @@ class TestBeforeSend:
         event = {}
         result = _before_send(event, {})
         assert result == {}
+
+
+class TestScrubText:
+    """Defence-in-depth regex scrubbing for issue #147.
+
+    Dramatiq serializes actor args via repr() into exception messages. The
+    structured-dict scrubber doesn't see those strings, so regex catches them.
+    """
+
+    def test_redacts_api_key_dict_repr(self):
+        text = "_actor_foo(user={'id': 1, 'api_key': '1h545g8e229f27ewxdv23z8h'})"
+        scrubbed = _scrub_text(text)
+        assert "1h545g8e229f27ewxdv23z8h" not in scrubbed
+        assert "[REDACTED]" in scrubbed
+        assert "'id': 1" in scrubbed
+
+    def test_redacts_mcp_token_dict_repr(self):
+        text = "args: {'mcp_token': 'WGcaMeXA35bfNvSrg4v7sWl-1jebW2Ne'}"
+        assert "WGcaMeXA35bfNvSrg4v7sWl-1jebW2Ne" not in _scrub_text(text)
+
+    def test_redacts_equals_form(self):
+        text = "foo(api_key=abc123, count=5)"
+        scrubbed = _scrub_text(text)
+        assert "abc123" not in scrubbed
+        assert "count=5" in scrubbed
+
+    def test_redacts_bearer_token(self):
+        text = "Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.xyz"
+        scrubbed = _scrub_text(text)
+        assert "eyJhbGciOiJIUzI1NiJ9.xyz" not in scrubbed
+        assert "Authorization" in scrubbed
+
+    def test_redacts_secretstr_literal(self):
+        text = "SecretStr('leaked-value')"
+        assert "leaked-value" not in _scrub_text(text)
+
+    def test_preserves_non_sensitive_text(self):
+        text = "Normal error message with no secrets"
+        assert _scrub_text(text) == text
+
+    def test_handles_none(self):
+        assert _scrub_text(None) is None
+
+    def test_handles_empty(self):
+        assert _scrub_text("") == ""
+
+
+class TestBeforeSendTextScrubbing:
+    """Issue #147: the actual leak in #146 was the exception.value string."""
+
+    def test_scrubs_exception_value(self):
+        event = {
+            "exception": {
+                "values": [
+                    {
+                        "value": "Failed to process message _actor_foo("
+                        "user={'id': 1, 'api_key': 'real-secret-key-123'})",
+                    }
+                ]
+            }
+        }
+        result = _before_send(event, {})
+        assert "real-secret-key-123" not in result["exception"]["values"][0]["value"]
+
+    def test_scrubs_event_message(self):
+        event = {"message": "Login with mcp_token='tok-abcdef'"}
+        result = _before_send(event, {})
+        assert "tok-abcdef" not in result["message"]
+
+    def test_scrubs_breadcrumb_message(self):
+        event = {"breadcrumbs": {"values": [{"message": "Calling API with api_key='xyz999'"}]}}
+        result = _before_send(event, {})
+        assert "xyz999" not in result["breadcrumbs"]["values"][0]["message"]
+
+    def test_scrubs_extra_string_values(self):
+        """String values under non-sensitive keys are still scrubbed by the tree walker."""
+        event = {"extra": {"context": "called foo(api_key='leaked-123')"}}
+        result = _before_send(event, {})
+        assert "leaked-123" not in result["extra"]["context"]
+
+    def test_scrubs_threads_frames(self):
+        """Non-exception threads stacktraces also get their vars scrubbed."""
+        event = {
+            "threads": {
+                "values": [
+                    {
+                        "stacktrace": {
+                            "frames": [
+                                {"vars": {"mcp_token": "real-thread-tok"}},
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+        result = _before_send(event, {})
+        assert result["threads"]["values"][0]["stacktrace"]["frames"][0]["vars"]["mcp_token"] == "[REDACTED]"
+
+    def test_scrubs_quoted_value_with_spaces(self):
+        """Quoted value containing spaces must be fully redacted, not truncated at first space."""
+        text = "password='hunter 2 with spaces'"
+        event = {"exception": {"values": [{"value": text}]}}
+        result = _before_send(event, {})
+        scrubbed = result["exception"]["values"][0]["value"]
+        assert "hunter" not in scrubbed
+        assert "spaces" not in scrubbed
 
 
 class TestTracesSampler:


### PR DESCRIPTION
Enhances security by eliminating credentials from UserDTO objects to prevent sensitive data leakage across service boundaries, as indicated in issue #147. Instead, credentials are fetched directly from the database when they are needed. 

Major changes also include:

- Improved Sentry configuration to redact credential-shaped substrings from logs and exception messages.
- Adjustments to various components to refetch user credentials directly from the ORM.
- Addition of robust tests ensuring that credentials are neither included in UserDTO nor accidentally passed through its constructor or representation.

This change addresses security concerns related to credential exposure in cross-boundary transport and enhances overall data safety across the multi-tenant system.

Relates to #147.