### PR TITLE
Handles IntegrityError during wellness data save

### DIFF
--- a/data/db/wellness.py
+++ b/data/db/wellness.py
@@ -5,6 +5,7 @@ import logging
 from datetime import datetime
 
 from sqlalchemy import JSON, DateTime, Float, ForeignKey, Integer, String, Text, UniqueConstraint, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Mapped, mapped_column
 
 from data.intervals.dto import WellnessDTO
@@ -165,6 +166,17 @@ class Wellness(Base):
         return result.scalar_one_or_none()
 
     @classmethod
+    def _apply_intervals_fields(cls, row: "Wellness", wellness: WellnessDTO) -> None:
+        # Apply non-None Intervals.icu fields onto a wellness row. ``sport_info``
+        # is merged (not replaced) so locally-tracked sport CTL survives.
+        for field, val in wellness.intervals_dict().items():
+            if val is None:
+                continue
+            if field == "sport_info":
+                val = cls._merge_sport_info(row.sport_info, val)
+            setattr(row, field, val)
+
+    @classmethod
     @with_sync_session
     def save(
         cls,
@@ -176,8 +188,7 @@ class Wellness(Base):
 
         date_str = wellness.id
 
-        result = session.execute(select(cls).where(cls.user_id == user_id, cls.date == date_str))
-        row = result.scalar_one_or_none()
+        row = session.execute(select(cls).where(cls.user_id == user_id, cls.date == date_str)).scalar_one_or_none()
 
         is_new = row is None
         if is_new:
@@ -186,17 +197,34 @@ class Wellness(Base):
         elif row.updated == wellness.updated:
             return ORMDTO(is_new=False, is_changed=False, row=row)
 
-        for field, val in wellness.intervals_dict().items():
-            if val is None:
-                continue
-            if field == "sport_info":
-                val = cls._merge_sport_info(row.sport_info, val)
+        cls._apply_intervals_fields(row, wellness)
 
-            setattr(row, field, val)
+        try:
+            session.commit()
+        except IntegrityError as e:
+            # Narrow recovery to the specific (user_id, date) unique-violation
+            # race (issue #255): bootstrap chunk retries and WELLNESS_UPDATED
+            # webhooks can both try to create the same row. SQLSTATE 23505 +
+            # constraint name pins this to ``uq_wellness_user_date`` only —
+            # FK / CHECK / NOT NULL violations re-raise so real data defects
+            # still surface (otherwise ``scalar_one()`` below would mask them
+            # as ``NoResultFound``).
+            pgcode = getattr(e.orig, "pgcode", None)
+            constraint = getattr(getattr(e.orig, "diag", None), "constraint_name", None)
+            if pgcode != "23505" or constraint != "uq_wellness_user_date":
+                raise
+            session.rollback()
+            row = session.execute(select(cls).where(cls.user_id == user_id, cls.date == date_str)).scalar_one()
+            if row.updated == wellness.updated:
+                return ORMDTO(is_new=False, is_changed=False, row=row)
+            cls._apply_intervals_fields(row, wellness)
+            # Second commit is UPDATE-only: ``uq_wellness_user_date`` cannot
+            # fire on UPDATE (SQLSTATE 23505 is INSERT-time), so this commit
+            # doesn't need its own retry guard.
+            session.commit()
+            is_new = False
 
-        session.commit()
         session.refresh(row)
-
         return ORMDTO(is_new=is_new, is_changed=True, row=row)
 
     @classmethod

--- a/tasks/actors/activities.py
+++ b/tasks/actors/activities.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import anthropic
 import dramatiq
+import httpx
 import numpy as np
 import sentry_sdk
 from dramatiq import group, pipeline
@@ -73,6 +74,20 @@ def _actor_download_fit_file(
         try:
             with IntervalsSyncClient.for_user(user) as client:
                 fit_bytes = client.download_fit(activity_id)
+        except httpx.HTTPStatusError as e:
+            # Intervals.icu returns 422 for activities with no downloadable
+            # FIT file (Strava-source per licensing, manually-entered, or
+            # web-only entries — issue #256). Not a defect; skip with an
+            # info log (kept for volume tracking — Sentry capture is the
+            # part we drop). 404 already short-circuits to ``fit_bytes=None``
+            # in the client via ``handle_404=True``, so we only see real
+            # HTTP failures here — keep ``capture_exception`` for those.
+            if e.response.status_code == 422:
+                logger.info("No FIT available for activity %s (HTTP 422)", activity_id)
+                return
+            sentry_sdk.capture_exception(e)
+            logger.exception("Failed to download FIT file for activity %s", activity_id)
+            return
         except Exception as e:
             sentry_sdk.capture_exception(e)
             logger.exception("Failed to download FIT file for activity %s", activity_id)


### PR DESCRIPTION
Improves wellness data saving logic by handling IntegrityErrors:
- Introduces retry mechanism to re-fetch and update on unique constraint violation.
- Adds a helper method to encapsulate interval fields application.

Enhances activity file download in tasks:
- Catches specific HTTP 422 error when no downloadable FIT file is available, logging this scenario and avoiding unnecessary exceptions.

Addresses issues #255 and #256.