### PR TITLE
Enhances webhook to include sport settings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -426,7 +426,7 @@ Specs and plans in `docs/`. Key: `ADAPTIVE_TRAINING_PLAN.md`, `MULTI_TENANT_SECU
 
 ## Next Steps
 
-1. **Webhook dispatchers** — `WELLNESS_UPDATED` ✓ and `CALENDAR_UPDATED` ✓ done. Remaining: `ACTIVITY_UPLOADED` → activities sync, `SPORT_SETTINGS_UPDATED` → settings sync. See `docs/INTERVALS_WEBHOOKS_RESEARCH.md`.
+1. **Webhook dispatchers** — `WELLNESS_UPDATED` ✓, `CALENDAR_UPDATED` ✓, `SPORT_SETTINGS_UPDATED` ✓ done. Remaining: `ACTIVITY_UPLOADED` → activities sync. See `docs/INTERVALS_WEBHOOKS_RESEARCH.md`.
 2. **OAuth remaining** — disconnect endpoint (`POST /api/intervals/auth/disconnect`), lazy 401 handling (catch 401 → clear tokens → Telegram notify)
 3. **ATP Phase 3 доделка** — `compute_personal_patterns()` еженедельный cron + prompt enrichment. Ждёт 30+ записей в training_log
 4. **Multi-Tenant Phase 2** — JWT upgrade (tenant_id, role, scope claims), bot middleware (resolve_tenant). See `docs/MULTI_TENANT_SECURITY.md`

--- a/api/dto.py
+++ b/api/dto.py
@@ -87,6 +87,7 @@ class IntervalsWebhookEvent(BaseModel):
     type: str
     timestamp: str | None = None
     records: list[dict[str, Any]] = Field(default_factory=list)
+    sport_settings: list[dict[str, Any]] = Field(default_factory=list, alias="sportSettings")
 
 
 class IntervalsWebhookPayload(BaseModel):

--- a/api/routers/intervals/webhook.py
+++ b/api/routers/intervals/webhook.py
@@ -13,7 +13,12 @@ from api.dto import IntervalsWebhookEvent, IntervalsWebhookPayload
 from config import settings
 from data.db import User, UserDTO
 from data.intervals.dto import ActivityDTO, SportSettingsDTO, WellnessDTO
-from tasks.actors import actor_sync_athlete_goals, actor_user_scheduled_workouts, actor_user_wellness
+from tasks.actors import (
+    actor_sync_athlete_goals,
+    actor_sync_athlete_settings,
+    actor_user_scheduled_workouts,
+    actor_user_wellness,
+)
 
 from . import router
 
@@ -150,6 +155,17 @@ def _dispatch_calendar(user: UserDTO) -> None:
     actor_sync_athlete_goals.send(user=user)
 
 
+def _dispatch_sport_settings(user: UserDTO, event: IntervalsWebhookEvent) -> None:
+    """Dispatch settings sync from SPORT_SETTINGS_UPDATED event.
+
+    Parses sport_settings from the webhook payload and passes directly
+    to the actor, avoiding a redundant API call to Intervals.icu.
+    """
+
+    settings = TypeAdapter(list[SportSettingsDTO]).validate_python(event.sport_settings)
+    actor_sync_athlete_settings.send(user=user, sport_settings=settings)
+
+
 # ---------------------------------------------------------------------------
 # Main webhook handler
 # ---------------------------------------------------------------------------
@@ -228,10 +244,14 @@ async def _handle_webhook_event(event: IntervalsWebhookEvent) -> None:
 
     # Dispatch actors for supported event types.
     user_dto = UserDTO.model_validate(user)
-    if normalized_type == "WELLNESS_UPDATED":
-        _dispatch_wellness(user_dto, event)
-    elif normalized_type == "CALENDAR_UPDATED":
-        _dispatch_calendar(user_dto)
+    dispatchers = {
+        "WELLNESS_UPDATED": lambda: _dispatch_wellness(user_dto, event),
+        "CALENDAR_UPDATED": lambda: _dispatch_calendar(user_dto),
+        "SPORT_SETTINGS_UPDATED": lambda: _dispatch_sport_settings(user_dto, event),
+    }
+    dispatcher = dispatchers.get(normalized_type)
+    if dispatcher is not None:
+        dispatcher()
 
 
 @router.post("/webhook")
@@ -240,7 +260,8 @@ async def intervals_webhook(request: Request) -> dict:
 
     Always returns 200 — Intervals.icu retries/disables the webhook on 4xx/5xx.
     Supported dispatchers: WELLNESS_UPDATED → ``actor_user_wellness``,
-    CALENDAR_UPDATED → ``actor_user_scheduled_workouts`` + ``actor_sync_athlete_goals``.
+    CALENDAR_UPDATED → ``actor_user_scheduled_workouts`` + ``actor_sync_athlete_goals``,
+    SPORT_SETTINGS_UPDATED → ``actor_sync_athlete_settings``.
     """
 
     interesting_headers = {

--- a/tasks/actors/athlets.py
+++ b/tasks/actors/athlets.py
@@ -8,7 +8,7 @@ from pydantic import validate_call
 
 from data.db import AthleteGoal, AthleteSettings, User, UserDTO
 from data.intervals.client import IntervalsSyncClient
-from data.intervals.dto import ScheduledWorkoutDTO
+from data.intervals.dto import ScheduledWorkoutDTO, SportSettingsDTO
 from tasks.dto import DateDTO
 
 from ..tools import TelegramTool
@@ -30,10 +30,19 @@ def _actor_send_zones_notification(user: UserDTO, updated: list[str]):
 
 @dramatiq.actor(queue_name="default")
 @validate_call
-def actor_sync_athlete_settings(user: UserDTO):
-    """Sync sport settings from Intervals.icu → athlete_settings table."""
-    with IntervalsSyncClient.for_user(user) as client:
-        all_settings = client.list_sport_settings()
+def actor_sync_athlete_settings(
+    user: UserDTO,
+    sport_settings: list[SportSettingsDTO] | None = None,
+):
+    """Sync sport settings from Intervals.icu → athlete_settings table.
+
+    If ``sport_settings`` is provided (e.g. from webhook payload), skips the API call.
+    """
+    if sport_settings is None:
+        with IntervalsSyncClient.for_user(user) as client:
+            all_settings = client.list_sport_settings()
+    else:
+        all_settings = sport_settings
 
     for ss in all_settings:
         # Map types to primary sport: ["Ride", "VirtualRide", ...] → "Ride"


### PR DESCRIPTION
This update adds the ability to process sport settings via webhooks:

- Introduces a new function to handle SPORT_SETTINGS_UPDATED events.
- Modifies existing functions to dispatch actor_sync_athlete_settings.
- Avoids redundant API calls by handling sport settings directly from webhook payloads.

Enables enhanced responsiveness and efficiency in multi-tenant environments.