### PR TITLE
Enhances workout prompts with personalized HR/power zones

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,9 +106,11 @@ Filter: `is_valid_for_decoupling()` — VI <= 1.10, >70% Z1+Z2, bike >= 60min / 
 Traffic light: green (<5%) / yellow (5-10%) / red (>10%). Uses abs() for negative drift.
 Trend: last-5 median via `get_efficiency_trend(strict_filter=True)`. Theory: `docs/knowledge/decoupling.md`.
 
-**HR Zones** — synced from Intervals.icu sport-settings (source of truth). `get_zones` MCP tool returns boundaries from DB; fallback to calculated zones if not yet synced. Zone count varies per user (typically 5-7 zones). Fallback defaults:
-Run (7-zone): Z1 0-84%, Z2 85-89%, Z3 90-94%, Z4 95-99%, Z5 100-103%, Z6 103-106%, Z7 106%+
-Bike (5-zone): Z1 0-68%, Z2 68-83%, Z3 83-94%, Z4 94-105%, Z5 105-120%
+**HR / Power / Pace Zones** — synced from Intervals.icu sport-settings into `athlete_settings.{hr,power,pace}_zones` (source of truth). Zone count varies per user (typically 5-7 zones). **Units contract** (see `data/db/athlete.py:33`): `hr_zones` are absolute bpm, `power_zones` are **%FTP** (not watts — Intervals stores them pre-normalized), `pace_zones` are %threshold where 100.0 = threshold. Top zone opens upward, often stored with a `999` sentinel.
+
+Two independent consumers read these zones, each with its own fallback:
+- **`get_zones` MCP tool** (`mcp_server/tools/zones.py`) — returns raw boundaries for tool-use introspection. Fallbacks: Run 7-zone Z1 0-84%…Z7 106%+, Bike 5-zone Z1 0-68%…Z5 105-120%.
+- **`get_system_prompt_chat`** (`bot/prompts.py`) — renders a per-user `{zones_block}` straight into `SYSTEM_PROMPT_CHAT` so workout generation uses the athlete's own zones rather than a hardcoded model. Fallbacks (Friel 5-zone): Run `_FALLBACK_RUN_HR_PCT` Z1 0-72%…Z5 92-100%, Bike HR `_FALLBACK_BIKE_HR_PCT` Z1 0-68%…Z5 105-120%, Ride power `_FALLBACK_RIDE_POWER_PCT` Z1 0-55%…Z5 105-120%. Each rendered branch always emits a concrete Example Z2 JSON step so Claude never invents the target shape.
 
 ---
 

--- a/bot/prompts.py
+++ b/bot/prompts.py
@@ -241,20 +241,148 @@ explicitly asks for today.
 **Every step must carry an intensity target** so Garmin/Wahoo watches alert on the HR/power/pace
 corridor. Never emit text-only steps (`Z2` label + duration with nothing else) — the watch will
 run the step without beeping and the athlete runs blind.
-  - **Run**: use `hr` with `%lthr` units. LTHR for run is {lthr_run}. Ranges per zone:
-    Z1 0-72%, Z2 72-82%, Z3 82-87%, Z4 87-92%, Z5 92-100%. Example Z2 step:
-    `{{"text": "Z2", "duration": 900, "hr": {{"units": "%lthr", "value": 72, "end": 82}}}}`.
-  - **Ride**: use `power` with `%ftp` units. FTP = {ftp}. Example Z2:
-    `"power": {{"units": "%ftp", "value": 65, "end": 75}}`.
-  - **Swim**: use `pace` with `%pace` units. CSS = {css}. Example:
-    `"pace": {{"units": "%pace", "value": 95, "end": 100}}`.
+{zones_block}
   - For repeat groups (`reps` + sub-`steps`), the target goes on each sub-step, not the wrapper.
 """
+
+
+# ---------------------------------------------------------------------------
+# Per-user HR/power zone block for workout generation
+# ---------------------------------------------------------------------------
+
+# Fallback Friel-like ranges (% of LTHR/FTP) used when the athlete has no
+# sport-settings synced from Intervals.icu yet.
+_FALLBACK_RUN_HR_PCT = [(0, 72), (72, 82), (82, 87), (87, 92), (92, 100)]
+_FALLBACK_BIKE_HR_PCT = [(0, 68), (68, 83), (83, 94), (94, 105), (105, 120)]
+_FALLBACK_RIDE_POWER_PCT = [(0, 55), (55, 75), (75, 90), (90, 105), (105, 120)]
+
+# Intervals.icu stores an open-ended top zone as a dummy boundary like 999.
+# Anything at or above this cutoff is treated as sentinel, not a real bound.
+_SENTINEL_PCT_CUTOFF = 500
+
+
+def _pct_ranges(pct_bounds: list[int]) -> list[tuple[int, int]]:
+    """Convert an ascending list of %-of-threshold bounds into zone ranges.
+
+    The top zone opens upward — we cap it at ``max(prev+10, 120)`` for display.
+    Sentinel boundaries (``>= _SENTINEL_PCT_CUTOFF``) are trimmed so the printed
+    top zone stays readable.
+    """
+    ranges: list[tuple[int, int]] = []
+    prev = 0
+    for p in pct_bounds:
+        if p >= _SENTINEL_PCT_CUTOFF:
+            break
+        ranges.append((prev, p))
+        prev = p
+    ranges.append((prev, max(prev + 10, 120)))
+    return ranges
+
+
+def _pct_ranges_from_hr(boundaries: list[int], lthr: int) -> list[tuple[int, int]]:
+    """Absolute bpm boundaries → %-of-LTHR ranges.
+
+    Enforces strict monotonicity: if ``round(b / lthr * 100)`` collapses two
+    adjacent boundaries onto the same integer (can happen with high LTHR and
+    tight zone spacing), bump the second by +1 so we never render zero-width
+    zones like ``Z2 84-84%`` into the prompt.
+    """
+    pct_bounds: list[int] = []
+    prev: int | None = None
+    for b in boundaries:
+        pct = round(b / lthr * 100)
+        if prev is not None and pct <= prev:
+            pct = prev + 1
+        pct_bounds.append(pct)
+        prev = pct
+    return _pct_ranges(pct_bounds)
+
+
+def _format_range_list(ranges: list[tuple[int, int]]) -> str:
+    return ", ".join(f"Z{i + 1} {lo}-{hi}%" for i, (lo, hi) in enumerate(ranges))
+
+
+def _zones_block(settings_by_sport: dict[str, AthleteSettings], t: AthleteThresholdsDTO) -> str:
+    """Render the Run/Ride/Swim zone block for SYSTEM_PROMPT_CHAT.
+
+    Uses real per-sport boundaries from ``athlete_settings`` (synced from
+    Intervals.icu) when available; falls back to a Friel-like 5-zone model
+    otherwise so new athletes still get sane defaults.
+    """
+    lines: list[str] = []
+
+    # Run — %LTHR. Prefer Intervals synced zones whenever an LTHR is available
+    # from either the sport-row or the thresholds DTO (historically some
+    # athlete_settings rows had hr_zones populated but lthr=None — don't punish
+    # them with Friel fallback when t.lthr_run is right there).
+    run = settings_by_sport.get("Run")
+    lthr_run = (run and run.lthr) or t.lthr_run
+    if run and run.hr_zones and lthr_run:
+        ranges = _pct_ranges_from_hr(run.hr_zones, lthr_run)
+        source = "from your Intervals.icu sport-settings"
+    else:
+        ranges = _FALLBACK_RUN_HR_PCT
+        source = "Friel fallback — athlete has no synced Run zones yet"
+    z2 = ranges[1] if len(ranges) >= 2 else (72, 82)
+    lines.append(
+        f"  - **Run**: use `hr` with `%lthr` units. LTHR = {lthr_run or '—'}. "
+        f"Ranges per zone ({source}): {_format_range_list(ranges)}. Example Z2 step: "
+        f'`{{"text": "Z2", "duration": 900, "hr": {{"units": "%lthr", "value": {z2[0]}, "end": {z2[1]}}}}}`.'
+    )
+
+    # Ride — prefer %FTP (power). Intervals.icu stores power_zones already as
+    # percentages of FTP (not absolute watts), so the zones themselves need no
+    # FTP — it's only displayed as the watts reference in the prompt text.
+    ride = settings_by_sport.get("Ride")
+    ftp = (ride and ride.ftp) or t.ftp
+    if ride and ride.power_zones:
+        ranges = _pct_ranges(list(ride.power_zones))
+        z2 = ranges[1] if len(ranges) >= 2 else (55, 75)
+        source = "from your Intervals.icu sport-settings"
+        ftp_str = f"{ftp}W" if ftp else "—"
+        lines.append(
+            f"  - **Ride**: use `power` with `%ftp` units. FTP = {ftp_str}. "
+            f"Ranges per zone ({source}): {_format_range_list(ranges)}. Example Z2: "
+            f'`"power": {{"units": "%ftp", "value": {z2[0]}, "end": {z2[1]}}}`.'
+        )
+    elif t.ftp:
+        z2 = _FALLBACK_RIDE_POWER_PCT[1]
+        lines.append(
+            f"  - **Ride**: use `power` with `%ftp` units. FTP = {t.ftp}W. "
+            f"Ranges per zone (Friel fallback): {_format_range_list(_FALLBACK_RIDE_POWER_PCT)}. "
+            f'Example Z2: `"power": {{"units": "%ftp", "value": {z2[0]}, "end": {z2[1]}}}`.'
+        )
+    else:
+        lthr_bike = (ride and ride.lthr) or t.lthr_bike
+        z2 = _FALLBACK_BIKE_HR_PCT[1]
+        lines.append(
+            f"  - **Ride**: use `hr` with `%lthr` units. LTHR bike = {lthr_bike or '—'}. "
+            f"Ranges per zone (Friel fallback): {_format_range_list(_FALLBACK_BIKE_HR_PCT)}. "
+            f'Example Z2: `"hr": {{"units": "%lthr", "value": {z2[0]}, "end": {z2[1]}}}`.'
+        )
+
+    # Swim — CSS corridor (no real zones in Intervals.icu sport-settings for swim).
+    css = t.css
+    if css:
+        mm = int(css // 60)
+        ss = int(css % 60)
+        css_str = f"{mm}:{ss:02d}/100m"
+    else:
+        css_str = "—"
+    lines.append(
+        f"  - **Swim**: use `pace` with `%pace` units. CSS = {css_str}. "
+        'Z2 corridor 95-105%. Example: `"pace": {"units": "%pace", "value": 95, "end": 105}`.'
+    )
+
+    return "\n".join(lines)
 
 
 async def get_system_prompt_chat(user_id: int, language: str = "ru") -> str:
     t: AthleteThresholdsDTO = await AthleteSettings.get_thresholds(user_id)
     g: AthleteGoalDTO | None = await AthleteGoal.get_goal_dto(user_id)
+    all_settings = await AthleteSettings.get_all(user_id)
+    settings_by_sport = {s.sport: s for s in all_settings}
+
     tz = zoneinfo.ZoneInfo(settings.TIMEZONE)
     today = datetime.now(tz).strftime("%Y-%m-%d")
 
@@ -267,5 +395,6 @@ async def get_system_prompt_chat(user_id: int, language: str = "ru") -> str:
         lthr_bike=t.lthr_bike or "—",
         ftp=t.ftp or "—",
         css=t.css or "—",
+        zones_block=_zones_block(settings_by_sport, t),
         response_language=_lang_name(language),
     )

--- a/data/db/athlete.py
+++ b/data/db/athlete.py
@@ -30,12 +30,18 @@ class AthleteSettings(Base):
     threshold_pace: Mapped[float | None] = mapped_column(Float, nullable=True)  # Swim: sec/100m, Run: sec/km
     pace_units: Mapped[str | None] = mapped_column(String(20), nullable=True)  # SECS_100M / MINS_KM
 
-    # Zone boundaries from Intervals.icu sport-settings (source of truth)
-    hr_zones: Mapped[list | None] = mapped_column(JSON, nullable=True)  # [129, 136, 144, 152, 157, 161]
+    # Zone boundaries from Intervals.icu sport-settings (source of truth).
+    # N threshold values → N+1 zones. Top zone opens upward (often with a sentinel
+    # value like 999 as the last bound).
+    # Units differ per kind — keep this contract in sync with consumers:
+    #   hr_zones     — absolute bpm, ascending.    Example: [129, 136, 144, 152, 157, 161]
+    #   power_zones  — **%FTP, ascending** (NOT absolute watts). Example: [55, 75, 90, 105, 120, 150, 999]
+    #   pace_zones   — %threshold where 100.0 = threshold, ascending. Example: [77.5, 87.7, 94.3, 100.0, 103.4]
+    hr_zones: Mapped[list | None] = mapped_column(JSON, nullable=True)
     hr_zone_names: Mapped[list | None] = mapped_column(JSON, nullable=True)  # ["Recovery", "Aerobic", ...]
-    power_zones: Mapped[list | None] = mapped_column(JSON, nullable=True)  # [100, 140, 170, 210, 260]
+    power_zones: Mapped[list | None] = mapped_column(JSON, nullable=True)
     power_zone_names: Mapped[list | None] = mapped_column(JSON, nullable=True)  # ["Active Recovery", ...]
-    pace_zones: Mapped[list | None] = mapped_column(JSON, nullable=True)  # [420, 390, 360, 330, 300]
+    pace_zones: Mapped[list | None] = mapped_column(JSON, nullable=True)
     pace_zone_names: Mapped[list | None] = mapped_column(JSON, nullable=True)  # ["Zone 1", "Zone 2", ...]
 
     synced_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/docs/BUSINESS_RULES.md
+++ b/docs/BUSINESS_RULES.md
@@ -75,11 +75,21 @@ Re-calibrate every 4-6 weeks via `scipy.optimize.minimize` against actual RMSSD.
 Linear regression on rolling window. Per-metric thresholds in `TREND_THRESHOLDS` dict.
 Directions: rising_fast/rising/stable/declining/declining_fast. Show only if r² ≥ 0.3.
 
-## HR Zones (% of LTHR)
+## HR / Power Zones
+
+Zones come from Intervals.icu sport-settings (`athlete_settings.{hr,power,pace}_zones`) —
+per-user, typically 5-7 zones. `hr_zones` = absolute bpm; `power_zones` = **%FTP**
+(pre-normalized by Intervals, not watts); `pace_zones` = %threshold (100.0 = threshold).
+
+The chat prompt renders these straight into `SYSTEM_PROMPT_CHAT` via
+`bot/prompts._zones_block()` so workout generation always uses the athlete's own zones.
+
+Friel fallbacks (applied only when Intervals.icu hasn't been synced yet):
 
 ```
-Run:  Z1 0-72%, Z2 72-82%, Z3 82-87%, Z4 87-92%, Z5 92-100%
-Bike: Z1 0-68%, Z2 68-83%, Z3 83-94%, Z4 94-105%, Z5 105-120%
+Run  (HR %LTHR):    Z1 0-72%, Z2 72-82%, Z3 82-87%, Z4 87-92%, Z5 92-100%
+Bike (HR %LTHR):    Z1 0-68%, Z2 68-83%, Z3 83-94%, Z4 94-105%, Z5 105-120%
+Ride (power %FTP):  Z1 0-55%, Z2 55-75%, Z3 75-90%, Z4 90-105%, Z5 105-120%
 ```
 
 ## Morning Report — Workout Suggestion Rules

--- a/docs/RACE_CREATION_SPEC.md
+++ b/docs/RACE_CREATION_SPEC.md
@@ -1,0 +1,551 @@
+# Race Creation Spec
+
+> Создание будущих гонок (`RACE_A/B/C`) через Telegram-чат: юзер просит бота
+> добавить старт, Claude собирает недостающие поля, делает dry-run preview,
+> по кнопке «Отправить в Intervals» — push в `intervals.icu/events` +
+> локальная запись в `athlete_goals`.
+
+**Related:**
+
+| Spec / code | Связь |
+|---|---|
+| `bot/prompts.py:SYSTEM_PROMPT_CHAT` | Добавится секция `## Race creation` с правилами ведения диалога |
+| `bot/main.py` — `_PREVIEWABLE_TOOLS` + `pending_workout` | Паттерн copy-paste для `pending_race` |
+| `mcp_server/tools/ai_workouts.py:suggest_workout` | Референс dry-run / push-flag логики |
+| `mcp_server/tools/races.py:tag_race` | Пост-гонка (уже есть); не путать с `suggest_race` для будущих |
+| `tasks/actors/athlets.py:actor_sync_athlete_goals` | Читает RACE_* events из Intervals в `athlete_goals` (каждые 30 мин) |
+| `data/db/athlete.py:AthleteGoal` | Целевая таблица, `intervals_event_id` — дедуп |
+| `data/intervals/dto.py:EventExDTO` | Payload для `POST /athlete/{id}/events` |
+
+---
+
+## 1. Мотивация
+
+Сейчас гонки в `athlete_goals` появляются **только** через синк из Intervals.icu — юзер должен руками создать Event в их UI с категорией RACE_A/B/C, потом подождать до 30 минут пока `scheduler_sync_goals_job` подхватит. Это:
+
+1. **Барьер входа.** Новый атлет заходит в бота, нажимает `/dashboard` → «Race Goal» пусто → не понимает что ему нужно сначала сходить в Intervals.icu.
+2. **Нет `ctl_target` в Intervals.** Peak-CTL к race day — наша внутренняя метрика, задать её можно только через Python shell (`cli shell`), пользователю недоступно.
+3. **Нет контекста у Claude.** Бот знает даты гонок, но не знает поверхности, погоды, целевого времени, дистанции — всё это могло бы улучшать suggest_workout.
+
+Хотим: юзер пишет «добавь мне Drina Trail 3 мая, RACE_A, трейл 17 км, хочу CTL 55 к старту» → бот собирает недостающее, показывает preview, по кнопке уходит в Intervals + в нашу БД.
+
+---
+
+## 2. Scope
+
+### Phase 1 (MVP) — делаем сейчас
+
+- **MCP tool** `suggest_race` (§4) с `dry_run` flag по образцу `suggest_workout`.
+- **Preview/confirm flow** через `context.user_data["pending_race"]` (§5) —
+  handler пушит напрямую без повторного inference, как в `workout_push`.
+- **Prompt rules** в `SYSTEM_PROMPT_CHAT` (§6) — инструктируем Claude собирать
+  обязательные поля перед `suggest_race`.
+- **Идемпотентность** по `(user_id, category, event_date)` — повторный запрос на
+  ту же дату и приоритет обновляет, а не создаёт дубль (§4.3).
+- **Запись в обе стороны**: Intervals.icu event + локальный `athlete_goals` в
+  одной транзакции tool'а (§4.4). Не ждём scheduler'а.
+- **Settings UI — ручное редактирование CTL-полей** (§14). `ctl_target` и
+  `per_sport_targets` хранятся только у нас, синком не перезаписываются — значит
+  логично дать inline-edit прямо в карточке «Race Goal» на `/settings`.
+
+### Phase 2 — опционально, по спросу
+
+- `/race` ConversationHandler с явным мастером (сейчас только свободный чат).
+- Редактирование **даты/имени/категории** из Settings (сейчас только через чат,
+  т.к. требует push в Intervals).
+- Удаление: `delete_race_goal(category)` — также убирает event из Intervals.
+- Ссылка из `/settings` «Race Goal» → кнопка «Добавить / изменить» → кидает в чат с пре-заполненным промптом.
+
+### Non-goals
+
+- Создание тренировочных планов (не за этот квартал).
+- Import из trka.rs и других сайтов — отдельная спека.
+- Post-race tagging — покрывается существующим `tag_race`.
+
+---
+
+## 3. User Flow
+
+### 3.1. Happy path (свободный чат)
+
+```
+User:  добавь Drina Trail 3 мая, трейл 17 км, хочу CTL 55 к старту, приоритет A
+
+Bot (после вызовов `get_athlete_profile`, `suggest_race(dry_run=True)`):
+  🏁 Preview: Drina Trail — RACE_A
+  📅 Дата: 2026-05-03 (через 13 дней)
+  🏃 Вид: TrailRun, 17 km
+  🎯 Peak CTL к старту: 55 (сейчас 21 → требует +34 за 13 дней → слишком агрессивно,
+      реалистично 28–30)
+  📝 Notes: —
+
+  [ ✅ Отправить в Intervals ]  [ ❌ Отмена ]
+
+User tap «✅ Отправить в Intervals»
+
+Bot:
+  ✅ Гонка создана в Intervals.icu и в вашем профиле.
+  Event ID: 105038593. Цель CTL 55 сохранена в athlete_goals.
+```
+
+### 3.2. Edit path (уже есть RACE_A)
+
+```
+User:  перенеси мой RACE_A на 10 мая
+
+Bot (вызов `get_races` → `suggest_race(category=RACE_A, date=2026-05-10, dry_run=True)`):
+  ♻️ Update preview: Drina Trail — RACE_A
+  📅 Было: 2026-05-03 → Станет: 2026-05-10
+  (остальные поля без изменений)
+
+  [ ✅ Обновить в Intervals ]  [ ❌ Отмена ]
+```
+
+### 3.3. Disambiguation (вопросов больше одного)
+
+```
+User:  добавь Ironman 70.3
+
+Bot:
+  Нужно ещё пару деталей:
+  • Дата старта?
+  • Приоритет: A, B или C? (A = основная цель сезона, B = проходная, C = проверка формы)
+  • Peak CTL target? (опционально; сейчас 21, реалистично +5…+10 к race day если остаётся 8+ недель)
+```
+
+Никаких tool-вызовов пока не хватает required-полей (см. §6).
+
+---
+
+## 4. MCP tool: `suggest_race`
+
+### 4.1. Signature
+
+```python
+@mcp.tool()
+@sentry_tool
+async def suggest_race(
+    name: str,
+    category: Literal["RACE_A", "RACE_B", "RACE_C"],
+    date: str,                       # ISO, "2026-05-03"
+    sport: str = "",                 # Run / Ride / Swim / TrailRun / Triathlon
+    distance_m: float | None = None,
+    description: str = "",           # freeform notes — surface/weather/goal time
+    ctl_target: float | None = None, # peak CTL on race day; validated vs current CTL
+    dry_run: bool = False,
+) -> str:
+    """Create or update a future race event in Intervals.icu (RACE_A/B/C)
+    and mirror it into athlete_goals. Dry-run returns a preview string; the
+    bot replays the exact same input with dry_run=False on user confirmation.
+    """
+```
+
+### 4.2. Validation
+
+- `category` — только RACE_A/B/C. Для просто «important training» — используй обычный calendar event (не этот tool).
+- `date` — парсится как ISO, должна быть **≥ today** (гонки в прошлом размечаются через `tag_race`, не этим).
+- `ctl_target` — если задан, компонуем «sanity hint» в preview (`current_ctl → target`, ramp rate, недели до гонки); **не отклоняем**, но показываем риск в rationale. Intervals `ramp_rate > 7 TSS/week` = flag.
+- `sport` — если пусто, дефолт подсказываем по `user.primary_sport` из `athlete_settings` (как делает `suggest_workout`).
+
+### 4.3. Идемпотентность
+
+Ключ дедупа: `(user_id, category, event_date)`. Один атлет = одна RACE_A на конкретную дату. Логика:
+
+1. Перед push читаем из Intervals `get_events(oldest=date, newest=date, category=category)`.
+2. Если нашли с тем же event_date — делаем `update_event(existing.id, payload)` + update `athlete_goals` запись с тем же `intervals_event_id`.
+3. Если категория та же, но дата другая (юзер переносит RACE_A) — `update_event` по существующему id, но ищем существующий RACE_A этого юзера через `AthleteGoal.get_by_category(user_id, category)` (новый метод) и обновляем его `event_date`.
+
+Intervals API вернёт тот же `event.id` при update — dedup в `athlete_goals` через `intervals_event_id` unique constraint (уже есть).
+
+### 4.4. Атомарная запись
+
+```python
+if dry_run:
+    return _format_preview(...)
+
+# 1) Push в Intervals
+async with IntervalsAsyncClient.for_user(user_id) as client:
+    payload = EventExDTO(
+        category=category,
+        type=sport or None,
+        name=name,
+        start_date_local=f"{date}T00:00:00",
+        description=description or None,
+        distance=distance_m,
+    )
+    result = existing_intervals_id
+        ? await client.update_event(existing_intervals_id, payload)
+        : await client.create_event(payload)
+
+# 2) Локально в athlete_goals
+goal = await AthleteGoal.upsert_from_intervals(
+    user_id=user_id,
+    category=category,
+    event_name=name,
+    event_date=date_obj,
+    intervals_event_id=result.id,
+)
+
+# 3) ctl_target — отдельным update (upsert_from_intervals его не трогает,
+#    см. data/db/athlete.py:236 "Does NOT overwrite CTL targets")
+if ctl_target is not None:
+    await AthleteGoal.set_ctl_target(goal.id, ctl_target)
+
+return _format_success(...)
+```
+
+### 4.5. Return shape
+
+`dry_run=True` → многострочная markdown-совместимая строка (см. §3.1 Preview).
+
+`dry_run=False` → короткое подтверждение с event_id + ссылкой на Intervals:
+```
+✅ RACE_A создана: Drina Trail — 2026-05-03.
+Peak CTL target: 55.
+Event: https://intervals.icu/event/105038593
+```
+
+Ошибки Intervals (422 duplicate, 401 auth) → `Error pushing: {e}` — bot handler показывает юзеру как есть.
+
+---
+
+## 5. Bot-side state: `pending_race`
+
+Копируем паттерн `pending_workout` из `bot/main.py:654-692`.
+
+### 5.1. Новый элемент `_PREVIEWABLE_TOOLS`
+
+```python
+def _suggest_race_is_preview(inp: dict) -> bool:
+    return inp.get("dry_run") is True
+
+def _suggest_race_apply_push(inp: dict) -> None:
+    inp["dry_run"] = False
+
+_PREVIEWABLE_TOOLS: dict[str, PreviewableTool] = {
+    "suggest_workout": PreviewableTool(_suggest_workout_is_preview, _suggest_workout_apply_push),
+    "compose_workout": PreviewableTool(_compose_workout_is_preview, _compose_workout_apply_push),
+    "suggest_race":    PreviewableTool(_suggest_race_is_preview,    _suggest_race_apply_push),  # NEW
+}
+```
+
+### 5.2. Extractor
+
+`_extract_pending_workout` переименовать в `_extract_pending_preview` (универсальный — уже скан по `_PREVIEWABLE_TOOLS`, меняется только ключ `context.user_data`). Или параллельный `_extract_pending_race` с тем же reverse-scan, но фильтрующий только `suggest_race`.
+
+Предпочтительно: **один универсальный extractor**, но разные ключи в user_data (`pending_workout` vs `pending_race`) — потому что handler разный (`workout_push` vs `race_push`) и UI кнопок тоже разный. В extractor добавить параметр `tool_filter: set[str]`.
+
+### 5.3. Confirm handler `race_push`
+
+Точная копия `workout_push` (`bot/main.py:830`) с двумя отличиями:
+- Pop из `"pending_race"`.
+- Кнопка `callback_data="race_push"` (регистрируется в `ConversationHandler.fallbacks` или как standalone `CallbackQueryHandler` — см. §5.5).
+
+### 5.4. Ключи в `user_data`
+
+| Ключ | Тип | Живёт | Кто ставит | Кто снимает |
+|---|---|---|---|---|
+| `pending_race` | `dict \| None` | до confirm / cancel / новой генерации | `handle_chat_message`, `handle_photo_message` после `agent.chat(...)` | `race_push` (pop), `/cancel`, следующий chat без `suggest_race` |
+
+Такой же TTL-by-replacement, как `pending_workout` — каждый новый turn вытесняет старый черновик.
+
+### 5.5. Интеграция в `handle_chat_message`
+
+Сейчас `handle_chat_message` вызывает `agent.chat(..., tool_calls_filter=set())` — фильтр пустой, т.е. tool_calls **не** сохраняются в результат. Надо поменять на `set(_PREVIEWABLE_TOOLS.keys())` чтобы ловить `suggest_race` в свободном чате (сейчас там только workout'ы через `/workout`, но race — именно free-form).
+
+После `agent.chat`:
+```python
+context.user_data["pending_race"] = _extract_pending_preview(
+    result.tool_calls, tool_filter={"suggest_race"}
+)
+if context.user_data["pending_race"]:
+    reply_markup = InlineKeyboardMarkup([
+        [InlineKeyboardButton("✅ Отправить в Intervals", callback_data="race_push")],
+        [InlineKeyboardButton("❌ Отмена", callback_data="race_cancel")],
+    ])
+```
+
+**Ограничение:** если в одном turn'е Claude сгенерил и workout, и race (маловероятно, но возможно) — сохраняем оба `pending_*` и показываем **две** группы кнопок. Extractor работает per-tool.
+
+---
+
+## 6. Prompt rules (`SYSTEM_PROMPT_CHAT`)
+
+Добавить секцию **после** `## Workout generation`:
+
+```
+## Race creation
+
+If the athlete wants to add a future race (triggers: «добавь гонку», «создай старт»,
+«запиши Ironman», «race A на X мая»), use `suggest_race`. Required fields the athlete
+must provide (or you must confirm via clarifying questions, not via tool-guessing):
+
+  • name (e.g. "Drina Trail", "Ironman 70.3 Hvar")
+  • category: A / B / C (priority). If ambiguous, ask — don't default.
+  • date (ISO). Relative phrasings like «через 2 недели» must be resolved to a concrete
+    date using today's date from the system prompt.
+
+Optional but high-value — ASK ONCE if plausible from context:
+
+  • sport (Run / Ride / Swim / TrailRun / Triathlon) — usually derivable from race name.
+  • distance_m — surface the distance if the athlete said it out loud.
+  • ctl_target — peak CTL on race day. If the athlete names a number, pass it through.
+    If not, don't invent one. Mention the current CTL and realistic ramp-rate (~5 TSS/week)
+    in the preview so the athlete can decide.
+  • description — surface (trail/asphalt), weather expectations, goal time — in 1-2 sentences.
+
+Flow — always 2-step:
+  1. Call `suggest_race(..., dry_run=True)` to produce a preview the user will see.
+  2. The bot shows a "Send to Intervals" button. If the user confirms, the bot pushes
+     the same payload with dry_run=False WITHOUT asking you again. Do NOT call
+     `suggest_race(dry_run=False)` yourself — the confirm button is the athlete's consent.
+
+Do NOT call `tag_race` for future races — it's for marking past activities as races.
+```
+
+### 6.1. Prompt caching
+
+Раздел небольшой (~25 строк), уйдёт в тот же `cache_control: ephemeral` block что и весь system prompt — инвалидация только при смене per-user данных (goal / thresholds), как сейчас.
+
+---
+
+## 7. Data model
+
+### 7.1. Без миграций
+
+`athlete_goals` уже содержит всё что нужно (`category`, `event_name`, `event_date`, `sport_type`, `ctl_target`, `intervals_event_id`). `upsert_from_intervals` — точка записи. Нужен только новый хелпер:
+
+```python
+# data/db/athlete.py
+@classmethod
+@dual
+def set_ctl_target(cls, goal_id: int, ctl_target: float, *, session: Session) -> None:
+    session.execute(
+        update(cls).where(cls.id == goal_id).values(ctl_target=ctl_target)
+    )
+    session.commit()
+```
+
+(`upsert_from_intervals` явно **не** трогает ctl_target чтобы синк не стирал руками-поставленную цель — см. docstring на 236. Мы следуем тому же контракту: ctl_target задаётся отдельным шагом.)
+
+### 7.2. Intervals.icu event payload
+
+Существующий `EventExDTO` покрывает всё. Вызов:
+
+```python
+EventExDTO(
+    category="RACE_A",          # RACE_A/B/C — see docs/intervals_icu_openapi.json
+    type="TrailRun",            # или Run/Ride/Swim/Triathlon
+    name="Drina Trail",
+    start_date_local="2026-05-03T00:00:00",
+    description="17 km trail, target 2h30m",
+    distance=17000.0,           # meters; Intervals.icu принимает в метрах для событий
+)
+```
+
+Поле `ctl_target` в Intervals **не существует** — там нет такой концепции на events. Хранится только у нас.
+
+---
+
+## 8. Edge cases
+
+| Сценарий | Поведение |
+|---|---|
+| Юзер просит RACE_A, но у него уже есть RACE_A на другую дату | Intervals позволит — он не enforce'ит «одна RACE_A в сезон». Мы делаем `update_event` по существующему (§4.3). Preview явно показывает «было X, станет Y». |
+| Дата в прошлом | Tool отклоняет: `Error: race date {date} is in the past — use tag_race to log past races`. |
+| CTL target нереалистичный (ramp > 10 TSS/week) | Preview показывает yellow warning, не блокирует. |
+| OAuth нет / 401 от Intervals | `Error pushing: unauthorized — reconnect Intervals in /settings`. |
+| Юзер два раза жмёт «Отправить» | `context.user_data.pop("pending_race", None)` в handler'е = consume-on-read (как в `workout_push:844`) — второй tap даёт «Не нашёл черновик». |
+| `suggest_race` вызвана без preview (Claude проигнорировал правило §6) | Не блокируем: инференс сделал `dry_run=False` напрямую → event реально создастся. Это bypass confirm-flow, но юзер всё равно в явном диалоге, не в фоне. Метрика `race_skipped_preview` для мониторинга (§10). |
+
+---
+
+## 9. Multi-tenant / security
+
+- `suggest_race` читает `user_id` из `get_current_user_id()` (contextvars, MCP middleware). **Нельзя** принимать `user_id` параметром — см. `docs/MULTI_TENANT_SECURITY.md` T1.
+- `IntervalsAsyncClient.for_user(user_id)` использует per-user `access_token_encrypted` / `api_key_encrypted` — push идёт в собственный Intervals аккаунт атлета.
+- Preview-текст содержит `event_name` / `description` от атлета → безопасно для Markdown (а значит и для HTML через `markdown_to_telegram_html`), но handler'у на стороне бота ничего экранировать не нужно: сам tool возвращает plain text, и `workout_push` / `race_push` шлют без `parse_mode` (`bot/main.py:881-884` — уже запротоколировано).
+
+---
+
+## 10. Observability
+
+Метрики через Sentry breadcrumbs (как `@sentry_tool` на других MCP tool'ах):
+- `race_created` — category, sport, days_to_race, ctl_target.
+- `race_updated` — diff полей.
+- `race_skipped_preview` — dry_run=False без предшествующего dry_run=True (indicator промпт-drift).
+- `race_push_no_draft` — handler вызван, а `pending_race` пуст (indicator двойного tap).
+
+Лог в Sentry не фильтруем по `INTERVALS_WEBHOOK_MONITORING` — это write-path, критично.
+
+---
+
+## 11. Testing
+
+### Unit (`tests/mcp/test_races.py`)
+
+- `suggest_race(dry_run=True)` → возвращает preview-строку, **не** делает HTTP-вызовов.
+- `suggest_race(dry_run=False)` c mock `IntervalsAsyncClient` → вызов `create_event` с правильным `EventExDTO`.
+- Идемпотентность: второй вызов с тем же `(user_id, category, event_date)` → `update_event`, не `create_event`.
+- `ctl_target` задан → `AthleteGoal.set_ctl_target` вызван; не задан → не вызван.
+- Past date → возвращает error без HTTP-вызова.
+
+### Bot integration (`tests/bot/test_race_flow.py`)
+
+- `handle_chat_message` + mock agent возвращает `tool_calls=[{"name":"suggest_race","input":{..., "dry_run": True}}]` → `pending_race` попадает в `user_data`, кнопка «Отправить в Intervals» рендерится.
+- `race_push` callback → `pending_race` pop'ается, MCP tool вызывается с `dry_run=False`.
+- Повторный tap «Отправить» → «Не нашёл черновик», без второго MCP-вызова.
+- `/cancel` чистит `pending_race`.
+
+### E2E (manual, за owner user_id=1)
+
+1. В чате: «добавь RACE_B на 2026-10-12 марафон 42 км».
+2. Проверить preview.
+3. Tap «Отправить».
+4. Проверить Intervals.icu calendar — event появился с `category=RACE_B`, `type=Run`.
+5. `poetry run python -c "from data.db import AthleteGoal; [print(g.__dict__) for g in AthleteGoal.get_all(1)]"` — запись с `ctl_target=None` (не задавали).
+6. В чате: «поставь CTL target 85 на RACE_B».
+7. Должен сработать через `update_race_goal` (Phase 2) или через повторный `suggest_race` с `ctl_target=85` (MVP).
+
+---
+
+## 12. Implementation order
+
+1. **MCP tool** `mcp_server/tools/race_creation.py` — `suggest_race(dry_run=...)`. Регистрация в `mcp_server/tools/__init__.py`.
+2. **ORM хелпер** `AthleteGoal.set_ctl_target`.
+3. **Prompt** — добавить секцию `## Race creation` в `bot/prompts.py:SYSTEM_PROMPT_CHAT`.
+4. **Bot handler**:
+   - Расширить `_PREVIEWABLE_TOOLS` новым `suggest_race`.
+   - Универсализировать `_extract_pending_preview(tool_calls, tool_filter)`.
+   - Новый `race_push` / `race_cancel` callback handler (copy-paste из `workout_push`).
+   - Поменять `handle_chat_message` / `handle_photo_message`: `tool_calls_filter=set(_PREVIEWABLE_TOOLS.keys())`; после `agent.chat` вытащить `pending_race`.
+   - Зарегистрировать `CallbackQueryHandler(race_push, pattern=r"^race_push$")` в `setup_handlers`.
+5. **Tests** — unit + bot integration.
+6. **Docs** — обновить `CLAUDE.md` секцию «Bot Commands» (упомянуть свободно-чатовый race creation) и `BUSINESS_RULES.md` (race priority semantics).
+7. **Settings UI edit** (§14) — backend PATCH endpoint + inline inputs на `/settings`.
+
+---
+
+## 13. Open questions
+
+- **Должны ли мы требовать goal_time_sec на preview?** Пока опциональный `description`. Если станет полезным для Claude при suggest_workout → вынести в отдельный параметр.
+- **Что делать с `disciplines` для триатлона?** Автоматически `["Swim","Ride","Run"]` при `sport="Triathlon"`, или спрашивать явно? MVP: автовставка, уточнить только если `sport="Duathlon"` / нестандарт.
+- **Ошибка push, а локальная запись уже prepared** — делаем ли компенсирующий delete? MVP: **нет** — tool падает до `AthleteGoal.upsert_from_intervals`, потому что вызов Intervals идёт первым. Если упадёт `set_ctl_target` после успешного upsert — ctl_target просто не запишется, юзер повторит.
+
+---
+
+## 14. Settings UI — manual CTL edit
+
+**Зачем отдельный путь помимо чата.** CTL target и per-sport CTL split — это
+«локальный overlay» над Intervals (см. §7). Синк их не трогает, а юзер может
+захотеть подправить число без запуска диалога с Claude («скорректировал план —
+теперь peak CTL 60, а не 55»). Также если гонка была создана **до** появления
+чат-флоу (через `cli sync-settings`), её `ctl_target=None`, и до сих пор
+единственный способ выставить CTL был `python -m cli shell`.
+
+### 14.1. Что редактируется
+
+| Поле | Тип | Источник | Редактируется из Settings? |
+|---|---|---|---|
+| `event_name` | string | Intervals | ❌ — только через чат (пушит в Intervals) |
+| `event_date` | date | Intervals | ❌ — только через чат |
+| `category` | RACE_A/B/C | Intervals | ❌ — только через чат |
+| `ctl_target` | float | **локально** | ✅ **да** |
+| `per_sport_targets` | `{swim,ride,run}` | **локально** | ✅ **да** |
+
+Только local-only поля. Всё что синхронизируется с Intervals — менять нельзя
+напрямую из UI, иначе следующий sync перезапишет (а писать обратно в Intervals
+здесь — это full-blown edit-race flow, он в Phase 2).
+
+### 14.2. API endpoint
+
+```
+PATCH /api/athlete/goal/{goal_id}
+body:   { "ctl_target"?: number | null, "per_sport_targets"?: {"swim"?: number, "ride"?: number, "run"?: number} | null }
+auth:   require_athlete (не demo)
+response: { "goal_id": int, "ctl_target": number | null, "per_sport_targets": {...} | null }
+```
+
+- `require_athlete` блокирует demo-юзеров (`api/deps.py` — существующая зависимость).
+- Проверка ownership: `goal.user_id == current_user.id` — 404 если чужая цель
+  (не 403, чтобы не подтверждать факт существования чужого goal_id; см.
+  `docs/MULTI_TENANT_SECURITY.md` T1).
+- `null` явно очищает поле. Пустой body → 400.
+- Никакого push в Intervals. Никакого re-sync. Меняются только две колонки.
+
+### 14.3. ORM
+
+Дополнить хелпер из §7.1:
+
+```python
+# data/db/athlete.py
+@classmethod
+@dual
+def update_local_fields(
+    cls,
+    goal_id: int,
+    *,
+    user_id: int,             # ownership check
+    ctl_target: float | None = _UNSET,
+    per_sport_targets: dict | None = _UNSET,
+    session: Session,
+) -> AthleteGoal | None:
+    """Patch the local-only overlay fields. Skip attributes passed as _UNSET so
+    the caller can clear a field to None without accidentally clearing others.
+    Returns None if goal not found or owned by another user.
+    """
+```
+
+Sentinel `_UNSET` — классический способ отличить «не передано» от «передано None» (тот же приём в `sqlalchemy.ext.Mutable` и pydantic). Без него PATCH превращается в PUT.
+
+### 14.4. Frontend (`webapp/src/pages/Settings.tsx`)
+
+Сейчас карточка «Race Goal» (`Settings.tsx:272-285`) — read-only `<Row>`s.
+Меняем `ctl_target` и `per_sport_targets.*` на inline-редактируемый input:
+
+- Клик на значение → `<input type="number" min=0 max=200 step=1>`.
+- Debounce 500ms → `PATCH /api/athlete/goal/{goal_id}` с изменённым полем.
+- Optimistic update локального state, rollback если 4xx/5xx.
+- На ошибке — toast «Не удалось сохранить CTL», значение возвращается.
+- Пустое значение submit → PATCH с `null` → поле очищается.
+
+UX-деталь: `ctl_target` и `per_sport_targets.swim/ride/run` логически связаны
+(сумма split должна быть ≤ общий target). Валидацию **не** делаем в MVP — юзер
+сам знает что пишет, а проверка только раздражает. Если войдёт в привычку — в
+Phase 2 подсвечивать несогласованность warning'ом.
+
+### 14.5. i18n
+
+Новые строки:
+- `webapp/src/i18n/ru.json` + `en.json`:
+  - `settings.goal.ctl_edit_hint` — "нажмите чтобы изменить" / "click to edit"
+  - `settings.goal.save_failed` — ошибка сохранения.
+
+### 14.6. Тесты
+
+**Backend** (`tests/api/test_athlete_goal.py`, новый):
+- PATCH с валидным body → 200 + обновлённая строка.
+- PATCH с `"ctl_target": null` → поле реально становится None.
+- PATCH чужой goal_id → 404.
+- PATCH без body / с пустым body → 400.
+- PATCH от demo-юзера → 403 (через `require_athlete`).
+
+**Frontend** (`webapp/src/pages/__tests__/Settings.test.tsx` — если есть тест-инфра;
+иначе — ручной smoke):
+- Клик по CTL → появляется input с текущим значением.
+- Успешный PATCH → значение обновляется inplace.
+- Failed PATCH → показан toast, значение возвращается.
+
+### 14.7. Sync-устойчивость
+
+Финальный sanity check: `actor_sync_athlete_goals` крутится каждые 30 мин
+(`bot/scheduler.py:70-73`). После PATCH от UI юзер закрывает вкладку, в следующий
+синк вызывается `AthleteGoal.upsert_from_intervals(...)`. Текущая реализация на
+`data/db/athlete.py:245-251` обновляет только `event_name`/`event_date`/`category`/`synced_at` —
+`ctl_target` и `per_sport_targets` остаются нетронутыми. UI-правка переживает
+синк. Регресс-тест это фиксирует (`tests/tasks/test_athlete_actors.py` или
+новый) — **обязательно добавить**, это load-bearing инвариант.
+
+- **Должны ли мы требовать goal_time_sec на preview?** Пока опциональный `description`. Если станет полезным для Claude при suggest_workout → вынести в отдельный параметр.
+- **Что делать с `disciplines` для триатлона?** Автоматически `["Swim","Ride","Run"]` при `sport="Triathlon"`, или спрашивать явно? MVP: автовставка, уточнить только если `sport="Duathlon"` / нестандарт.
+- **Ошибка push, а локальная запись уже prepared** — делаем ли компенсирующий delete? MVP: **нет** — tool падает до `AthleteGoal.upsert_from_intervals`, потому что вызов Intervals идёт первым. Если упадёт `set_ctl_target` после успешного upsert — ctl_target просто не запишется, юзер повторит.

--- a/docs/USER_CONTEXT_SPEC.md
+++ b/docs/USER_CONTEXT_SPEC.md
@@ -193,6 +193,10 @@ _UNDOABLE_TOOLS = {
 
 Готовая почва для расширения: если появятся другие «committed with undo» tool'ы (например, `schedule_workout` без preview), регистрируем их сюда.
 
+**Edge case — `save_fact` внутри `/workout` flow.** Хэндлеры `workout_sport_chosen` / `workout_dialog_text` вызывают `agent.chat(..., tool_calls_filter={"suggest_workout", "compose_workout"})` — узкий filter, чтобы не хранить deep-copy чужих tool_calls. Если Claude решит внутри этого диалога вызвать `save_fact` («запомни, что тренируюсь утром»), факт **запишется в БД** (server-side MCP работает всегда), но undo-кнопка **не появится** — `save_fact` не попадёт в `ChatResult.tool_calls` из-за фильтра.
+
+Решение для MVP: **silent save** — приемлемо, т.к. факт можно deactivate'ить из обычного чата («забудь что я тренируюсь утром») или `list_facts` + `deactivate_fact`. Альтернатива — union фильтра `{"suggest_workout", "compose_workout", "save_fact"}` в workout-хэндлерах + показ undo-кнопки после основного preview. Сделаем если пользователи начнут жаловаться.
+
 ### Phase 2 — async post-chat extractor с batch-approval
 
 1. `ClaudeAgent.chat()` после ответа пушит в Redis stream `user_facts_stream:{user_id}` кортеж `(user_msg, assistant_msg)`.
@@ -211,6 +215,10 @@ _UNDOABLE_TOOLS = {
 3. Драфт живёт в `context.user_data["pending_facts"] = [...]` **ровно так же**, как `pending_workout` в `/workout`. Batch approval — прямой `MCPClient.call_tool("save_fact", ...)` в цикле, без повторной Claude-инференции.
 4. «⚙️ Выборочно» — вторая клавиатура с per-item чекбоксами (можно начать без этой кнопки в Phase 2a, добавить в 2b).
 5. Consume-on-read: `pop("pending_facts")` при любом финальном действии.
+
+**Timing.** Cron в локальной TZ юзера (`users.timezone` или fallback `TIMEZONE=Europe/Belgrade`), окно `hour=18..19` — в это время атлет обычно free + evening report уже ушёл, можно спокойно показать предложение. Не в 3 утра. Scheduler читает per-user TZ как это делает `tasks/scheduler.py` для morning report.
+
+**Concurrent pending.** Если при запуске cron видим что `user_data["pending_facts"]` уже непустой (предыдущий батч без ответа) — **skip** текущий запуск, не затирая старый. Юзер отреагирует → флаг очистится → следующий cron подхватит. Объединять батчи не стоит: смешанные свежие + вчерашние кандидаты ломают UX «я подметил в недавних разговорах». Если pending висит >48h — автоматически dismiss через job_queue (см. TTL на undo в §4), чтобы не блокировать пайплайн навечно.
 
 **Почему здесь preview-confirm оправдан** (в отличие от Phase 1 `save_fact`):
 - Extractor может галлюцинировать — пользователь **должен** увидеть что сохраняется.
@@ -232,13 +240,15 @@ _UNDOABLE_TOOLS = {
 ### Как
 
 ```
-[ статический system prompt ──── стабильно, cache_control:ephemeral ]
-[ блок goal      (из athlete://goal)  ────┐                           ]
-[ блок facts     (активные user_facts) ───┤ меняются редко,           ]
-[ блок athlete   (профиль, sports)    ────┘ тоже под cache_control    ]
+[ static_prompt  ─ cache_control #1 ]    ← вечный кэш, один раз на сессию
+[ dynamic_tail   ─ cache_control #2 ]    ← tухнет при save_fact / goal update
+     │
+     ├── athlete profile (sports, TZ)
+     ├── goal block       (из athlete://goal)
+     └── facts block      (активные user_facts)
 ```
 
-Все три блока попадают в **один** cacheable segment, т.к. Anthropic позволяет максимум 4 `cache_control` точки. Порядок: статика сверху, «часто-не-меняющееся» снизу — если факт изменится, отвалится только хвост кэша.
+Два `cache_control` маркера — см. §6 для полного объяснения. Статика держится горячей между сохранениями фактов.
 
 **Формат facts-блока:**
 
@@ -264,19 +274,40 @@ _UNDOABLE_TOOLS = {
 
 ## 6. Prompt caching — стратегия
 
-Подтверждено в `bot/agent.py:76`:
+Сейчас `bot/agent.py:76` ставит **один** `cache_control` в конец system prompt:
 
 ```python
 cached_system = [{"type": "text", "text": system, "cache_control": {"type": "ephemeral"}}]
 ```
 
-Сейчас весь system prompt — один блок с `ephemeral`. После этого спека системный промпт **остаётся одним string-ом**, внутрь которого мы просто склеиваем goal + facts + athlete. Никаких структурных изменений в `agent.py` не нужно — вся работа в `bot/prompts.py`.
+**Почему одного маркера мало.** Anthropic prompt cache работает как **префиксный хэш**: хэш считается от начала до маркера. Если в конце блока меняется хоть один символ (добавили факт → блок `## Что я помню о тебе` переписался) — хэш префикса до маркера другой → **cache miss на весь system prompt**, включая статику. Текущая схема работает пока facts/goal не меняются — но как только сделаем `save_fact` в диалоге, следующее сообщение читает всё с нуля.
+
+**Как надо.** Разбиваем system prompt на **два** cacheable сегмента (лимит — 4, запас есть):
+
+```python
+static_prompt = get_static_system_prompt()           # ~весь текущий SYSTEM_PROMPT_CHAT
+dynamic_tail  = render_athlete_block(user)           # goal + facts + профиль
+
+cached_system = [
+    {"type": "text", "text": static_prompt, "cache_control": {"type": "ephemeral"}},
+    {"type": "text", "text": dynamic_tail,  "cache_control": {"type": "ephemeral"}},
+]
+```
+
+**Поведение:**
+
+- `static_prompt` хэшируется до маркера #1 → кэш **вечный** относительно изменений facts (пока не правим сам шаблон промпта).
+- `dynamic_tail` — свой кэш, тухнет только при `save_fact` / `deactivate_fact` / смене `goal`.
+- `save_fact` инвалидирует ровно хвост; статика (3–5к токенов) остаётся горячей.
 
 **Эффект:**
 
-- TTL ephemeral кэша 5 мин. При активном диалоге (несколько сообщений подряд) — кэш попадает на каждом tool-use-loop-итерации.
-- Стоимость cache read ≈10% от input tokens. Для чата с MCP tools где tool-use-loop делает 3–5 итераций — это уже экономит кратно.
-- `save_fact` инвалидирует кэш для следующего сообщения — ожидаемо, делать ничего не надо.
+- TTL ephemeral 5 мин → при активном диалоге кэш попадает на каждой tool-use-loop итерации и в следующих сообщениях.
+- Cache read ≈10% от input tokens. На чате с tool-use (3–5 итераций) + частыми сохранениями фактов экономия **кратная** — без двух маркеров весь system prompt инвалидировался бы на каждом save.
+
+**Порядок внутри `dynamic_tail`:** athlete profile (редко) → goal (реже) → facts (чаще). Но после второго маркера порядок значения не имеет — всё одним хэшем. Оставляем читабельный порядок.
+
+**Что делать в `agent.py`:** поменять строку 76 с одного blob'а на два элемента. Весь остальной tool-use-loop не трогаем. В `bot/prompts.py` разделить `SYSTEM_PROMPT_CHAT` на `get_static_system_prompt()` (константа) и `render_athlete_block(user)` (динамика).
 
 ---
 
@@ -331,7 +362,7 @@ cached_system = [{"type": "text", "text": system, "cache_control": {"type": "eph
 
 ### Phase 2 — Async extractor с batch-approval (условный)
 
-Запускаем только если Phase 1 покажет, что Claude систематически забывает звать `save_fact` (см. §10.3 trigger: <3 tool-фактов при >100 сообщений за 30 дней).
+Запускаем только если Phase 1 покажет, что Claude систематически забывает звать `save_fact` (см. §11.3 trigger + §10 метрики).
 
 - [ ] Redis stream `user_facts_stream:{user_id}` — писатель в `ClaudeAgent.chat()`, LTRIM до последних 50 пар.
 - [ ] Dramatiq actor `actor_extract_user_facts` — раз в 24ч на активного юзера.
@@ -361,9 +392,9 @@ cached_system = [{"type": "text", "text": system, "cache_control": {"type": "eph
 | `undo_tap_rate` | (count `deactivated_reason='user_request'` within 10min of `created_at`) / `facts_written` | Если >30% — Claude слишком жадный, нужно ужесточать docstring. |
 | `topic_distribution` | `SELECT topic, count(*) FROM user_facts WHERE deactivated_at IS NULL GROUP BY topic` | Ловим разрастание синонимов (`food_preference` vs `nutrition`). >3 near-synonyms → пропишем enum. |
 | `cap_evictions_per_week` | count `deactivated_reason='topic_cap'` | Высокий rate на одном topic → увеличить N с 3 до 5, или это спам от Claude. |
-| `fact_citation_rate` | heuristic: count сообщений, где в ответе Claude встречается substring любого активного факта / total chat messages | Proxy для «факты реально используются». Ловим случай «кладём в промпт, но не влияет на ответы». |
+| `fact_citation_rate` ⚠ best-effort | heuristic: count сообщений, где в ответе Claude встречается substring любого активного факта / total chat messages | Proxy для «факты реально используются». **Подводные камни:** Claude парафразит («болит колено» → «травма ноги») — substring match промахнётся. Метрика low-signal, **не используется** для gating-решений (вроде «выключить facts-блок»), только как лёгкий sanity check. Альтернатива (структурный `cited_fact_ids` в ответе) меняет chat-protocol — откладываем. |
 | `cache_hit_rate_chat` | `api_usage_daily.cache_read_tokens / input_tokens` по чат-вызовам | Хотим ≥70% на активных диалогах. Падение после релиза = facts-блок ломает кэш (порядок блоков кривой). |
-| `tool_facts_per_100_msgs` | `facts_written / chat_messages * 100` за 30 дней | **Триггер Phase 2**: если <3 — Claude не зовёт tool, пора включать extractor (см. §11.3). |
+| `tool_facts_per_100_msgs` | `facts_written / chat_messages * 100` за 30 дней, **только если `chat_messages >= 100`** | **Триггер Phase 2**: если ratio <3 при достаточной выборке — Claude не зовёт tool, пора включать extractor (см. §11.3). |
 
 ### Где хранить
 
@@ -383,9 +414,9 @@ MCP tool `get_fact_metrics()` — **per-user**, как все остальные
 
 ## 11. Open questions
 
-1. **Язык фактов.** Атлет пишет по-русски → факт сохранится по-русски. Если атлет позже переключится на `/lang en`, в промпте всё равно будет русскоязычный факт. Phase 1 — храним as-is, Claude многоязычный и поймёт. Если увидим проблемы — добавим `fact_language` + переводы on-the-fly.
+1. **Язык фактов.** Факт сохраняется на том языке, на котором атлет его произнёс (без нормализации). **При смене `/lang` переводы НЕ делаем** — ни в момент смены языка, ни при инъекции в промпт. Claude многоязычный и корректно цитирует русский факт в английском ответе. Это экономит лишние Claude-вызовы и защищает от дрейфа смысла при авто-переводе («болит ахилл» ≠ «Achilles tendon pain» в коннотации). Если через полгода увидим, что факты на родном языке мешают — добавим колонку `fact_language` + ручную миграцию по запросу юзера, не автомат.
 2. **Ограничение количества.** Решено: per-topic cap N=3 (append-with-cap, §3) + global soft warning на >50. Hard cap не ставим.
-3. **Phase 2 trigger.** `tool_facts_per_100_msgs < 3` за 30 дней (§10) → включаем extractor. До этого — not planned.
+3. **Phase 2 trigger.** Минимум данных для надёжного ratio: `total_chat_msgs_30d >= 100`. Если выполнено **И** `tool_facts_per_100_msgs < 3` — включаем extractor для этого юзера. При `msgs < 100` не триггерим вообще: ratio на малой выборке шумный (у тихого юзера 0/10 даст нулевой ratio, но проблемы нет — просто мало данных).
 4. **Morning report inject.** Решено: Phase 1 не инжектим. Revisit после ≥2 недель данных.
 5. **Sensitive topics injection.** Факты `topic=health`/`family` могут быть чувствительными. Инжектим их наравне с остальными (иначе теряется смысл памяти), но не логируем тело факта в Sentry breadcrumbs — только `topic` + `fact_id`. См. §12.
 

--- a/tests/bot/test_prompts_zones.py
+++ b/tests/bot/test_prompts_zones.py
@@ -1,0 +1,148 @@
+"""Tests for the per-user zones block rendered into SYSTEM_PROMPT_CHAT.
+
+Covers:
+- _pct_ranges: sentinel trimming, top-zone capping.
+- _pct_ranges_from_hr: bpm → %LTHR conversion.
+- _zones_block: Intervals.icu sport-settings are preferred, Friel fallback
+  kicks in when a sport has no synced boundaries.
+"""
+
+from types import SimpleNamespace
+
+from bot.prompts import _pct_ranges, _pct_ranges_from_hr, _zones_block
+from data.db.dto import AthleteThresholdsDTO
+
+
+def _settings(**kw):
+    defaults = dict(
+        lthr=None,
+        ftp=None,
+        threshold_pace=None,
+        hr_zones=None,
+        power_zones=None,
+        pace_zones=None,
+    )
+    defaults.update(kw)
+    return SimpleNamespace(**defaults)
+
+
+class TestPctRanges:
+    def test_trims_sentinel(self):
+        # 999 is a common Intervals.icu sentinel for the open-ended top zone.
+        ranges = _pct_ranges([55, 75, 90, 105, 120, 150, 999])
+        assert ranges == [(0, 55), (55, 75), (75, 90), (90, 105), (105, 120), (120, 150), (150, 160)]
+
+    def test_no_sentinel_still_appends_top(self):
+        ranges = _pct_ranges([55, 75])
+        assert ranges == [(0, 55), (55, 75), (75, 120)]
+
+
+class TestPctRangesFromHr:
+    def test_converts_bpm_to_percent_of_lthr(self):
+        # forkbomb: LTHR 182, boundaries [153, 162, 171, 181, 186, 191, 200]
+        ranges = _pct_ranges_from_hr([153, 162, 171, 181, 186, 191, 200], 182)
+        # Z1 ..84, Z2 84-89, Z3 89-94, Z4 94-99, Z5 99-102, Z6 102-105, Z7 105-110, top
+        assert ranges[0] == (0, 84)
+        assert ranges[1] == (84, 89)
+        assert ranges[2] == (89, 94)
+
+    def test_monotonic_enforcement_prevents_zero_width_zones(self):
+        # Two boundaries that would round to the same integer percent must be
+        # bumped up so we never emit a (84, 84) range.
+        # LTHR 200, boundaries [168, 169] → both round to 84 without monotonic fix.
+        ranges = _pct_ranges_from_hr([168, 169], 200)
+        assert ranges[0] == (0, 84)
+        assert ranges[1] == (84, 85)  # bumped from 84 to 85
+        # Strict monotonic: every range's end > its start.
+        for lo, hi in ranges:
+            assert hi > lo
+
+
+class TestZonesBlock:
+    def _thresholds(self, **kw):
+        return AthleteThresholdsDTO(
+            age=kw.get("age", 30),
+            lthr_run=kw.get("lthr_run"),
+            lthr_bike=kw.get("lthr_bike"),
+            ftp=kw.get("ftp"),
+            css=kw.get("css"),
+        )
+
+    def test_run_uses_intervals_zones_when_synced(self):
+        settings = {
+            "Run": _settings(lthr=182, hr_zones=[153, 162, 171, 181, 186, 191, 200]),
+        }
+        out = _zones_block(settings, self._thresholds(lthr_run=182))
+        assert "LTHR = 182" in out
+        assert "from your Intervals.icu sport-settings" in out
+        assert "Z2 84-89%" in out
+
+    def test_run_falls_back_without_synced_zones(self):
+        out = _zones_block({}, self._thresholds(lthr_run=170))
+        assert "Friel fallback" in out
+        assert "Z2 72-82%" in out  # default Friel model
+
+    def test_ride_power_zones_treated_as_percentages(self):
+        # Intervals stores power_zones already as %FTP (not absolute watts).
+        settings = {
+            "Ride": _settings(lthr=175, ftp=250, power_zones=[55, 75, 90, 105, 120, 150, 999]),
+        }
+        out = _zones_block(settings, self._thresholds(ftp=250, lthr_bike=175))
+        assert "FTP = 250W" in out
+        assert "Z2 55-75%" in out  # endurance range, not 22-30% (the pre-fix bug)
+
+    def test_ride_falls_back_to_friel_when_no_synced_power(self):
+        out = _zones_block({}, self._thresholds(ftp=220, lthr_bike=170))
+        assert "Friel fallback" in out
+        assert "Z2 55-75%" in out
+
+    def test_run_uses_dto_lthr_when_sport_row_lthr_is_missing(self):
+        # Legit shape: some athlete_settings rows had hr_zones populated but
+        # lthr=None. Before the guard relax, this fell to Friel — now it uses
+        # t.lthr_run.
+        settings = {
+            "Run": _settings(lthr=None, hr_zones=[153, 162, 171, 181, 186, 191, 200]),
+        }
+        out = _zones_block(settings, self._thresholds(lthr_run=182))
+        assert "from your Intervals.icu sport-settings" in out
+        assert "Z2 84-89%" in out
+        assert "Friel fallback" not in out.splitlines()[0]  # run line only
+
+    def test_ride_power_zones_used_even_when_ride_ftp_missing(self):
+        # power_zones are stored as %FTP, so the zones themselves don't need FTP.
+        # Fall back to t.ftp for the displayed watts reference.
+        settings = {
+            "Ride": _settings(lthr=175, ftp=None, power_zones=[55, 75, 90, 105, 120, 150, 999]),
+        }
+        out = _zones_block(settings, self._thresholds(ftp=250, lthr_bike=175))
+        ride_line = next(line for line in out.splitlines() if "**Ride**" in line)
+        assert "from your Intervals.icu sport-settings" in ride_line
+        assert "Z2 55-75%" in ride_line
+        assert "FTP = 250W" in ride_line  # reference watts from DTO, not sport row
+
+    def test_ride_power_zones_used_even_when_no_ftp_anywhere(self):
+        # Edge: zones synced, but no FTP on any side → show "—" for the watts.
+        settings = {
+            "Ride": _settings(ftp=None, power_zones=[55, 75, 90, 105, 120, 150, 999]),
+        }
+        out = _zones_block(settings, self._thresholds())
+        ride_line = next(line for line in out.splitlines() if "**Ride**" in line)
+        assert "Z2 55-75%" in ride_line
+        assert "FTP = —" in ride_line
+
+    def test_ride_hr_fallback_uses_bike_constants_and_includes_example(self):
+        # No synced power, no FTP at all → falls through to HR-based fallback.
+        out = _zones_block({}, self._thresholds(lthr_bike=170))
+        ride_line = next(line for line in out.splitlines() if "**Ride**" in line)
+        assert "LTHR bike = 170" in ride_line
+        assert "Z2 68-83%" in ride_line  # bike-specific fallback, not run's 72-82%
+        assert "Z2 72-82%" not in ride_line
+        assert 'Example Z2: `"hr":' in ride_line  # prompt contract requires example step
+
+    def test_swim_css_formatted(self):
+        out = _zones_block({}, self._thresholds(css=120.0))
+        assert "CSS = 2:00/100m" in out
+
+    def test_swim_css_missing(self):
+        out = _zones_block({}, self._thresholds())
+        assert "CSS = —" in out


### PR DESCRIPTION
Introduces per-user HR, power, and pace zones to the workout prompts:
- Implements a fallback model based on Friel zones for users without synced data
- Adjusts logic to use user-specific settings from Intervals.icu when available
- Adds tests ensuring correct zone calculations and fallbacks

Relates to multi-tenant user versioning