### PR TITLE
Enhances webhook to include sport settings

### DIFF
--- a/api/dto.py
+++ b/api/dto.py
@@ -88,6 +88,11 @@ class IntervalsWebhookEvent(BaseModel):
     timestamp: str | None = None
     records: list[dict[str, Any]] = Field(default_factory=list)
     sport_settings: list[dict[str, Any]] = Field(default_factory=list, alias="sportSettings")
+    # ACTIVITY_* events deliver data via `activity` (single object, not array)
+    activity: dict[str, Any] | None = None
+    # APP_SCOPE_CHANGED delivers scope info as top-level event fields
+    scope: str | None = None
+    deauthorized: bool | None = None
 
 
 class IntervalsWebhookPayload(BaseModel):

--- a/api/routers/intervals/webhook.py
+++ b/api/routers/intervals/webhook.py
@@ -2,8 +2,10 @@
 resolves tenant, dispatches actors for supported event types.
 """
 
+import asyncio
 import hmac
 import logging
+from typing import Any
 
 import sentry_sdk
 from fastapi import Request
@@ -11,7 +13,7 @@ from pydantic import BaseModel, TypeAdapter, ValidationError
 
 from api.dto import IntervalsWebhookEvent, IntervalsWebhookPayload
 from config import settings
-from data.db import User, UserDTO
+from data.db import User, UserDTO, get_session
 from data.intervals.dto import ActivityDTO, SportSettingsDTO, WellnessDTO
 from tasks.actors import (
     actor_sync_athlete_goals,
@@ -161,9 +163,23 @@ def _dispatch_sport_settings(user: UserDTO, event: IntervalsWebhookEvent) -> Non
     Parses sport_settings from the webhook payload and passes directly
     to the actor, avoiding a redundant API call to Intervals.icu.
     """
+    parsed = TypeAdapter(list[SportSettingsDTO]).validate_python(event.sport_settings)
+    actor_sync_athlete_settings.send(user=user, sport_settings=parsed)
 
-    settings = TypeAdapter(list[SportSettingsDTO]).validate_python(event.sport_settings)
-    actor_sync_athlete_settings.send(user=user, sport_settings=settings)
+
+async def _dispatch_scope_changed(user: User, event: IntervalsWebhookEvent) -> None:
+    """Handle APP_SCOPE_CHANGED — update scope or clear tokens on deauthorize."""
+    async with get_session() as session:
+        db_user = await session.get(User, user.id)
+        if not db_user:
+            return
+        if event.deauthorized:
+            db_user.clear_oauth_tokens()
+            logger.warning("User %d deauthorized Intervals.icu OAuth", user.id)
+        elif event.scope is not None:
+            db_user.intervals_oauth_scope = event.scope
+            logger.info("Updated OAuth scope for user %d: %s", user.id, event.scope)
+        await session.commit()
 
 
 # ---------------------------------------------------------------------------
@@ -244,14 +260,17 @@ async def _handle_webhook_event(event: IntervalsWebhookEvent) -> None:
 
     # Dispatch actors for supported event types.
     user_dto = UserDTO.model_validate(user)
-    dispatchers = {
+    dispatchers: dict[str, Any] = {
         "WELLNESS_UPDATED": lambda: _dispatch_wellness(user_dto, event),
         "CALENDAR_UPDATED": lambda: _dispatch_calendar(user_dto),
         "SPORT_SETTINGS_UPDATED": lambda: _dispatch_sport_settings(user_dto, event),
+        "APP_SCOPE_CHANGED": lambda: _dispatch_scope_changed(user, event),
     }
     dispatcher = dispatchers.get(normalized_type)
     if dispatcher is not None:
-        dispatcher()
+        result = dispatcher()
+        if asyncio.iscoroutine(result):
+            await result
 
 
 @router.post("/webhook")
@@ -261,7 +280,8 @@ async def intervals_webhook(request: Request) -> dict:
     Always returns 200 — Intervals.icu retries/disables the webhook on 4xx/5xx.
     Supported dispatchers: WELLNESS_UPDATED → ``actor_user_wellness``,
     CALENDAR_UPDATED → ``actor_user_scheduled_workouts`` + ``actor_sync_athlete_goals``,
-    SPORT_SETTINGS_UPDATED → ``actor_sync_athlete_settings``.
+    SPORT_SETTINGS_UPDATED → ``actor_sync_athlete_settings``,
+    APP_SCOPE_CHANGED → update scope / clear tokens on deauthorize.
     """
 
     interesting_headers = {

--- a/tests/api/test_webhook_dispatch.py
+++ b/tests/api/test_webhook_dispatch.py
@@ -1,0 +1,388 @@
+"""Tests for Intervals.icu webhook dispatch — one test per event type with real JSON fixtures."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from api.dto import IntervalsWebhookEvent
+from api.routers.intervals.webhook import (
+    _dispatch_calendar,
+    _dispatch_scope_changed,
+    _dispatch_sport_settings,
+    _dispatch_wellness,
+    _handle_webhook_event,
+)
+from data.db.dto import UserDTO
+
+# ---------------------------------------------------------------------------
+# Fixtures — real JSON payloads from production (PII redacted)
+# ---------------------------------------------------------------------------
+
+WELLNESS_UPDATED_EVENT = {
+    "athlete_id": "i317960",
+    "type": "WELLNESS_UPDATED",
+    "timestamp": "2026-04-15T16:29:56.819+00:00",
+    "records": [
+        {
+            "id": "2026-04-15",
+            "ctl": 18.41,
+            "atl": 37.39,
+            "rampRate": 4.69,
+            "ctlLoad": 14.0,
+            "atlLoad": 14.0,
+            "sportInfo": [{"type": "Ride", "eftp": 207.82, "wPrime": 17460.5, "pMax": 642.5}],
+            "updated": "2026-04-15T16:29:54.818+00:00",
+            "weight": 77.36,
+            "restingHR": 59,
+            "hrv": 46.0,
+            "sleepSecs": 22242,
+            "sleepScore": 76.0,
+            "sleepQuality": 3,
+            "bodyFat": 24.6,
+            "steps": 11208,
+        }
+    ],
+}
+
+CALENDAR_UPDATED_EVENT = {
+    "athlete_id": "i317960",
+    "type": "CALENDAR_UPDATED",
+    "timestamp": "2026-04-16T14:22:33.000+00:00",
+    "records": [],
+}
+
+SPORT_SETTINGS_UPDATED_EVENT = {
+    "athlete_id": "i317960",
+    "type": "SPORT_SETTINGS_UPDATED",
+    "timestamp": "2026-04-16T12:15:44.000+00:00",
+    "sportSettings": [
+        {
+            "id": 1,
+            "types": ["Ride", "VirtualRide"],
+            "lthr": 163,
+            "max_hr": 179,
+            "ftp": 210,
+            "hr_zones": [110, 135, 153, 171, 195],
+            "power_zones": [115, 156, 189, 220, 252],
+        },
+        {
+            "id": 2,
+            "types": ["Run", "VirtualRun", "TrailRun"],
+            "lthr": 153,
+            "max_hr": 179,
+            "threshold_pace": 4.13,
+            "pace_units": "MINS_KM",
+            "hr_zones": [129, 136, 144, 152, 157, 161],
+        },
+    ],
+    "records": [],
+}
+
+APP_SCOPE_CHANGED_EVENT = {
+    "athlete_id": "i317960",
+    "type": "APP_SCOPE_CHANGED",
+    "scope": "ACTIVITY:WRITE,WELLNESS:READ,CALENDAR:WRITE,SETTINGS:WRITE",
+    "deauthorized": False,
+    "client_id": "endurai",
+    "client_name": "EndurAI",
+    "records": [],
+}
+
+APP_DEAUTHORIZED_EVENT = {
+    "athlete_id": "i317960",
+    "type": "APP_SCOPE_CHANGED",
+    "scope": "",
+    "deauthorized": True,
+    "client_id": "endurai",
+    "client_name": "EndurAI",
+    "records": [],
+}
+
+ACTIVITY_UPLOADED_EVENT = {
+    "athlete_id": "i317960",
+    "type": "ACTIVITY_UPLOADED",
+    "timestamp": "2026-04-16T15:42:26.000+00:00",
+    "activity": {
+        "id": "i317960-2026-04-16-abc123",
+        "start_date_local": "2026-04-16T15:00:00",
+        "type": "VirtualRide",
+        "moving_time": 3312,
+        "icu_training_load": 41.2,
+        "average_heartrate": 141,
+        "average_watts": 168,
+        "distance": 25400,
+        "name": "Zwift - Zone 2 Endurance",
+        "source": "GARMIN_CONNECT",
+    },
+    "records": [],
+}
+
+ACTIVITY_DELETED_EVENT = {
+    "athlete_id": "i317960",
+    "type": "ACTIVITY_DELETED",
+    "timestamp": "2026-04-16T16:00:00.000+00:00",
+    "activity": {"id": "i317960-2026-04-16-abc123"},
+    "records": [],
+}
+
+FITNESS_UPDATED_EVENT = {
+    "athlete_id": "i317960",
+    "type": "FITNESS_UPDATED",
+    "timestamp": "2026-04-16T15:42:28.000+00:00",
+    "records": [
+        {"id": "2026-04-16", "ctl": 19.5, "atl": 38.0, "sportInfo": [{"type": "Ride", "eftp": 208.0}]},
+        {"id": "2026-04-17", "ctl": 18.8, "atl": 35.2, "sportInfo": [{"type": "Ride", "eftp": 207.5}]},
+    ],
+}
+
+
+def _make_user_dto(**kwargs) -> UserDTO:
+    defaults = {"id": 1, "chat_id": "12345", "athlete_id": "i317960", "language": "en"}
+    defaults.update(kwargs)
+    return UserDTO(**defaults)
+
+
+def _make_event(data: dict) -> IntervalsWebhookEvent:
+    return IntervalsWebhookEvent.model_validate(data)
+
+
+# ---------------------------------------------------------------------------
+# DTO parsing tests
+# ---------------------------------------------------------------------------
+
+
+class TestEventParsing:
+    """IntervalsWebhookEvent correctly parses all delivery patterns."""
+
+    def test_wellness_records(self):
+        event = _make_event(WELLNESS_UPDATED_EVENT)
+        assert len(event.records) == 1
+        assert event.records[0]["id"] == "2026-04-15"
+
+    def test_calendar_empty_records(self):
+        event = _make_event(CALENDAR_UPDATED_EVENT)
+        assert event.records == []
+
+    def test_sport_settings_alias(self):
+        event = _make_event(SPORT_SETTINGS_UPDATED_EVENT)
+        assert len(event.sport_settings) == 2
+        assert event.sport_settings[0]["types"] == ["Ride", "VirtualRide"]
+
+    def test_scope_changed_fields(self):
+        event = _make_event(APP_SCOPE_CHANGED_EVENT)
+        assert event.scope == "ACTIVITY:WRITE,WELLNESS:READ,CALENDAR:WRITE,SETTINGS:WRITE"
+        assert event.deauthorized is False
+
+    def test_deauthorized_event(self):
+        event = _make_event(APP_DEAUTHORIZED_EVENT)
+        assert event.deauthorized is True
+
+    def test_activity_field(self):
+        event = _make_event(ACTIVITY_UPLOADED_EVENT)
+        assert event.activity is not None
+        assert event.activity["type"] == "VirtualRide"
+
+    def test_activity_deleted_minimal(self):
+        event = _make_event(ACTIVITY_DELETED_EVENT)
+        assert event.activity is not None
+        assert "id" in event.activity
+
+    def test_fitness_updated_records(self):
+        event = _make_event(FITNESS_UPDATED_EVENT)
+        assert len(event.records) == 2
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchWellness:
+    def test_dispatches_for_each_record(self):
+        event = _make_event(WELLNESS_UPDATED_EVENT)
+        user = _make_user_dto()
+        with patch("api.routers.intervals.webhook.actor_user_wellness") as mock:
+            _dispatch_wellness(user, event)
+            assert mock.send.call_count == 1
+            call_kwargs = mock.send.call_args.kwargs
+            assert call_kwargs["dt"] == "2026-04-15"
+            assert call_kwargs["user"] == user
+
+    def test_skips_empty_records(self):
+        event = _make_event({**WELLNESS_UPDATED_EVENT, "records": []})
+        user = _make_user_dto()
+        with patch("api.routers.intervals.webhook.actor_user_wellness") as mock:
+            _dispatch_wellness(user, event)
+            mock.send.assert_not_called()
+
+
+class TestDispatchCalendar:
+    def test_dispatches_both_actors(self):
+        user = _make_user_dto()
+        with (
+            patch("api.routers.intervals.webhook.actor_user_scheduled_workouts") as mock_workouts,
+            patch("api.routers.intervals.webhook.actor_sync_athlete_goals") as mock_goals,
+        ):
+            _dispatch_calendar(user)
+            mock_workouts.send.assert_called_once_with(user=user)
+            mock_goals.send.assert_called_once_with(user=user)
+
+
+class TestDispatchSportSettings:
+    def test_dispatches_with_parsed_settings(self):
+        event = _make_event(SPORT_SETTINGS_UPDATED_EVENT)
+        user = _make_user_dto()
+        with patch("api.routers.intervals.webhook.actor_sync_athlete_settings") as mock:
+            _dispatch_sport_settings(user, event)
+            mock.send.assert_called_once()
+            call_kwargs = mock.send.call_args.kwargs
+            assert len(call_kwargs["sport_settings"]) == 2
+            assert call_kwargs["sport_settings"][0].lthr == 163
+
+
+class TestDispatchScopeChanged:
+    @pytest.mark.asyncio
+    async def test_updates_scope(self):
+        event = _make_event(APP_SCOPE_CHANGED_EVENT)
+        mock_user = MagicMock()
+        mock_user.id = 1
+        mock_db_user = MagicMock()
+        mock_db_user.intervals_oauth_scope = None
+
+        mock_session = AsyncMock()
+        mock_session.get = AsyncMock(return_value=mock_db_user)
+        mock_session.commit = AsyncMock()
+
+        with patch("api.routers.intervals.webhook.get_session") as mock_get_session:
+            mock_get_session.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_get_session.return_value.__aexit__ = AsyncMock(return_value=False)
+            await _dispatch_scope_changed(mock_user, event)
+
+        assert mock_db_user.intervals_oauth_scope == "ACTIVITY:WRITE,WELLNESS:READ,CALENDAR:WRITE,SETTINGS:WRITE"
+
+    @pytest.mark.asyncio
+    async def test_clears_tokens_on_deauthorize(self):
+        event = _make_event(APP_DEAUTHORIZED_EVENT)
+        mock_user = MagicMock()
+        mock_user.id = 1
+        mock_db_user = MagicMock()
+
+        mock_session = AsyncMock()
+        mock_session.get = AsyncMock(return_value=mock_db_user)
+        mock_session.commit = AsyncMock()
+
+        with patch("api.routers.intervals.webhook.get_session") as mock_get_session:
+            mock_get_session.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_get_session.return_value.__aexit__ = AsyncMock(return_value=False)
+            await _dispatch_scope_changed(mock_user, event)
+
+        mock_db_user.clear_oauth_tokens.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Integration: _handle_webhook_event routes to correct dispatcher
+# ---------------------------------------------------------------------------
+
+
+def _make_orm_user_mock(**kwargs):
+    """Create a MagicMock that passes UserDTO.model_validate."""
+    defaults = {
+        "id": 1,
+        "chat_id": "12345",
+        "athlete_id": "i317960",
+        "username": "test",
+        "language": "en",
+        "is_silent": False,
+    }
+    defaults.update(kwargs)
+    mock = MagicMock(spec=[])
+    for k, v in defaults.items():
+        setattr(mock, k, v)
+    return mock
+
+
+class TestHandleWebhookEvent:
+    """Verify the dispatch table routes each event type correctly."""
+
+    @pytest.mark.asyncio
+    async def test_wellness_dispatched(self):
+        event = _make_event(WELLNESS_UPDATED_EVENT)
+        with (
+            patch("api.routers.intervals.webhook.User") as mock_user_cls,
+            patch("api.routers.intervals.webhook._dispatch_wellness") as mock_dispatch,
+            patch("api.routers.intervals.webhook.settings") as mock_settings,
+        ):
+            mock_settings.INTERVALS_WEBHOOK_MONITORING = False
+            mock_user_cls.get_by_athlete_id = AsyncMock(return_value=_make_orm_user_mock())
+            await _handle_webhook_event(event)
+            mock_dispatch.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_calendar_dispatched(self):
+        event = _make_event(CALENDAR_UPDATED_EVENT)
+        with (
+            patch("api.routers.intervals.webhook.User") as mock_user_cls,
+            patch("api.routers.intervals.webhook._dispatch_calendar") as mock_dispatch,
+            patch("api.routers.intervals.webhook.settings") as mock_settings,
+        ):
+            mock_settings.INTERVALS_WEBHOOK_MONITORING = False
+            mock_user_cls.get_by_athlete_id = AsyncMock(return_value=_make_orm_user_mock())
+            await _handle_webhook_event(event)
+            mock_dispatch.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_sport_settings_dispatched(self):
+        event = _make_event(SPORT_SETTINGS_UPDATED_EVENT)
+        with (
+            patch("api.routers.intervals.webhook.User") as mock_user_cls,
+            patch("api.routers.intervals.webhook._dispatch_sport_settings") as mock_dispatch,
+            patch("api.routers.intervals.webhook.settings") as mock_settings,
+        ):
+            mock_settings.INTERVALS_WEBHOOK_MONITORING = False
+            mock_user_cls.get_by_athlete_id = AsyncMock(return_value=_make_orm_user_mock())
+            await _handle_webhook_event(event)
+            mock_dispatch.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_scope_changed_dispatched(self):
+        event = _make_event(APP_SCOPE_CHANGED_EVENT)
+        with (
+            patch("api.routers.intervals.webhook.User") as mock_user_cls,
+            patch("api.routers.intervals.webhook._dispatch_scope_changed", new_callable=AsyncMock) as mock_dispatch,
+            patch("api.routers.intervals.webhook.settings") as mock_settings,
+        ):
+            mock_settings.INTERVALS_WEBHOOK_MONITORING = False
+            mock_user_cls.get_by_athlete_id = AsyncMock(return_value=_make_orm_user_mock())
+            await _handle_webhook_event(event)
+            mock_dispatch.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_unknown_athlete_skipped(self):
+        event = _make_event(WELLNESS_UPDATED_EVENT)
+        with (
+            patch("api.routers.intervals.webhook.User") as mock_user_cls,
+            patch("api.routers.intervals.webhook._dispatch_wellness") as mock_dispatch,
+        ):
+            mock_user_cls.get_by_athlete_id = AsyncMock(return_value=None)
+            await _handle_webhook_event(event)
+            mock_dispatch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_unknown_event_type_skipped(self):
+        event = _make_event(
+            {
+                "athlete_id": "i317960",
+                "type": "SOME_FUTURE_EVENT",
+                "records": [],
+            }
+        )
+        with (
+            patch("api.routers.intervals.webhook.User") as mock_user_cls,
+            patch("api.routers.intervals.webhook.settings") as mock_settings,
+        ):
+            mock_settings.INTERVALS_WEBHOOK_MONITORING = False
+            mock_user = MagicMock()
+            mock_user.id = 1
+            mock_user_cls.get_by_athlete_id = AsyncMock(return_value=mock_user)
+            # Should not raise
+            await _handle_webhook_event(event)


### PR DESCRIPTION
This update adds the ability to process sport settings via webhooks:

- Introduces a new function to handle SPORT_SETTINGS_UPDATED events.
- Modifies existing functions to dispatch actor_sync_athlete_settings.
- Avoids redundant API calls by handling sport settings directly from webhook payloads.

Enables enhanced responsiveness and efficiency in multi-tenant environments.