### PR TITLE
Add user-level decorator for broader command access

### DIFF
--- a/bot/decorator.py
+++ b/bot/decorator.py
@@ -37,3 +37,40 @@ def athlete_required(fn):
         return await fn(update, context, *args, user=user, **kwargs)
 
     return wrapper
+
+
+def user_required(fn):
+    """Decorator for Telegram handlers: resolve any active user (viewer or
+    athlete), pass as `user` kwarg.
+
+    Weaker than `athlete_required` — does NOT require `athlete_id`. Use for
+    commands that make sense for not-yet-onboarded users: `/silent`, `/lang`,
+    `/donate`, `/whoami`, etc. For commands that read athlete-scoped data
+    (`/morning`, `/workout`), stick with `athlete_required`.
+
+    Lookup: `User.get_by_chat_id(update.effective_user.id)`. The column name
+    `users.chat_id` is legacy — it stores the Telegram **user** ID, which in
+    private chats (the only chat type this bot handles) equals `chat.id`.
+    We use `effective_user.id` to identify the sender regardless of chat type,
+    matching the existing `athlete_required` convention.
+
+    Fallback: if the row is missing or `is_active=False`, reply with
+    "Сначала отправьте /start" on both `message` and `callback_query` paths
+    so the user gets consistent guidance on how to recover.
+    """
+
+    @functools.wraps(fn)
+    async def wrapper(update, context, *args, **kwargs):
+        user = await User.get_by_chat_id(str(update.effective_user.id))
+        if user:
+            set_language(user.language or "ru")
+        if not user or not user.is_active:
+            msg = _("Сначала отправьте /start")
+            if update.callback_query:
+                await update.callback_query.answer(msg, show_alert=True)
+            elif update.message:
+                await update.message.reply_text(msg)
+            return
+        return await fn(update, context, *args, user=user, **kwargs)
+
+    return wrapper

--- a/bot/main.py
+++ b/bot/main.py
@@ -30,7 +30,7 @@ from telegram.ext import (
 
 from api.auth import generate_code
 from bot.agent import ClaudeAgent
-from bot.decorator import athlete_required
+from bot.decorator import athlete_required, user_required
 from bot.donate_nudge import get_nudge_text, should_show_nudge
 from bot.i18n import _
 from bot.i18n import set_language as _set_lang
@@ -152,7 +152,7 @@ async def morning(update: Update, context: ContextTypes.DEFAULT_TYPE, user: User
     await update.message.reply_text(_("Отчёт формируется, подождите пару минут."), reply_markup=keyboard)
 
 
-@athlete_required
+@user_required
 async def set_lang(update: Update, context: ContextTypes.DEFAULT_TYPE, user: User) -> None:
     """Handle /lang command — show language picker inline buttons."""
     keyboard = InlineKeyboardMarkup(
@@ -166,7 +166,7 @@ async def set_lang(update: Update, context: ContextTypes.DEFAULT_TYPE, user: Use
     await update.message.reply_text("🌐 Choose language:", reply_markup=keyboard)
 
 
-@athlete_required
+@user_required
 async def handle_lang_callback(update: Update, context: ContextTypes.DEFAULT_TYPE, user: User) -> None:
     """Handle language selection callback."""
     query = update.callback_query
@@ -271,7 +271,7 @@ async def web_login(update: Update, context: ContextTypes.DEFAULT_TYPE, user: Us
     )
 
 
-@athlete_required
+@user_required
 async def silent(update: Update, context: ContextTypes.DEFAULT_TYPE, user: User) -> None:
     """Handle /silent command — toggle silent mode."""
     async with get_session() as session:


### PR DESCRIPTION
Introduces a new user-level decorator to handle commands accessible to all users, not just athletes. This provides a more inclusive access layer for features that don't require athlete data, such as language settings and donation options.

- Updates functions to utilize the new decorator (`user_required`) to expand usability beyond just athletes.
- Enhances user support for commands like `/silent`, `/lang`.

Relates to multi-tenant improvements.