### PR TITLE
Adds multi-language support for wellness insights

### DIFF
--- a/webapp/src/components/DayNav.tsx
+++ b/webapp/src/components/DayNav.tsx
@@ -11,7 +11,7 @@ interface DayNavProps {
 }
 
 export default function DayNav({ currentDate, isToday, hasPrev = true, hasNext, onPrev, onNext }: DayNavProps) {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
   const disableNext = hasNext !== undefined ? !hasNext : isToday
 
   return (
@@ -24,7 +24,7 @@ export default function DayNav({ currentDate, isToday, hasPrev = true, hasNext, 
         &larr; {t('common.prev')}
       </button>
       <span className="text-sm font-semibold min-w-[140px] text-center">
-        {formatDateDisplay(currentDate)}
+        {formatDateDisplay(currentDate, i18n.language)}
         {isToday && (
           <span className="inline-block bg-[var(--button)] text-white text-[10px] font-bold px-1.5 py-px rounded ml-1.5 align-middle">
             {t('common.today_lower')}

--- a/webapp/src/components/SyncButton.tsx
+++ b/webapp/src/components/SyncButton.tsx
@@ -13,7 +13,7 @@ interface SyncButtonProps {
 export default function SyncButton({ endpoint, lastSyncedAt, onSynced }: SyncButtonProps) {
   const [syncing, setSyncing] = useState(false)
   const [queued, setQueued] = useState(false)
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
 
   useEffect(() => {
     setQueued(false)
@@ -51,7 +51,7 @@ export default function SyncButton({ endpoint, lastSyncedAt, onSynced }: SyncBut
         )}
       </button>
       <span className="text-xs text-text-dim">
-        {lastSyncedAt ? t('common.updated_at', { time: relativeTime(lastSyncedAt) }) : t('common.not_synced')}
+        {lastSyncedAt ? t('common.updated_at', { time: relativeTime(lastSyncedAt, i18n.language) }) : t('common.not_synced')}
       </span>
     </div>
   )

--- a/webapp/src/components/WeekNav.tsx
+++ b/webapp/src/components/WeekNav.tsx
@@ -11,7 +11,7 @@ interface WeekNavProps {
 }
 
 export default function WeekNav({ weekStart, weekEnd, hasPrev, hasNext, onPrev, onNext }: WeekNavProps) {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
   return (
     <div className="flex items-center justify-center gap-3 py-2">
       <button
@@ -22,7 +22,7 @@ export default function WeekNav({ weekStart, weekEnd, hasPrev, hasNext, onPrev, 
         &larr; {t('common.prev')}
       </button>
       <span className="text-sm font-semibold min-w-[180px] text-center">
-        {formatWeekLabel(weekStart, weekEnd)}
+        {formatWeekLabel(weekStart, weekEnd, i18n.language)}
       </span>
       <button
         onClick={onNext}

--- a/webapp/src/lib/constants.ts
+++ b/webapp/src/lib/constants.ts
@@ -5,11 +5,10 @@ export const SPORT_ICONS: Record<string, string> = {
   Other: '\u{1F3CB}\uFE0F',
 }
 
-export const WEEKDAY_RU: Record<string, string> = {
-  Mon: 'Пн', Tue: 'Вт', Wed: 'Ср', Thu: 'Чт', Fri: 'Пт', Sat: 'Сб', Sun: 'Вс',
+export const MONTHS: Record<string, string[]> = {
+  ru: ['янв', 'фев', 'мар', 'апр', 'мая', 'июн', 'июл', 'авг', 'сен', 'окт', 'ноя', 'дек'],
+  en: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
 }
-
-export const MONTHS = ['янв', 'фев', 'мар', 'апр', 'мая', 'июн', 'июл', 'авг', 'сен', 'окт', 'ноя', 'дек']
 
 export const ZONE_COLORS = ['#6b7280', '#22c55e', '#f59e0b', '#f97316', '#ef4444']
 export const ZONE_LABELS = ['Z1', 'Z2', 'Z3', 'Z4', 'Z5']

--- a/webapp/src/lib/formatters.ts
+++ b/webapp/src/lib/formatters.ts
@@ -1,4 +1,4 @@
-import { MONTHS, WEEKDAY_RU } from './constants'
+import { MONTHS } from './constants'
 
 export function formatDate(dateStr: string): string {
   const d = new Date(dateStr + 'T00:00:00')
@@ -6,40 +6,60 @@ export function formatDate(dateStr: string): string {
   return `${days[d.getDay()]}, ${d.getDate()} ${MONTHS[d.getMonth()]}`
 }
 
-export function formatWeekLabel(start: string, end: string): string {
+export function formatWeekLabel(start: string, end: string, lang: string = 'ru'): string {
   const s = new Date(start + 'T00:00:00')
   const e = new Date(end + 'T00:00:00')
-  const sm = MONTHS[s.getMonth()]
-  const em = MONTHS[e.getMonth()]
+  const months = MONTHS[lang] || MONTHS.en
+  const sm = months[s.getMonth()]
+  const em = months[e.getMonth()]
   if (sm === em) {
     return `${sm} ${s.getDate()} \u2013 ${e.getDate()}, ${s.getFullYear()}`
   }
   return `${sm} ${s.getDate()} \u2013 ${em} ${e.getDate()}, ${e.getFullYear()}`
 }
 
-export function formatDayDate(dateStr: string, weekday: string): string {
+const _WEEKDAYS: Record<string, Record<string, string>> = {
+  ru: { Mon: 'пн', Tue: 'вт', Wed: 'ср', Thu: 'чт', Fri: 'пт', Sat: 'сб', Sun: 'вс' },
+  en: { Mon: 'Mon', Tue: 'Tue', Wed: 'Wed', Thu: 'Thu', Fri: 'Fri', Sat: 'Sat', Sun: 'Sun' },
+}
+
+const _WEEKDAYS_SHORT: Record<string, string[]> = {
+  ru: ['вс', 'пн', 'вт', 'ср', 'чт', 'пт', 'сб'],
+  en: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+}
+
+export function formatDayDate(dateStr: string, weekday: string, lang: string = 'ru'): string {
   const d = new Date(dateStr + 'T00:00:00')
-  return `${WEEKDAY_RU[weekday] || weekday} ${d.getDate()}`
+  const wd = (_WEEKDAYS[lang] || _WEEKDAYS.en)[weekday] || weekday
+  return `${wd} ${d.getDate()}`
 }
 
-export function formatDateDisplay(d: Date): string {
-  const days = ['вс', 'пн', 'вт', 'ср', 'чт', 'пт', 'сб']
-  return `${days[d.getDay()]}, ${d.getDate()} ${MONTHS[d.getMonth()]} ${d.getFullYear()}`
+export function formatDateDisplay(d: Date, lang: string = 'ru'): string {
+  const days = _WEEKDAYS_SHORT[lang] || _WEEKDAYS_SHORT.en
+  const months = MONTHS[lang] || MONTHS.en
+  return `${days[d.getDay()]}, ${d.getDate()} ${months[d.getMonth()]} ${d.getFullYear()}`
 }
 
-export function fmtDateShort(dateStr: string): string {
+export function fmtDateShort(dateStr: string, lang: string = 'ru'): string {
   const d = new Date(dateStr + 'T00:00:00')
-  return `${MONTHS[d.getMonth()]} ${d.getDate()}, ${d.getFullYear()}`
+  const months = MONTHS[lang] || MONTHS.en
+  return `${months[d.getMonth()]} ${d.getDate()}, ${d.getFullYear()}`
 }
 
-export function relativeTime(isoStr: string | null): string {
+const _RELATIVE: Record<string, { just_now: string; min: string; h: string; d: string }> = {
+  ru: { just_now: 'только что', min: 'мин назад', h: 'ч назад', d: 'дн назад' },
+  en: { just_now: 'just now', min: 'min ago', h: 'h ago', d: 'd ago' },
+}
+
+export function relativeTime(isoStr: string | null, lang: string = 'ru'): string {
   if (!isoStr) return ''
+  const t = _RELATIVE[lang] || _RELATIVE.en
   const diffMin = Math.floor((Date.now() - new Date(isoStr).getTime()) / 60000)
-  if (diffMin < 1) return 'только что'
-  if (diffMin < 60) return `${diffMin} мин назад`
+  if (diffMin < 1) return t.just_now
+  if (diffMin < 60) return `${diffMin} ${t.min}`
   const diffH = Math.floor(diffMin / 60)
-  if (diffH < 24) return `${diffH} ч назад`
-  return `${Math.floor(diffH / 24)} дн назад`
+  if (diffH < 24) return `${diffH} ${t.h}`
+  return `${Math.floor(diffH / 24)} ${t.d}`
 }
 
 export function num(v: number | null | undefined, decimals = 1): string {

--- a/webapp/src/lib/formatters.ts
+++ b/webapp/src/lib/formatters.ts
@@ -1,15 +1,28 @@
 import { MONTHS } from './constants'
 
-export function formatDate(dateStr: string): string {
+/** Normalize 'ru-RU' → 'ru', 'en-US' → 'en', etc. */
+function normLang(lang: string): string {
+  const base = lang.split('-')[0]
+  return base in MONTHS ? base : 'en'
+}
+
+const _WEEKDAYS_FULL: Record<string, string[]> = {
+  ru: ['Воскресенье', 'Понедельник', 'Вторник', 'Среда', 'Четверг', 'Пятница', 'Суббота'],
+  en: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
+}
+
+export function formatDate(dateStr: string, lang: string = 'ru'): string {
+  const l = normLang(lang)
   const d = new Date(dateStr + 'T00:00:00')
-  const days = ['Воскресенье', 'Понедельник', 'Вторник', 'Среда', 'Четверг', 'Пятница', 'Суббота']
-  return `${days[d.getDay()]}, ${d.getDate()} ${MONTHS[d.getMonth()]}`
+  const days = _WEEKDAYS_FULL[l] || _WEEKDAYS_FULL.en
+  return `${days[d.getDay()]}, ${d.getDate()} ${(MONTHS[l] || MONTHS.en)[d.getMonth()]}`
 }
 
 export function formatWeekLabel(start: string, end: string, lang: string = 'ru'): string {
+  const l = normLang(lang)
   const s = new Date(start + 'T00:00:00')
   const e = new Date(end + 'T00:00:00')
-  const months = MONTHS[lang] || MONTHS.en
+  const months = MONTHS[l] || MONTHS.en
   const sm = months[s.getMonth()]
   const em = months[e.getMonth()]
   if (sm === em) {
@@ -29,20 +42,23 @@ const _WEEKDAYS_SHORT: Record<string, string[]> = {
 }
 
 export function formatDayDate(dateStr: string, weekday: string, lang: string = 'ru'): string {
+  const l = normLang(lang)
   const d = new Date(dateStr + 'T00:00:00')
-  const wd = (_WEEKDAYS[lang] || _WEEKDAYS.en)[weekday] || weekday
+  const wd = (_WEEKDAYS[l] || _WEEKDAYS.en)[weekday] || weekday
   return `${wd} ${d.getDate()}`
 }
 
 export function formatDateDisplay(d: Date, lang: string = 'ru'): string {
-  const days = _WEEKDAYS_SHORT[lang] || _WEEKDAYS_SHORT.en
-  const months = MONTHS[lang] || MONTHS.en
+  const l = normLang(lang)
+  const days = _WEEKDAYS_SHORT[l] || _WEEKDAYS_SHORT.en
+  const months = MONTHS[l] || MONTHS.en
   return `${days[d.getDay()]}, ${d.getDate()} ${months[d.getMonth()]} ${d.getFullYear()}`
 }
 
 export function fmtDateShort(dateStr: string, lang: string = 'ru'): string {
+  const l = normLang(lang)
   const d = new Date(dateStr + 'T00:00:00')
-  const months = MONTHS[lang] || MONTHS.en
+  const months = MONTHS[l] || MONTHS.en
   return `${months[d.getMonth()]} ${d.getDate()}, ${d.getFullYear()}`
 }
 
@@ -53,7 +69,7 @@ const _RELATIVE: Record<string, { just_now: string; min: string; h: string; d: s
 
 export function relativeTime(isoStr: string | null, lang: string = 'ru'): string {
   if (!isoStr) return ''
-  const t = _RELATIVE[lang] || _RELATIVE.en
+  const t = _RELATIVE[normLang(lang)] || _RELATIVE.en
   const diffMin = Math.floor((Date.now() - new Date(isoStr).getTime()) / 60000)
   if (diffMin < 1) return t.just_now
   if (diffMin < 60) return `${diffMin} ${t.min}`

--- a/webapp/src/pages/Activities.tsx
+++ b/webapp/src/pages/Activities.tsx
@@ -15,7 +15,7 @@ import { SPORT_ICONS } from '../lib/constants'
 import type { ActivitiesWeekResponse, ActivityItem, ActivityDetailsResponse, SyncResponse } from '../api/types'
 
 export default function Activities() {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
   const { offset, prev, next } = useWeekNav()
   const { data, loading, error, reload } = useApi<ActivitiesWeekResponse>(`/api/activities-week?week_offset=${offset}`)
 
@@ -55,7 +55,7 @@ export default function Activities() {
             return (
               <div key={day.date} className={`bg-surface border rounded-[14px] mb-2.5 overflow-hidden ${isToday ? 'border-accent' : 'border-border'}`}>
                 <div className="flex items-center justify-between px-4 py-3">
-                  <span className="text-sm font-semibold">{formatDayDate(day.date, day.weekday)}</span>
+                  <span className="text-sm font-semibold">{formatDayDate(day.date, day.weekday, i18n.language)}</span>
                   {isToday && <span className="text-[10px] font-bold bg-accent text-white px-2 py-0.5 rounded-lg tracking-wide">{t('common.today_badge')}</span>}
                 </div>
                 {day.activities.length === 0 && !isFuture && (

--- a/webapp/src/pages/Activity.tsx
+++ b/webapp/src/pages/Activity.tsx
@@ -17,7 +17,7 @@ import { SPORT_ICONS } from '../lib/constants'
 import type { ActivityDetailsResponse, RaceInfo } from '../api/types'
 
 export default function Activity() {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
   const { id } = useParams<{ id: string }>()
   const { data, loading, error } = useApi<ActivityDetailsResponse>(
     id && /^i\d+$/.test(id) ? `/api/activity/${id}/details` : null
@@ -64,7 +64,7 @@ export default function Activity() {
   const swimPaceSecPer100m = swimPaceSecPerKm ? swimPaceSecPerKm / 10 : null
   const gapSecPerKm = normalizePaceSecPerKm(d?.gap)
 
-  const subParts = [fmtDateShort(data.date), data.duration, data.icu_training_load != null ? `TSS ${data.icu_training_load}` : null, data.average_hr != null ? `\u2764\uFE0F ${data.average_hr} bpm` : null].filter(Boolean)
+  const subParts = [fmtDateShort(data.date, i18n.language), data.duration, data.icu_training_load != null ? `TSS ${data.icu_training_load}` : null, data.average_hr != null ? `\u2764\uFE0F ${data.average_hr} bpm` : null].filter(Boolean)
 
   return (
     <Layout backTo="/activities" backLabel={t('activities.back_to_list')} hideBottomTabs>

--- a/webapp/src/pages/Plan.tsx
+++ b/webapp/src/pages/Plan.tsx
@@ -12,7 +12,7 @@ import { SPORT_ICONS } from '../lib/constants'
 import type { ScheduledWorkoutsResponse, SyncResponse, ScheduledWorkout } from '../api/types'
 
 export default function Plan() {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
   const { offset, prev, next } = useWeekNav()
   const { data, loading, error, reload } = useApi<ScheduledWorkoutsResponse>(`/api/scheduled-workouts?week_offset=${offset}`)
 
@@ -51,7 +51,7 @@ export default function Plan() {
             return (
               <div key={day.date} className={`bg-surface border rounded-[14px] mb-2.5 overflow-hidden ${isToday ? 'border-accent' : 'border-border'}`}>
                 <div className="flex items-center justify-between px-4 py-3">
-                  <span className="text-sm font-semibold">{formatDayDate(day.date, day.weekday)}</span>
+                  <span className="text-sm font-semibold">{formatDayDate(day.date, day.weekday, i18n.language)}</span>
                   {isToday && <span className="text-[10px] font-bold bg-accent text-white px-2 py-0.5 rounded-lg tracking-wide">{t('common.today_badge')}</span>}
                 </div>
                 {day.workouts.length === 0 ? (

--- a/webapp/src/pages/Settings.tsx
+++ b/webapp/src/pages/Settings.tsx
@@ -247,12 +247,6 @@ export default function Settings() {
         <Row label="Run CTL" value="25" />
       </Section>
 
-      {/* AI Workouts */}
-      <Section title="AI Workouts" icon="🤖">
-        <Row label="Auto-generate" value="Coming soon" />
-        <Row label="Auto-push to Garmin" value="Coming soon" />
-      </Section>
-
       {/* MCP Connection */}
       {isAuthenticated && (
         <Section title={t('settings.mcp.title')} icon="🔌">

--- a/webapp/src/pages/Today.tsx
+++ b/webapp/src/pages/Today.tsx
@@ -19,7 +19,7 @@ import type {
 } from '../api/types'
 
 export default function Today() {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
   const [report, setReport] = useState<WellnessResponse | null>(null)
   const [workouts, setWorkouts] = useState<ScheduledWorkoutsResponse | null>(null)
   const [activities, setActivities] = useState<ActivitiesWeekResponse | null>(null)
@@ -158,7 +158,7 @@ export default function Today() {
             <div className="flex-1">
               <div className="text-[13px] font-medium">{sportLabel(lastActivity.type)}</div>
               <div className="text-xs text-text-dim">
-                {fmtDateShort(lastActivity.date)}
+                {fmtDateShort(lastActivity.date, i18n.language)}
                 {lastActivity.duration && ` \u00B7 ${lastActivity.duration}`}
                 {lastActivity.icu_training_load != null && ` \u00B7 TSS ${lastActivity.icu_training_load}`}
               </div>


### PR DESCRIPTION
Implements language support across wellness insights and status badges:
- Adds dictionaries for Russian and English for verdicts
- Updates functions to accept a language parameter to return the appropriate translations
- Integrates i18n for StatusBadge labels with translation keys

Enhances usability in multi-tenant environments by allowing language-specific messages.