### PR TITLE
END-12: wire real Goal tab data + hide when no race

### DIFF
--- a/api/dashboard_routes.py
+++ b/api/dashboard_routes.py
@@ -185,11 +185,12 @@ async def dashboard(user: User = Depends(require_viewer)) -> dict:
     }
 
 
-# NOTE: The next three handlers are superseded at runtime by the real Load-tab
-# handlers in `api/routers/dashboard.py` (registered first in `api/server.py`).
-# `include_in_schema=False` keeps them out of OpenAPI so generated clients/docs
-# don't see two contradictory contracts for the same path. Removed entirely once
-# [END-12] / [END-13] cut over and the whole mock module is deleted.
+# NOTE: The next three handlers are superseded at runtime by the real Load /
+# Goal handlers in `api/routers/dashboard.py` (registered first in
+# `api/server.py`). `include_in_schema=False` keeps them out of OpenAPI so
+# generated clients/docs don't see two contradictory contracts for the same
+# path. Removed entirely once [END-13] cuts over and the whole mock module
+# is deleted.
 
 
 @router.get("/api/training-load", include_in_schema=False)
@@ -213,26 +214,6 @@ async def recovery_trend(days: int = Query(default=21, ge=1, le=90), user: User 
     if days >= 21:
         return _RECOVERY_21
     return {k: v[-days:] if isinstance(v, list) else v for k, v in _RECOVERY_21.items()}
-
-
-@router.get("/api/goal")
-async def goal(user: User = Depends(require_viewer)) -> dict:
-    """Race goal progress."""
-    return {
-        "event_name": "Ironman 70.3",
-        "event_date": "2026-09-15",
-        "weeks_remaining": 25,
-        "overall_pct": 63,
-        "swim_pct": 60,
-        "swim_ctl": 9.0,
-        "swim_target": 15,
-        "bike_pct": 72,
-        "bike_ctl": 25.2,
-        "bike_target": 35,
-        "run_pct": 55,
-        "run_ctl": 13.8,
-        "run_target": 25,
-    }
 
 
 @router.get("/api/weekly-summary")

--- a/api/routers/dashboard.py
+++ b/api/routers/dashboard.py
@@ -1,9 +1,10 @@
 """Dashboard API routes — real per-user data for the Mini App Dashboard.
 
 These handlers replace the seeded mocks in ``api/dashboard_routes.py`` for the
-**Load** tab. They are mounted *before* the mock router in ``api/server.py`` so
-FastAPI's first-match-wins routing picks the real handlers; the mock module
-keeps serving Goal/Week tabs until [END-12] / [END-13] cut over.
+**Load** and **Goal** tabs. They are mounted *before* the mock router in
+``api/server.py`` so FastAPI's first-match-wins routing picks the real
+handlers; the mock module keeps serving the Week tab until [END-13] cuts
+over.
 """
 
 import zoneinfo
@@ -14,8 +15,8 @@ from sqlalchemy import select
 
 from api.deps import get_data_user_id, require_viewer
 from config import settings
-from data.db import Activity, User, Wellness, get_session
-from data.utils import normalize_sport
+from data.db import Activity, AthleteGoal, User, Wellness, get_session
+from data.utils import extract_sport_ctl, normalize_sport
 
 router = APIRouter()
 
@@ -113,6 +114,82 @@ async def activities(
         out.append({"date": dt, "sport": sport, "tss": round(float(tss), 1)})
 
     return {"activities": out}
+
+
+@router.get("/api/goal")
+async def goal(user: User = Depends(require_viewer)) -> dict:
+    """Race goal progress for the Goal tab.
+
+    Returns ``{"has_goal": false}`` when the athlete has no active race —
+    the React Dashboard hides the Goal tab entirely in that case (per the
+    [END-12] scoping decision; we don't want to push users into a CTA they
+    didn't ask for, and the tab list is shorter and clearer with it gone).
+
+    When a goal exists, the response always includes the overall CTL bar
+    (``ctl_current`` / ``ctl_target`` / ``overall_pct``). Per-sport bars
+    are only included when ``per_sport_targets`` is set on the goal —
+    auto-splitting an overall target by canonical 70.3 ratios was rejected
+    because the per-sport mix varies too much between athletes to fake.
+    """
+    uid = get_data_user_id(user)
+    g = await AthleteGoal.get_goal_dto(uid)
+    if not g:
+        return {"has_goal": False}
+
+    today = _today_local()
+    days_remaining = (g.event_date - today).days
+    # Round toward zero so the day-of-event reads "0 weeks" rather than
+    # rounding up to "1 week to go" the morning of.
+    weeks_remaining = max(0, days_remaining // 7)
+
+    async with get_session() as session:
+        result = await session.execute(
+            select(Wellness)
+            .where(Wellness.user_id == uid, Wellness.ctl.isnot(None))
+            .order_by(Wellness.date.desc())
+            .limit(1)
+        )
+        row = result.scalar_one_or_none()
+
+    current_ctl = float(row.ctl) if row and row.ctl is not None else None
+    sport_ctl = extract_sport_ctl(row.sport_info) if row else {"swim": None, "ride": None, "run": None}
+    targets: dict = g.per_sport_targets or {}
+
+    overall_pct = (
+        round(current_ctl / g.ctl_target * 100)
+        if (current_ctl is not None and g.ctl_target)
+        else None
+    )
+
+    response: dict = {
+        "has_goal": True,
+        "event_name": g.event_name,
+        "event_date": str(g.event_date),
+        "weeks_remaining": weeks_remaining,
+        "days_remaining": days_remaining,
+        "ctl_current": round(current_ctl, 1) if current_ctl is not None else None,
+        "ctl_target": g.ctl_target,
+        "overall_pct": overall_pct,
+    }
+
+    # Per-sport bars: only emit sports that actually have a target. A sport
+    # with target=0 or missing is treated as "not part of this race plan"
+    # and dropped, not rendered as 0% (which would look like a regression).
+    per_sport: dict[str, dict] = {}
+    for sport in ("swim", "ride", "run"):
+        target = targets.get(sport)
+        if not target or target <= 0:
+            continue
+        cur = sport_ctl.get(sport)
+        per_sport[sport] = {
+            "ctl_current": round(cur, 1) if cur is not None else None,
+            "ctl_target": target,
+            "pct": round(cur / target * 100) if cur is not None else None,
+        }
+    if per_sport:
+        response["per_sport"] = per_sport
+
+    return response
 
 
 @router.get("/api/recovery-trend")

--- a/api/routers/dashboard.py
+++ b/api/routers/dashboard.py
@@ -43,8 +43,9 @@ async def training_load(
     """CTL/ATL/TSB time series from the user's wellness rows.
 
     Per-sport CTL keys (``ctl_swim`` / ``ctl_ride`` / ``ctl_run``) are
-    intentionally omitted here — GoalTab consumes them and is wired up in
-    [END-12].
+    intentionally omitted: GoalTab takes the latest snapshot from
+    ``wellness.sport_info``, not a time series — re-add only if a future
+    tab needs the 84d trend.
     """
     today = _today_local()
     start = today - timedelta(days=days - 1)
@@ -137,9 +138,11 @@ async def goal(user: User = Depends(require_viewer)) -> dict:
         return {"has_goal": False}
 
     today = _today_local()
-    days_remaining = (g.event_date - today).days
-    # Round toward zero so the day-of-event reads "0 weeks" rather than
-    # rounding up to "1 week to go" the morning of.
+    # Clamp both to 0 if the athlete forgot to deactivate a past goal — a
+    # negative "days_remaining" in the JSON is misleading. Floor-divide
+    # before clamping so day-of-event reads "0 weeks" instead of rounding
+    # up to "1 week to go" the morning of.
+    days_remaining = max(0, (g.event_date - today).days)
     weeks_remaining = max(0, days_remaining // 7)
 
     async with get_session() as session:

--- a/tests/api/test_dashboard.py
+++ b/tests/api/test_dashboard.py
@@ -513,6 +513,19 @@ class TestGoal:
         assert data["weeks_remaining"] == 0
         assert data["days_remaining"] == 0
 
+    async def test_past_race_clamps_to_zero(self, client):
+        """Athlete forgot to deactivate a past goal — both counters clamp to 0
+        rather than returning a negative `days_remaining` in the JSON."""
+        await _seed_goal(1, event_date=_FIXED_TODAY - timedelta(days=10), ctl_target=80.0)
+        await _seed_wellness(1, _FIXED_TODAY, ctl=70.0, atl=55.0)
+
+        async with client as c:
+            resp = await c.get("/api/goal")
+
+        data = resp.json()
+        assert data["weeks_remaining"] == 0
+        assert data["days_remaining"] == 0
+
     async def test_no_wellness_yet(self, client):
         """Brand-new athlete with a goal but no wellness rows yet renders an
         empty bar instead of crashing the endpoint."""

--- a/tests/api/test_dashboard.py
+++ b/tests/api/test_dashboard.py
@@ -1,6 +1,6 @@
-"""Smoke tests for the real Load-tab endpoints (END-14).
+"""Smoke tests for the real Load- and Goal-tab endpoints (END-12, END-14).
 
-We only validate the contract the React Load tab depends on:
+We only validate the contract the React Dashboard depends on:
 - shape of the response,
 - date window respected,
 - filtering rules (NULL TSS dropped, non-bucketable sports dropped),
@@ -16,7 +16,7 @@ from httpx import ASGITransport, AsyncClient
 
 from api.deps import require_viewer
 from api.routers.dashboard import router as dashboard_router
-from data.db import Activity, User, Wellness, get_session
+from data.db import Activity, AthleteGoal, User, Wellness, get_session
 from data.intervals.dto import ActivityDTO
 
 
@@ -349,3 +349,192 @@ class TestRecoveryTrend:
             resp = await c.get("/api/recovery-trend?days=21")
 
         assert resp.json() == {"dates": [], "recovery": [], "hrv": []}
+
+
+# ---------------------------------------------------------------------------
+# /api/goal
+# ---------------------------------------------------------------------------
+
+
+async def _seed_goal(
+    user_id: int,
+    *,
+    event_date: date,
+    ctl_target: float | None = 75.0,
+    per_sport_targets: dict | None = None,
+    event_name: str = "Ironman 70.3",
+    category: str = "RACE_A",
+) -> None:
+    async with get_session() as session:
+        session.add(
+            AthleteGoal(
+                user_id=user_id,
+                category=category,
+                event_name=event_name,
+                event_date=event_date,
+                sport_type="triathlon",
+                ctl_target=ctl_target,
+                per_sport_targets=per_sport_targets,
+                is_active=True,
+            )
+        )
+        await session.commit()
+
+
+async def _seed_wellness_with_sport_ctl(
+    user_id: int,
+    dt: date,
+    *,
+    ctl: float,
+    sport_info: list[dict],
+) -> None:
+    async with get_session() as session:
+        session.add(
+            Wellness(
+                user_id=user_id,
+                date=dt.isoformat(),
+                ctl=ctl,
+                atl=ctl,  # value irrelevant, just satisfy NOT NULL constraints
+                sport_info=sport_info,
+                updated=datetime.now(timezone.utc),
+            )
+        )
+        await session.commit()
+
+
+class TestGoal:
+    async def test_no_goal_returns_has_goal_false(self, client):
+        async with client as c:
+            resp = await c.get("/api/goal")
+
+        assert resp.status_code == 200
+        assert resp.json() == {"has_goal": False}
+
+    async def test_goal_without_per_sport_targets(self, client):
+        """Athlete with overall target only — single overall bar, no per_sport block."""
+        await _seed_goal(1, event_date=_FIXED_TODAY + timedelta(days=70), ctl_target=80.0)
+        await _seed_wellness(1, _FIXED_TODAY, ctl=60.0, atl=55.0)
+
+        async with client as c:
+            resp = await c.get("/api/goal")
+
+        data = resp.json()
+        assert data["has_goal"] is True
+        assert data["event_name"] == "Ironman 70.3"
+        assert data["weeks_remaining"] == 10  # 70 // 7
+        assert data["days_remaining"] == 70
+        assert data["ctl_current"] == 60.0
+        assert data["ctl_target"] == 80.0
+        assert data["overall_pct"] == 75  # 60/80 * 100
+        # Per-sport block must be omitted when targets are absent (END-12 scoping
+        # decision — don't fake bars from canonical 70.3 ratios).
+        assert "per_sport" not in data
+
+    async def test_goal_with_per_sport_targets(self, client):
+        await _seed_goal(
+            1,
+            event_date=_FIXED_TODAY + timedelta(days=84),
+            ctl_target=80.0,
+            per_sport_targets={"swim": 15.0, "ride": 35.0, "run": 25.0},
+        )
+        await _seed_wellness_with_sport_ctl(
+            1,
+            _FIXED_TODAY,
+            ctl=60.0,
+            sport_info=[
+                {"type": "Swim", "ctl": 12.0},
+                {"type": "Ride", "ctl": 28.0},
+                {"type": "Run", "ctl": 20.0},
+            ],
+        )
+
+        async with client as c:
+            resp = await c.get("/api/goal")
+
+        data = resp.json()
+        assert data["has_goal"] is True
+        assert data["weeks_remaining"] == 12
+        assert data["per_sport"] == {
+            "swim": {"ctl_current": 12.0, "ctl_target": 15.0, "pct": 80},
+            "ride": {"ctl_current": 28.0, "ctl_target": 35.0, "pct": 80},
+            "run": {"ctl_current": 20.0, "ctl_target": 25.0, "pct": 80},
+        }
+
+    async def test_per_sport_drops_sports_without_target(self, client):
+        """A target=0 or missing entry means "not part of this race plan" — drop, don't render 0%."""
+        await _seed_goal(
+            1,
+            event_date=_FIXED_TODAY + timedelta(days=42),
+            ctl_target=50.0,
+            per_sport_targets={"run": 25.0, "swim": 0.0},  # ride missing, swim zeroed
+        )
+        await _seed_wellness_with_sport_ctl(
+            1,
+            _FIXED_TODAY,
+            ctl=40.0,
+            sport_info=[
+                {"type": "Swim", "ctl": 5.0},
+                {"type": "Ride", "ctl": 22.0},
+                {"type": "Run", "ctl": 18.0},
+            ],
+        )
+
+        async with client as c:
+            resp = await c.get("/api/goal")
+
+        data = resp.json()
+        assert "per_sport" in data
+        assert set(data["per_sport"].keys()) == {"run"}
+        assert data["per_sport"]["run"]["pct"] == 72  # 18 / 25
+
+    async def test_overall_pct_handles_missing_target(self, client):
+        """Athlete set the race but never set a CTL target — overall_pct must be null, not /0."""
+        await _seed_goal(1, event_date=_FIXED_TODAY + timedelta(days=21), ctl_target=None)
+        await _seed_wellness(1, _FIXED_TODAY, ctl=60.0, atl=55.0)
+
+        async with client as c:
+            resp = await c.get("/api/goal")
+
+        data = resp.json()
+        assert data["has_goal"] is True
+        assert data["ctl_target"] is None
+        assert data["overall_pct"] is None
+        assert data["ctl_current"] == 60.0
+
+    async def test_zero_weeks_remaining_on_race_day(self, client):
+        """Day-of-event reads "0 weeks", not rounded up to 1."""
+        await _seed_goal(1, event_date=_FIXED_TODAY, ctl_target=80.0)
+        await _seed_wellness(1, _FIXED_TODAY, ctl=70.0, atl=55.0)
+
+        async with client as c:
+            resp = await c.get("/api/goal")
+
+        data = resp.json()
+        assert data["weeks_remaining"] == 0
+        assert data["days_remaining"] == 0
+
+    async def test_no_wellness_yet(self, client):
+        """Brand-new athlete with a goal but no wellness rows yet renders an
+        empty bar instead of crashing the endpoint."""
+        await _seed_goal(1, event_date=_FIXED_TODAY + timedelta(days=30), ctl_target=80.0)
+
+        async with client as c:
+            resp = await c.get("/api/goal")
+
+        data = resp.json()
+        assert data["has_goal"] is True
+        assert data["ctl_current"] is None
+        assert data["overall_pct"] is None
+
+    async def test_per_user_scoping(self, client):
+        """Goal for another user must not leak into the response."""
+        async with get_session() as session:
+            session.add(User(id=2, chat_id="other_user", role="athlete"))
+            await session.commit()
+        await _seed_goal(2, event_date=_FIXED_TODAY + timedelta(days=14), ctl_target=90.0)
+
+        async with client as c:
+            resp = await c.get("/api/goal")
+
+        # User 1 has no goal of their own; user 2's must not leak through
+        assert resp.json() == {"has_goal": False}

--- a/webapp/src/api/types.ts
+++ b/webapp/src/api/types.ts
@@ -11,6 +11,14 @@ export interface IntervalsStatus {
   scope: string | null
 }
 
+export interface AuthMeGoal {
+  id?: number | null
+  event_name: string
+  event_date: string
+  ctl_target?: number | null
+  per_sport_targets?: { swim?: number; ride?: number; run?: number } | null
+}
+
 export interface AuthMeResponse {
   role: 'owner' | 'viewer' | 'demo' | 'anonymous'
   authenticated: boolean
@@ -22,6 +30,9 @@ export interface AuthMeResponse {
   // until this flips true.
   bot_chat_initialized?: boolean
   bot_username?: string | null
+  // Goal block: null when athlete has no active race. Dashboard hides the
+  // Goal tab entirely in that case (END-12 scoping).
+  goal?: AuthMeGoal | null
 }
 
 // Recovery
@@ -313,30 +324,40 @@ export interface TrainingLoadSeries {
   ctl: number[]
   atl: number[]
   tsb: number[]
-  ctl_swim: number[]
-  ctl_ride: number[]
-  ctl_run: number[]
 }
 
 export interface ActivitiesSeries {
   activities: { date: string; sport: string; tss: number }[]
 }
 
-export interface GoalResponse {
-  event_name: string
-  event_date: string
-  weeks_remaining: number
-  overall_pct: number
-  swim_pct: number
-  swim_ctl: number
-  swim_target: number
-  bike_pct: number
-  bike_ctl: number
-  bike_target: number
-  run_pct: number
-  run_ctl: number
-  run_target: number
+export interface GoalSportProgress {
+  ctl_current: number | null
+  ctl_target: number
+  pct: number | null
 }
+
+// Discriminated union: ``has_goal: false`` means the athlete has no active
+// race and the Goal tab is hidden. ``has_goal: true`` always carries the
+// overall CTL bar fields; ``per_sport`` is only present when
+// ``per_sport_targets`` is set on the AthleteGoal (END-12 scoping decision —
+// don't fake per-sport bars from a single overall target).
+export type GoalResponse =
+  | { has_goal: false }
+  | {
+      has_goal: true
+      event_name: string
+      event_date: string
+      weeks_remaining: number
+      days_remaining: number
+      ctl_current: number | null
+      ctl_target: number | null
+      overall_pct: number | null
+      per_sport?: {
+        swim?: GoalSportProgress
+        ride?: GoalSportProgress
+        run?: GoalSportProgress
+      }
+    }
 
 export interface WeeklySummary {
   week_start: string

--- a/webapp/src/pages/Dashboard.tsx
+++ b/webapp/src/pages/Dashboard.tsx
@@ -5,13 +5,12 @@ import Layout from '../components/Layout'
 import LoadingSpinner from '../components/LoadingSpinner'
 import ErrorMessage from '../components/ErrorMessage'
 import { apiFetch } from '../api/client'
-import { CHART_COLORS } from '../lib/constants'
-import type { TrainingLoadSeries, ActivitiesSeries, GoalResponse, WeeklySummary, ScheduledList, RecoveryTrendSeries } from '../api/types'
+import { CHART_COLORS, SPORT_ICONS } from '../lib/constants'
+import type { AuthMeResponse, TrainingLoadSeries, ActivitiesSeries, GoalResponse, WeeklySummary, ScheduledList, RecoveryTrendSeries } from '../api/types'
 
 Chart.register(...registerables)
 
-const TABS = ['load', 'goal', 'week'] as const
-type TabKey = typeof TABS[number]
+type TabKey = 'load' | 'goal' | 'week'
 
 const TAB_LABELS: Record<TabKey, string> = {
   load: 'Load',
@@ -21,12 +20,29 @@ const TAB_LABELS: Record<TabKey, string> = {
 
 export default function Dashboard() {
   const [activeTab, setActiveTab] = useState<TabKey>('load')
+  // null = still loading, true/false = known. We optimistically render all
+  // three tabs while loading so the common case (race set) doesn't flicker
+  // a missing tab in for a frame; if the athlete turns out to have no goal
+  // we drop the Goal tab and bounce them back to Load.
+  const [hasGoal, setHasGoal] = useState<boolean | null>(null)
+
+  useEffect(() => {
+    apiFetch<AuthMeResponse>('/api/auth/me')
+      .then(data => setHasGoal(!!data.goal))
+      .catch(() => setHasGoal(null))
+  }, [])
+
+  useEffect(() => {
+    if (hasGoal === false && activeTab === 'goal') setActiveTab('load')
+  }, [hasGoal, activeTab])
+
+  const tabs: TabKey[] = hasGoal === false ? ['load', 'week'] : ['load', 'goal', 'week']
 
   return (
     <Layout maxWidth="480px">
       {/* Sticky Tabs */}
       <div className="flex gap-1 py-3 sticky top-0 bg-bg z-10">
-        {TABS.map(tab => (
+        {tabs.map(tab => (
           <button
             key={tab}
             onClick={() => setActiveTab(tab)}
@@ -195,63 +211,117 @@ function LoadTab() {
   )
 }
 
+// Sport key → display label + emoji + color. Reuses CHART_COLORS so the
+// Goal-tab bars match the Load-tab TSS chart, and SPORT_ICONS so the
+// vocabulary lines up with the bot (END-12 visuals decision).
+const SPORT_META: Record<'swim' | 'ride' | 'run', { label: string; emoji: string; color: string }> = {
+  swim: { label: 'Swim', emoji: SPORT_ICONS.Swim, color: CHART_COLORS.swim },
+  ride: { label: 'Ride', emoji: SPORT_ICONS.Ride, color: CHART_COLORS.ride },
+  run: { label: 'Run', emoji: SPORT_ICONS.Run, color: CHART_COLORS.run },
+}
+
+function ProgressBar({
+  label,
+  current,
+  target,
+  pct,
+  color,
+}: {
+  label: React.ReactNode
+  current: number | null
+  target: number | null
+  pct: number | null
+  color: string
+}) {
+  // Bar fill is clamped to 100% so an over-target athlete (pct > 100) doesn't
+  // overflow the row, but the numeric pct is shown as-is so they can see the
+  // overshoot. A null pct (no target or no current CTL) renders an empty bar
+  // and "—" instead of a misleading 0%.
+  const fill = pct === null ? 0 : Math.min(100, Math.max(0, pct))
+  return (
+    <div className="flex items-center gap-2 mb-2">
+      <span className="w-[60px] text-[13px] font-semibold">{label}</span>
+      <div className="flex-1 h-2.5 bg-bg rounded-full overflow-hidden">
+        <div
+          className="h-full rounded-full transition-[width] duration-500"
+          style={{ width: `${fill}%`, background: color }}
+        />
+      </div>
+      <span className="w-12 text-[13px] text-right tabular-nums">
+        {pct === null ? '—' : `${pct}%`}
+      </span>
+      <span className="w-16 text-[11px] text-right text-text-dim tabular-nums">
+        {current === null ? '—' : current.toFixed(0)}
+        {target !== null ? ` / ${Math.round(target)}` : ''}
+      </span>
+    </div>
+  )
+}
+
 function GoalTab() {
-  const chartRef = useRef<HTMLCanvasElement>(null)
-  const chartInstRef = useRef<Chart | null>(null)
   const [goal, setGoal] = useState<GoalResponse | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
-    Promise.all([
-      apiFetch<GoalResponse>('/api/goal'),
-      apiFetch<TrainingLoadSeries>('/api/training-load?days=84'),
-    ]).then(([goalData, loadData]) => {
-      setGoal(goalData)
-      if (chartRef.current && loadData.dates?.length) {
-        chartInstRef.current?.destroy()
-        const labels = loadData.dates.map(d => { const p = d.split('-'); return `${p[1]}/${p[2]}` })
-        chartInstRef.current = new Chart(chartRef.current, {
-          type: 'line',
-          data: {
-            labels,
-            datasets: [
-              { label: 'Swim CTL', data: loadData.ctl_swim || [], borderColor: CHART_COLORS.swim, tension: 0.3, pointRadius: 0, borderWidth: 2 },
-              { label: 'Ride CTL', data: loadData.ctl_ride || [], borderColor: CHART_COLORS.ride, tension: 0.3, pointRadius: 0, borderWidth: 2 },
-              { label: 'Run CTL', data: loadData.ctl_run || [], borderColor: CHART_COLORS.run, tension: 0.3, pointRadius: 0, borderWidth: 2 },
-            ],
-          },
-          options: chartOptions('CTL by Sport'),
-        })
-      }
-    }).catch(err => setError(err instanceof Error ? err.message : 'Failed to load')).finally(() => setLoading(false))
-
-    return () => { chartInstRef.current?.destroy() }
+    apiFetch<GoalResponse>('/api/goal')
+      .then(setGoal)
+      .catch(err => setError(err instanceof Error ? err.message : 'Failed to load'))
+      .finally(() => setLoading(false))
   }, [])
 
   if (loading) return <LoadingSpinner />
   if (error) return <ErrorMessage message={error} />
-  if (!goal) return <div className="text-center py-6 text-text-dim">No goal data.</div>
+  // The Dashboard shell already hides the Goal tab when the athlete has no
+  // race, so we should never actually hit `has_goal: false` here. Keep a
+  // lightweight fallback in case the two fetches race (Dashboard reads
+  // /api/auth/me, GoalTab reads /api/goal — the goal could be deleted
+  // between the two).
+  if (!goal || !goal.has_goal) {
+    return <div className="text-center py-6 text-text-dim">No race set.</div>
+  }
 
   return (
     <>
       <div className="text-center py-4 text-xl font-bold">
         <span className="text-[var(--button)]">{goal.weeks_remaining}</span> weeks to {goal.event_name}
       </div>
-      {(['swim', 'bike', 'run'] as const).map(sport => {
-        const pct = goal[`${sport}_pct`]
-        const colors: Record<string, string> = { swim: '#3b82f6', bike: '#22c55e', run: '#f59e0b' }
-        return (
-          <div key={sport} className="flex items-center gap-2 mb-2">
-            <span className="w-[50px] text-[13px] font-semibold capitalize">{sport}</span>
-            <div className="flex-1 h-2.5 bg-bg rounded-full overflow-hidden">
-              <div className="h-full rounded-full transition-[width] duration-500" style={{ width: `${Math.min(100, pct)}%`, background: colors[sport] }} />
-            </div>
-            <span className="w-10 text-[13px] text-right">{pct.toFixed(0)}%</span>
+
+      <div className="bg-[var(--surface)] rounded-xl p-3 mb-3">
+        <ProgressBar
+          label={<span>Overall CTL</span>}
+          current={goal.ctl_current}
+          target={goal.ctl_target}
+          pct={goal.overall_pct}
+          color={CHART_COLORS.ctl}
+        />
+
+        {goal.per_sport && (
+          <div className="mt-3 pt-3 border-t border-bg">
+            {(['swim', 'ride', 'run'] as const).map(sport => {
+              const block = goal.per_sport?.[sport]
+              if (!block) return null
+              const meta = SPORT_META[sport]
+              return (
+                <ProgressBar
+                  key={sport}
+                  label={<span>{meta.emoji} {meta.label}</span>}
+                  current={block.ctl_current}
+                  target={block.ctl_target}
+                  pct={block.pct}
+                  color={meta.color}
+                />
+              )
+            })}
           </div>
-        )
-      })}
-      <ChartContainer><canvas ref={chartRef} /></ChartContainer>
+        )}
+
+        {!goal.per_sport && goal.ctl_target && (
+          <div className="text-[11px] text-text-dim mt-3 pt-3 border-t border-bg">
+            Set per-sport CTL targets in Settings to see swim / ride / run progress.
+          </div>
+        )}
+      </div>
     </>
   )
 }

--- a/webapp/src/pages/Dashboard.tsx
+++ b/webapp/src/pages/Dashboard.tsx
@@ -240,7 +240,7 @@ function ProgressBar({
   const fill = pct === null ? 0 : Math.min(100, Math.max(0, pct))
   return (
     <div className="flex items-center gap-2 mb-2">
-      <span className="w-[60px] text-[13px] font-semibold">{label}</span>
+      <span className="w-[72px] text-[13px] font-semibold">{label}</span>
       <div className="flex-1 h-2.5 bg-bg rounded-full overflow-hidden">
         <div
           className="h-full rounded-full transition-[width] duration-500"


### PR DESCRIPTION
The Dashboard Goal tab was rendering hardcoded Ironman 70.3 mock data for every athlete. Replace the mock with a real per-user endpoint, and hide the tab entirely when the athlete has no active race (per CEO scoping).

Backend
- New ``GET /api/goal`` in ``api/routers/dashboard.py``. Returns ``{has_goal: false}`` for athletes without an active race; otherwise returns the overall CTL bar (current vs ``ctl_target``) and a ``per_sport`` block only when ``per_sport_targets`` is set on the goal.
- Per-sport CTL is read from ``wellness.sport_info`` via the existing ``extract_sport_ctl`` helper (already populated daily by ``_actor_enrich_wellness_sport_info``), so no new aggregation pipeline.
- Drops the mock ``/api/goal`` from ``api/dashboard_routes.py``.

Frontend
- ``Dashboard`` fetches ``/api/auth/me`` once on mount; if ``goal`` is null the Goal tab is hidden and an active "goal" tab falls back to Load. While loading we optimistically render all three tabs so the common case (race set) doesn't flicker.
- ``GoalTab`` consumes the new endpoint shape: header weeks-to-event, one overall CTL bar (always), three per-sport bars (only when ``per_sport_targets`` is set). Reuses ``CHART_COLORS`` + ``SPORT_ICONS`` for visual continuity with the Load tab and bot vocabulary.
- The 84-day "CTL by Sport" line chart is dropped from MVP; it required a per-sport CTL time-series backend that nobody has asked for.
- ``GoalResponse`` reshaped into a discriminated union; ``ctl_swim`` / ``ctl_ride`` / ``ctl_run`` removed from ``TrainingLoadSeries`` (they were never populated by the real Load endpoint).

Tests
- ``tests/api/test_dashboard.py::TestGoal`` covers no-goal, overall-only, per-sport, target=0 dropping, missing target, zero-weeks day-of-event, no-wellness, and per-user scoping.

CEO scoping decisions captured in ``ask_user_questions`` interaction on [END-12](/END/issues/END-12).