### PR TITLE
Adds handling for Telegram chat member updates

### DIFF
--- a/api/server.py
+++ b/api/server.py
@@ -9,6 +9,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 from starlette.exceptions import HTTPException as StarletteHTTPException
+from telegram import Update
 
 from api.dashboard_routes import router as dashboard_router
 from api.routes import router
@@ -104,6 +105,7 @@ async def lifespan(app):
             await tg_app.bot.set_webhook(
                 url=webhook_url,
                 secret_token=hashlib.sha256(settings.TELEGRAM_BOT_TOKEN.get_secret_value().encode()).hexdigest()[:32],
+                allowed_updates=Update.ALL_TYPES,
             )
             app.state.tg_app = tg_app
             logger.info("Telegram webhook set: %s", webhook_url)

--- a/bot/main.py
+++ b/bot/main.py
@@ -13,12 +13,13 @@ import psutil
 import sentry_sdk
 from sqlalchemy import text
 from sqlalchemy import update as sa_update
-from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update, WebAppInfo
+from telegram import ChatMember, InlineKeyboardButton, InlineKeyboardMarkup, Update, WebAppInfo
 from telegram.error import TelegramError
 from telegram.ext import (
     Application,
     ApplicationBuilder,
     CallbackQueryHandler,
+    ChatMemberHandler,
     CommandHandler,
     ContextTypes,
     ConversationHandler,
@@ -65,6 +66,12 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         username=tg_user.username,
         display_name=tg_user.full_name,
     )
+    # Explicit reactivation: /start is an unambiguous re-engagement signal.
+    # Webapp/Login Widget auth paths intentionally do NOT reactivate — see
+    # `docs/MULTI_TENANT_SECURITY.md` §T14.
+    if not user.is_active:
+        await User.set_active_by_chat_id(chat_id, True)
+        user.is_active = True
     logger.info("User resolved via /start: id=%s chat_id=%s username=%s", user.id, chat_id, tg_user.username)
 
     webapp_url = settings.API_BASE_URL
@@ -828,6 +835,27 @@ async def whoami(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     await update.message.reply_text("\n".join(lines), parse_mode="Markdown")
 
 
+async def handle_my_chat_member(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Track user block/unblock of the bot via `my_chat_member` updates.
+
+    `kicked` = blocked the bot, `member` = (re)started it. Flips `users.is_active`
+    so scheduled broadcasts (which go through `User.get_active_athletes`) skip
+    blocked users without hitting the Telegram API. Reactivation is explicit:
+    this handler on `MEMBER` transitions, and `bot/main.py:start` when the
+    user sends `/start`. Webapp/Login Widget auth paths deliberately do not
+    reactivate — see `docs/MULTI_TENANT_SECURITY.md` §T14.
+    """
+    cmu = update.my_chat_member
+    if cmu is None or cmu.chat.type != "private":
+        return
+    new_status = cmu.new_chat_member.status
+    if new_status not in (ChatMember.BANNED, ChatMember.MEMBER):
+        return
+    active = new_status == ChatMember.MEMBER
+    await User.set_active_by_chat_id(cmu.chat.id, active)
+    logger.info("User %s is_active=%s (my_chat_member=%s)", cmu.chat.id, active, new_status)
+
+
 # ---------------------------------------------------------------------------
 # App builder (shared between polling and webhook modes)
 # ---------------------------------------------------------------------------
@@ -866,6 +894,7 @@ def build_application() -> Application:
     if settings.TELEGRAM_WEBHOOK_URL:
         builder = builder.updater(None)
     app = builder.build()
+    app.add_handler(ChatMemberHandler(handle_my_chat_member, ChatMemberHandler.MY_CHAT_MEMBER))
     app.add_handler(CommandHandler("start", start))
     app.add_handler(CommandHandler("morning", morning))
     app.add_handler(CommandHandler("dashboard", dashboard))
@@ -913,7 +942,7 @@ def start_bot() -> None:
         raise RuntimeError("TELEGRAM_WEBHOOK_URL is set — bot runs via webhook in api service, not polling")
     app = build_application()
     logger.info("Bot started (polling mode)")
-    app.run_polling()
+    app.run_polling(allowed_updates=Update.ALL_TYPES)
 
 
 if __name__ == "__main__":

--- a/data/db/user.py
+++ b/data/db/user.py
@@ -4,7 +4,7 @@ import secrets
 from datetime import date, datetime, timezone
 from enum import Enum
 
-from sqlalchemy import Boolean, DateTime, Integer, String, Text, select
+from sqlalchemy import Boolean, DateTime, Integer, String, Text, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Mapped, Session, mapped_column
@@ -90,7 +90,12 @@ class User(Base):
     @classmethod
     @dual
     def get_active_athletes(cls, *, session: Session) -> list[User]:
-        result = session.execute(select(cls).where(cls.is_active.is_(True), cls.athlete_id.isnot(None)))
+        result = session.execute(
+            select(cls).where(
+                cls.is_active.is_(True),
+                cls.athlete_id.isnot(None),
+            )
+        )
         return list(result.scalars().all())
 
     @classmethod
@@ -101,9 +106,25 @@ class User(Base):
 
     @classmethod
     @with_session
-    async def get_by_chat_id(cls, chat_id: str, *, session: AsyncSession) -> User | None:
-        result = await session.execute(select(cls).where(cls.chat_id == chat_id, cls.is_active.is_(True)))
+    async def get_by_chat_id(
+        cls,
+        chat_id: int | str,
+        include_inactive: bool = False,
+        *,
+        session: AsyncSession,
+    ) -> User | None:
+        query = select(cls).where(cls.chat_id == str(chat_id))
+        if not include_inactive:
+            query = query.where(cls.is_active.is_(True))
+        result = await session.execute(query)
         return result.scalar_one_or_none()
+
+    @classmethod
+    @dual
+    def set_active_by_chat_id(cls, chat_id: int | str, active: bool, *, session: Session) -> None:
+        """Toggle `is_active` by chat_id. Called from `my_chat_member` handler and 403 fallbacks."""
+        session.execute(update(cls).where(cls.chat_id == str(chat_id)).values(is_active=active))
+        session.commit()
 
     @classmethod
     @dual
@@ -277,7 +298,13 @@ class User(Base):
         on `create()`'s default role, so a future change to that default
         cannot silently widen the widget-auth security posture.
         """
-        user = await cls.get_by_chat_id(chat_id)
+        # `include_inactive=True` so a blocked user (is_active=False) is still
+        # findable — prevents `IntegrityError` on the UNIQUE `chat_id` if we
+        # tried to `create()` a fresh row. Reactivation is NOT done here: it
+        # belongs to explicit re-engagement paths (`/start` handler and
+        # `my_chat_member` MEMBER transition), not to webapp/Login Widget auth.
+        # See `docs/MULTI_TENANT_SECURITY.md` §T14 for rationale.
+        user = await cls.get_by_chat_id(chat_id, include_inactive=True)
         if user:
             return user
         try:

--- a/docs/MULTI_TENANT_SECURITY.md
+++ b/docs/MULTI_TENANT_SECURITY.md
@@ -156,6 +156,20 @@
 - **Operator setup:** `/setdomain` в `@BotFather` → `bot.endurai.me` (иначе виджет не рендерится). `TELEGRAM_BOT_USERNAME` в `.env` для фронта через `GET /api/auth/telegram-widget-config`
 - **Тесты:** `tests/api/test_telegram_widget_auth.py` — 18 кейсов, включая valid/tampered/missing-fields/stale/future/wrong-token/empty-token/null-optional/extra-fields-signed-through
 
+#### T14. Silent Re-Activation of Blocked Users (Tampering / Availability)
+
+- **Что:** Пользователь блокирует бота в Telegram → `users.is_active=False` (см. `bot/main.py:handle_my_chat_member` и 403-fallback в `tasks/tools.py:TelegramTool.send_message`). Но у заблокированного юзера может оставаться открытая вкладка Mini App или старая ссылка с валидным `initData`. Если auth-путь автоматически реактивирует юзера при первом же API-запросе, scheduler снова начнёт дёргать Telegram API, ловить 403, снова выключать — пинг-понг, лишние Sentry-события, лишние Telegram calls.
+- **Где:** `data/db/user.py:get_or_create_from_telegram()`, вызывается из `api/deps.py:get_current_user` (initData), `api/routers/auth.py` (Login Widget) и `bot/main.py:start` (`/start` handler)
+- **Severity:** Medium (availability degradation + auth policy leak, не ведёт к data disclosure)
+- **Mitigation (реализовано):**
+  - `get_or_create_from_telegram` ищет юзера через `get_by_chat_id(..., include_inactive=True)` — предотвращает `IntegrityError` на UNIQUE `chat_id` если row существует как `is_active=False`. Но **реактивацию не делает**: возвращает юзера "как есть", auth-код дальше сам решает что с ним.
+  - Реактивация (`set_active_by_chat_id(..., True)`) происходит **только** в двух явных сигналах re-engagement:
+    1. `bot/main.py:start` — юзер явно пишет `/start`
+    2. `bot/main.py:handle_my_chat_member` — Telegram прислал `my_chat_member` с `status=MEMBER`
+  - Webapp auth (initData) и Login Widget **не реактивируют** — они читают `is_active` через существующий фильтр в `get_by_chat_id(chat_id)` (без `include_inactive`), т.е. заблокированный юзер для webapp просто "не найден" и получает anonymous flow.
+- **Семантика `users.is_active`:** флаг перегружен двумя смыслами — "админ-деактивация через CLI" ∪ "Telegram-канал недоступен". Оба состояния = полная потеря доступа (webapp, MCP, рассылки), потому что auth-запросы (`get_by_mcp_token`, `get_by_chat_id`) фильтруют по `is_active=True`. Это **намеренное решение**: блокировка бота = явный сигнал "не хочу пользоваться сервисом", и даёт юзеру единую kill-switch.
+- **Граничный случай:** юзер блокирует бота, но webapp-вкладка открыта. Первый API-запрос вернёт 401 (юзер не найден через `get_by_chat_id`). Frontend должен показать баннер "переподключите бота через /start" (TODO в `webapp/src/auth/`). Пока баннер не реализован — юзер увидит generic "требуется авторизация".
+
 #### T13. RPE Callback Cross-Tenant Write (Tampering)
 
 - **Что:** Подделка `callback_data` вида `rpe:{activity_id}:{value}` → запись RPE на чужую activity

--- a/tasks/tools.py
+++ b/tasks/tools.py
@@ -16,6 +16,7 @@ import httpx
 
 from bot.prompts import get_system_prompt_v2
 from config import settings
+from data.db import User
 from tasks.dto import DateDTO
 
 logger = logging.getLogger(__name__)
@@ -436,6 +437,14 @@ class TelegramTool:
                     json=payload,
                     timeout=15.0,
                 )
+                if resp.status_code == 403:
+                    # User blocked the bot (or deactivated). `my_chat_member` is
+                    # the primary signal, but scheduled actors may fire between
+                    # the block and the webhook — flip the flag here too so the
+                    # next scheduled run skips this user.
+                    logger.info("Telegram 403 for chat_id=%s — marking inactive", _chat_id)
+                    User.set_active_by_chat_id(_chat_id, False)
+                    return None
                 resp.raise_for_status()
                 return resp.json()
             except (httpx.TimeoutException, httpx.ConnectError) as e:


### PR DESCRIPTION
Enhances the bot's handling of Telegram chat member status changes by introducing a new handler for `my_chat_member` updates. This improvement tracks when a user blocks or unblocks the bot, adjusting user activity status accordingly to optimize scheduled broadcasts and API usage.

Additionally:
- Extends database capabilities to toggle user activity status based on chat ID.
- Modifies webhook and polling configuration to allow all types of updates.

These changes aim to improve the bot's performance in multi-tenant environments by ensuring more reliable user status tracking.

Relates to versions/multi-tenant