### PR TITLE
Makes workout suffix optional

### DIFF
--- a/api/routers/intervals/webhook.py
+++ b/api/routers/intervals/webhook.py
@@ -54,7 +54,7 @@ def _verify_webhook_secret(payload: IntervalsWebhookPayload) -> bool:
         logger.warning(
             "Intervals webhook received but INTERVALS_WEBHOOK_SECRET is not set — "
             "accepting all requests (debug mode). Set the env var to enforce "
-            "verification. This warning will emit only once per process."
+            "verification."
         )
         return True
 
@@ -134,13 +134,13 @@ def _dispatch_wellness(user: UserDTO, event: IntervalsWebhookEvent) -> None:
     wellness_dtos = TypeAdapter(list[WellnessDTO]).validate_python(event.records)
 
     # Sort by updated ascending — process oldest records first
-    wellness_dtos.sort(key=lambda w: w.updated or "")
+    wellness_dtos.sort(key=lambda w: str(w.updated or ""))
 
     for wellness_dto in wellness_dtos:
         actor_user_wellness.send(
             user=user,
             dt=wellness_dto.id,
-            wellnessDTO=wellness_dto,
+            wellness=wellness_dto,
         )
 
 

--- a/bot/formatter.py
+++ b/bot/formatter.py
@@ -48,20 +48,20 @@ def build_workout_pushed_message(
     name: str,
     duration_minutes: int,
     target_tss: int | None,
-    suffix: str,
+    suffix: str | None,
     intervals_id: int | None,
     athlete_id: str,
     target_date: date | None = None,
 ) -> str:
     """Build Telegram notification for AI workout pushed to Intervals.icu."""
     emoji = sport_emoji(sport)
-    suffix_label = "adapted" if suffix == "adapted" else "generated"
+    suffix_label = f" ({suffix})" if suffix else ""
 
     date_str = target_date.strftime("%d.%m") if target_date else ""
     header = f"🏋️ AI тренировка добавлена на {date_str}" if date_str else "🏋️ AI тренировка добавлена"
 
     tss_part = f", ~{target_tss} TSS" if target_tss else ""
-    detail = f"{emoji} {name} ({suffix_label})\n{duration_minutes} мин{tss_part}"
+    detail = f"{emoji} {name}{suffix_label}\n{duration_minutes} мин{tss_part}"
 
     lines = [header, "", detail]
 

--- a/data/db/athlete.py
+++ b/data/db/athlete.py
@@ -230,7 +230,10 @@ class AthleteGoal(Base):
         """Upsert goal from Intervals.icu event. Does NOT overwrite CTL targets."""
         now = datetime.now(timezone.utc)
         existing = session.execute(
-            select(cls).where(cls.user_id == user_id, cls.intervals_event_id == intervals_event_id)
+            select(cls).where(
+                cls.user_id == user_id,
+                cls.intervals_event_id == intervals_event_id,
+            )
         ).scalar_one_or_none()
 
         if existing:

--- a/data/db/wellness.py
+++ b/data/db/wellness.py
@@ -210,7 +210,12 @@ class Wellness(Base):
         session: Session,
     ) -> None:
         date_str = dt.isoformat()
-        result = session.execute(select(cls).where(cls.user_id == user_id, cls.date == date_str))
+        result = session.execute(
+            select(cls).where(
+                cls.user_id == user_id,
+                cls.date == date_str,
+            )
+        )
         row = result.scalar_one_or_none()
         if row is None:
             return

--- a/data/intervals/dto.py
+++ b/data/intervals/dto.py
@@ -242,7 +242,7 @@ class PlannedWorkoutDTO(BaseModel):
     rationale: str = ""  # why this workout
     target_date: date = Field(default_factory=date.today)
     slot: str = "morning"  # "morning" | "evening"
-    suffix: str = "generated"  # "generated" | "adapted"
+    suffix: str | None = None  # "adapted"
 
     @model_validator(mode="after")
     def _check_steps_have_targets(self) -> "PlannedWorkoutDTO":
@@ -341,7 +341,7 @@ class PlannedWorkoutDTO(BaseModel):
         return EventExDTO(
             category="WORKOUT",
             type=self.sport,
-            name=f"AI: {clean_name} ({self.suffix})",
+            name=f"AI: {clean_name}" + (f" ({self.suffix})" if self.suffix else ""),
             description=self.rationale or "",
             start_date_local=f"{self.target_date}T00:00:00",
             moving_time=self.duration_minutes * 60,

--- a/data/ramp_tests.py
+++ b/data/ramp_tests.py
@@ -60,5 +60,4 @@ def create_ramp_test(sport: str, target_date: date, days_since: int = 0) -> Plan
             "Hold steady effort for each 5-min step."
         ),
         target_date=target_date,
-        suffix="generated",
     )

--- a/tests/db/test_ai_workouts.py
+++ b/tests/db/test_ai_workouts.py
@@ -83,10 +83,11 @@ class TestPlannedWorkout:
         assert event.moving_time == 3600
         assert event.external_id == "tricoach:2026-03-29:ride:morning"
 
-    def test_generated_suffix(self):
-        w = self._make_workout(suffix="generated")
+    def test_no_suffix_in_event_name(self):
+        """Default suffix=None produces clean name without parentheses."""
+        w = self._make_workout()
         event = w.to_intervals_event()
-        assert event.name == "AI: Z2 Endurance (generated)"
+        assert event.name == "AI: Z2 Endurance"
 
     def test_adapted_suffix(self):
         w = self._make_workout(suffix="adapted")

--- a/tests/metrics/test_ramp_tests.py
+++ b/tests/metrics/test_ramp_tests.py
@@ -59,7 +59,7 @@ class TestCreateRampTest:
         workout = create_ramp_test("Ride", date(2026, 4, 1), days_since=25)
         assert workout.sport == "Ride"
         assert "Ramp Test" in workout.name
-        assert workout.suffix == "generated"
+        assert workout.suffix is None
         assert len(workout.steps) == 8
         assert workout.duration_minutes == 50
         assert "25 days old" in workout.rationale
@@ -83,7 +83,8 @@ class TestCreateRampTest:
         assert event.category == "WORKOUT"
         assert event.type == "Ride"
         assert "AI: Ramp Test" in event.name
-        assert "(generated)" in event.name
+        assert "AI: Ramp Test" in event.name
+        assert "(generated)" not in event.name  # suffix=None → no label
         assert event.workout_doc is not None
         assert len(event.workout_doc["steps"]) == 8
 


### PR DESCRIPTION
Updates the handling of the workout suffix to be optional across the codebase:
- Adjusts the formatter logic to accommodate None suffix values
- Modifies the PlannedWorkoutDTO to default suffix to None
- Refactors code to consistently manage the absence of a suffix

This change facilitates better handling of workout variations and aligns with multi-tenant capabilities.