### PR TITLE
Handle FIT parse errors and GPS dropouts in card renderer

### DIFF
--- a/data/card_renderer.py
+++ b/data/card_renderer.py
@@ -143,17 +143,25 @@ def _format_swim_pace(sec_per_100m: float) -> str:
 
 def _render_polyline(
     draw: ImageDraw.ImageDraw,
-    latlng: list[tuple[float, float]],
+    latlng: list[tuple[float | None, float | None]],
     bbox: tuple[int, int, int, int],
     color: str,
     line_width: int = 4,
 ) -> None:
-    """Draw GPS track on the image within the given bounding box."""
-    if len(latlng) < 2:
+    """Draw GPS track on the image within the given bounding box.
+
+    Tolerant to ``None`` values inside ``latlng`` points — GPS dropouts
+    (tunnels, indoor segments, Intervals.icu sentinel samples) may produce
+    ``[None, None]`` or ``[lat, None]`` entries. Mixing them with floats
+    crashed ``min()`` / ``max()`` before (issue #249); now we filter to
+    fully-populated points before the bounding-box math.
+    """
+    clean: list[tuple[float, float]] = [(lat, lng) for lat, lng in latlng if lat is not None and lng is not None]
+    if len(clean) < 2:
         return
 
-    lats = [p[0] for p in latlng]
-    lngs = [p[1] for p in latlng]
+    lats = [p[0] for p in clean]
+    lngs = [p[1] for p in clean]
     min_lat, max_lat = min(lats), max(lats)
     min_lng, max_lng = min(lngs), max(lngs)
 
@@ -185,7 +193,7 @@ def _render_polyline(
     offset_y = y0 + padding + (draw_h - track_h) / 2
 
     points = []
-    for lat, lng in latlng:
+    for lat, lng in clean:
         px = offset_x + (lng - min_lng) * scale
         py = offset_y + (max_lat - lat) * scale  # flip Y axis
         points.append((px, py))

--- a/data/card_renderer.py
+++ b/data/card_renderer.py
@@ -64,7 +64,7 @@ class WorkoutCardData:
     avg_hr: int | None = None
     elevation_gain: float | None = None
     ai_text: str | None = None
-    latlng: list[tuple[float, float]] | None = None
+    latlng: list[tuple[float | None, float | None]] | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -365,7 +365,12 @@ def _render_story(data: WorkoutCardData) -> bytes:
     track_color = "#4A90D9"
     track_top = 330
     track_bottom = 1080
-    if data.latlng and len(data.latlng) >= 2:
+    # Count non-None points at the caller so an all-None ``latlng`` (issue
+    # #249: GPS dropouts that produced only ``(None, None)`` samples) falls
+    # through to the emoji fallback below instead of silently rendering an
+    # empty track area.
+    valid_points = sum(1 for lat, lng in data.latlng if lat is not None and lng is not None) if data.latlng else 0
+    if valid_points >= 2:
         _render_polyline(draw, data.latlng, (40, track_top, W - 40, track_bottom), track_color, line_width=9)
     else:
         # No GPS (indoor trainer, pool swim, gym) — fill the track area with a

--- a/tasks/actors/activities.py
+++ b/tasks/actors/activities.py
@@ -176,7 +176,7 @@ def _actor_process_fit_file(prev: str | None):
             scope.set_tag("fit_parse_aborted", "true")
             scope.set_extra("records_parsed", len(records))
             scope.set_extra("rr_parsed", len(rr_ms))
-            scope.set_extra("fit_path", prev)
+            scope.set_extra("fit_filename", Path(prev).name)
             sentry_sdk.capture_message(f"FIT parse aborted: {e}", level="warning")
 
     # Tail ``parse_aborted`` on the return so ``_actor_post_process_fit_file``
@@ -193,7 +193,7 @@ def _actor_post_process_fit_file(
     parsed_fit_data: tuple[list[float], list[dict], bool] | None,
     user: UserDTO,
     activity_id: str,
-) -> FitProcessingResultDTO | None:
+) -> dict[str, Any] | None:
     if not parsed_fit_data:
         return
 

--- a/tasks/actors/activities.py
+++ b/tasks/actors/activities.py
@@ -12,6 +12,7 @@ import numpy as np
 import sentry_sdk
 from dramatiq import group, pipeline
 from fitparse import FitFile
+from fitparse.utils import FitParseError
 from pydantic import validate_call
 from sqlalchemy import select
 
@@ -104,9 +105,13 @@ def _actor_process_fit_file(prev: str | None):
     """Parse FIT file once, extracting both RR intervals and Record messages.
 
     Returns:
-        (rr_ms, records) where:
+        (rr_ms, records, parse_aborted) where:
         - rr_ms: list of RR intervals in milliseconds (from HRV messages)
         - records: list of dicts with timestamp_s, heart_rate, power, speed
+        - parse_aborted: True when ``FitParseError`` truncated the iteration
+          mid-file. Downstream post-processing uses this to mark the result
+          ``hrv_quality="poor"`` instead of storing DFA / thresholds derived
+          from a truncated RR tail as if they were clean.
     """
 
     if prev is None:
@@ -120,39 +125,72 @@ def _actor_process_fit_file(prev: str | None):
     rr_ms: list[float] = []
     records: list[dict] = []
     start_ts = None
+    parse_aborted = False
 
-    for msg in fit.get_messages():
-        msg_name = msg.name
-        if msg_name == "hrv":
-            for field in msg.fields:
-                if field.name == "time" and field.value is not None:
-                    values = field.value if isinstance(field.value, (list, tuple)) else [field.value]
-                    for v in values:
-                        if v is not None and v < 60.0:
-                            rr_ms.append(v * 1000.0)
-        elif msg_name == "record":
-            rec: dict[str, Any] = {}
-            for field in msg.fields:
-                if field.name == "timestamp" and field.value is not None:
-                    if start_ts is None:
-                        start_ts = field.value
-                    rec["timestamp_s"] = (field.value - start_ts).total_seconds()
-                elif field.name == "heart_rate":
-                    rec["heart_rate"] = field.value
-                elif field.name == "power":
-                    rec["power"] = field.value
-                elif field.name in ("speed", "enhanced_speed"):
-                    rec["speed"] = field.value
-            if "timestamp_s" in rec:
-                records.append(rec)
+    # fit.get_messages() is a generator — a single malformed dev_data field
+    # aborts the whole iteration with FitParseError (issue #250). Wrap the
+    # loop so we keep whatever's been parsed so far instead of losing the
+    # entire activity; bad dev fields typically appear late in the file
+    # (records + hrv arrive first), so partial data is usually sufficient.
+    try:
+        for msg in fit.get_messages():
+            msg_name = msg.name
+            if msg_name == "hrv":
+                for field in msg.fields:
+                    if field.name == "time" and field.value is not None:
+                        values = field.value if isinstance(field.value, (list, tuple)) else [field.value]
+                        for v in values:
+                            if v is not None and v < 60.0:
+                                rr_ms.append(v * 1000.0)
+            elif msg_name == "record":
+                rec: dict[str, Any] = {}
+                for field in msg.fields:
+                    if field.name == "timestamp" and field.value is not None:
+                        if start_ts is None:
+                            start_ts = field.value
+                        rec["timestamp_s"] = (field.value - start_ts).total_seconds()
+                    elif field.name == "heart_rate":
+                        rec["heart_rate"] = field.value
+                    elif field.name == "power":
+                        rec["power"] = field.value
+                    elif field.name in ("speed", "enhanced_speed"):
+                        rec["speed"] = field.value
+                if "timestamp_s" in rec:
+                    records.append(rec)
+    except FitParseError as e:
+        parse_aborted = True
+        # Log loud locally — we deliberately do NOT ``capture_exception`` per
+        # file (noisy: every Wahoo / third-party-field Garmin export would
+        # spam Sentry) but a fingerprinted message keeps a single grouped
+        # issue alive so we can watch for volume spikes that would signal a
+        # ``fitparse`` SDK regression or a new Garmin firmware drift.
+        logger.warning(
+            "FIT parse aborted mid-file for %s after %d records / %d rr values: %s",
+            prev,
+            len(records),
+            len(rr_ms),
+            e,
+        )
+        with sentry_sdk.new_scope() as scope:
+            scope.fingerprint = ["fit-parse-aborted"]
+            scope.set_tag("fit_parse_aborted", "true")
+            scope.set_extra("records_parsed", len(records))
+            scope.set_extra("rr_parsed", len(rr_ms))
+            scope.set_extra("fit_path", prev)
+            sentry_sdk.capture_message(f"FIT parse aborted: {e}", level="warning")
 
-    return rr_ms, records
+    # Tail ``parse_aborted`` on the return so ``_actor_post_process_fit_file``
+    # can degrade to ``hrv_quality="poor"`` rather than storing DFA /
+    # thresholds computed from a truncated RR series as if they were valid
+    # (issue #250 follow-up — see reviewer's warning on partial-data
+    # ambiguity).
+    return rr_ms, records, parse_aborted
 
 
 @dramatiq.actor(queue_name="default", time_limit=30 * 60 * 1000)
 @validate_call
 def _actor_post_process_fit_file(
-    parsed_fit_data: tuple[list[float], list[dict]] | None,
+    parsed_fit_data: tuple[list[float], list[dict], bool] | None,
     user: UserDTO,
     activity_id: str,
 ) -> FitProcessingResultDTO | None:
@@ -169,7 +207,18 @@ def _actor_post_process_fit_file(
             session=session,
         )
 
-    rr_ms, records = parsed_fit_data
+    rr_ms, records, parse_aborted = parsed_fit_data
+    # Parse-aborted short-circuit: a truncated RR series can pass the 300
+    # sample gate (e.g. 500 samples before dev-data field broke fitparse),
+    # but the DFA / threshold regression over that tail is unreliable —
+    # mark the whole result ``low_quality`` so post-activity notifications
+    # stay honest. ``count_active`` / upstream gates will still run.
+    if parse_aborted:
+        return FitProcessingResultDTO(
+            status="low_quality",
+            hrv_quality="poor",
+            rr_count=len(rr_ms),
+        ).model_dump()
     if len(rr_ms) < 300:  # < ~5 min of data
         status = "too_short" if rr_ms else "no_rr_data"
         return FitProcessingResultDTO(status=status, rr_count=len(rr_ms)).model_dump()

--- a/tests/test_card_renderer.py
+++ b/tests/test_card_renderer.py
@@ -312,6 +312,42 @@ class TestRenderWorkoutCard:
         result = render_workout_card(data)
         assert result[:8] == b"\x89PNG\r\n\x1a\n"
 
+    def test_latlng_with_none_values_filtered(self):
+        """Issue #249 regression: Intervals.icu GPS streams occasionally emit
+        ``(None, None)`` or ``(lat, None)`` sentinel samples from GPS dropouts
+        (tunnels, indoor segments). ``min()`` / ``max()`` crashed on mixed
+        ``float`` vs ``None`` comparison. Renderer must now filter those
+        points before bbox math and still produce a valid PNG.
+        """
+        data = WorkoutCardData(
+            sport_type="Run",
+            distance_m=5000.0,
+            duration_sec=1800,
+            latlng=[
+                (48.8566, 2.3522),
+                (48.8570, 2.3530),
+                (None, None),  # GPS dropout
+                (48.8575, None),  # half-populated sample
+                (None, 2.3540),
+                (48.8580, 2.3545),
+            ],
+        )
+        result = render_workout_card(data)
+        assert result[:8] == b"\x89PNG\r\n\x1a\n"
+
+    def test_latlng_all_none_falls_back_to_no_gps(self):
+        """All-None latlng must not crash and must render the no-GPS fallback
+        (sport emoji) the same way ``latlng=None`` does.
+        """
+        data = WorkoutCardData(
+            sport_type="Run",
+            distance_m=5000.0,
+            duration_sec=1800,
+            latlng=[(None, None), (None, None), (None, None)],
+        )
+        result = render_workout_card(data)
+        assert result[:8] == b"\x89PNG\r\n\x1a\n"
+
     def test_with_ai_text(self):
         data = WorkoutCardData(
             sport_type="Run",

--- a/tests/test_card_renderer.py
+++ b/tests/test_card_renderer.py
@@ -336,17 +336,23 @@ class TestRenderWorkoutCard:
         assert result[:8] == b"\x89PNG\r\n\x1a\n"
 
     def test_latlng_all_none_falls_back_to_no_gps(self):
-        """All-None latlng must not crash and must render the no-GPS fallback
-        (sport emoji) the same way ``latlng=None`` does.
+        """All-None latlng must render bit-for-bit identically to ``latlng=None``
+        — after filtering, neither has any drawable points, so the no-GPS
+        fallback (sport emoji) must kick in the same way.
         """
-        data = WorkoutCardData(
+        all_none_data = WorkoutCardData(
             sport_type="Run",
             distance_m=5000.0,
             duration_sec=1800,
             latlng=[(None, None), (None, None), (None, None)],
         )
-        result = render_workout_card(data)
-        assert result[:8] == b"\x89PNG\r\n\x1a\n"
+        no_gps_data = WorkoutCardData(
+            sport_type="Run",
+            distance_m=5000.0,
+            duration_sec=1800,
+            latlng=None,
+        )
+        assert render_workout_card(all_none_data) == render_workout_card(no_gps_data)
 
     def test_with_ai_text(self):
         data = WorkoutCardData(


### PR DESCRIPTION
Makes the activity pipeline resilient to two real-world failure modes that
currently crash downstream rendering / persistence.

## Changes

**`tasks/actors/activities.py` — FIT parse mid-file abort (#250)**
- `_actor_process_fit_file` wraps `fit.get_messages()` in `try/except FitParseError`.
  A single malformed dev_data field used to abort the whole iteration; we now
  keep whatever parsed before the break and tail a `parse_aborted` flag on the
  return tuple.
- Sentry captures a fingerprinted `warning` (not `exception`) so one grouped
  issue tracks volume without spamming. Sends `fit_filename` (basename) + parse
  counters — never the full path.
- `_actor_post_process_fit_file` short-circuits `parse_aborted=True` cases to
  `status="low_quality"` / `hrv_quality="poor"` so DFA / thresholds derived
  from a truncated RR tail aren't stored as clean data.
- Return annotation corrected to `dict[str, Any] | None` (function already
  returns `.model_dump()` on every branch — Dramatiq serializes between
  actors, downstream `@validate_call` re-hydrates).

**`data/card_renderer.py` — GPS dropout handling (#249)**
- `_render_polyline` filters `(None, None)` / `(lat, None)` samples before
  bbox math. Intervals.icu streams emit these during GPS dropouts (tunnels,
  indoor segments) and `min()` / `max()` crashed on mixed `float` vs `None`.
- `WorkoutCardData.latlng` widened to
  `list[tuple[float | None, float | None]] | None` to match the new contract.
- Caller counts valid points before deciding between polyline and emoji
  fallback — an all-`None` `latlng` now correctly falls through to the
  no-GPS sport-emoji rendering (was silently producing an empty track area).

**`tests/test_card_renderer.py`**
- Regression test for mixed `None` / valid samples.
- `test_latlng_all_none_falls_back_to_no_gps` asserts **byte-for-byte**
  equivalence with `latlng=None` to lock the fallback contract.

Relates to versions/multi-tenant
