### PR TITLE
END-70: log corridor-unparseable skips in race-plan validator

### DIFF
--- a/mcp_server/tools/races.py
+++ b/mcp_server/tools/races.py
@@ -832,7 +832,12 @@ def _parse_corridor_value(s: Any) -> tuple[float, str] | None:
     return None
 
 
-def _validate_race_plan(plan: dict[str, Any], *, athlete_max_hr: int | None) -> list[str]:
+def _validate_race_plan(
+    plan: dict[str, Any],
+    *,
+    athlete_max_hr: int | None,
+    goal_id: int | None = None,
+) -> list[str]:
     """Defensive post-generation checks the JSON schema can't enforce.
 
     Returns a list of human-readable error strings (empty == valid). Used to
@@ -848,7 +853,31 @@ def _validate_race_plan(plan: dict[str, Any], *, athlete_max_hr: int | None) -> 
 
         # Corridor ordering: low < target < cap in effort space.
         pacing = leg.get("pacing") or {}
-        parsed = [_parse_corridor_value(pacing.get(k)) for k in ("low", "target", "cap")]
+        fields = ("low", "target", "cap")
+        raw_values = [pacing.get(k) for k in fields]
+        parsed = [_parse_corridor_value(v) for v in raw_values]
+
+        # Instrument the silent skip-on-unparseable path so we can eyeball how
+        # often the model emits qualitative pacing labels ("easy", "tempo")
+        # instead of numeric corridors. If the rate trends >5% of plans we
+        # tighten the prompt or convert this validator to reject (END-70).
+        for field, raw, p in zip(fields, raw_values, parsed):
+            if p is None:
+                logger.info(
+                    "race_plan.corridor_unparseable goal_id=%s leg=%r field=%s value=%r",
+                    goal_id,
+                    leg_name,
+                    field,
+                    raw,
+                    extra={
+                        "race_plan_corridor_unparseable": True,
+                        "goal_id": goal_id,
+                        "leg": leg_name,
+                        "field": field,
+                        "value": raw,
+                    },
+                )
+
         if all(p is not None for p in parsed):
             units = {u for _, u in parsed}  # type: ignore[misc]
             if len(units) == 1:
@@ -1073,7 +1102,11 @@ async def generate_race_plan(goal_id: int | None = None, dry_run: bool = False) 
     # Defensive post-generation pass — schema can't enforce per-athlete HR or
     # corridor monotonicity. Refuse persistence on validation failure so we
     # don't ship a nonsensical plan to the athlete.
-    validation_errors = _validate_race_plan(plan_input, athlete_max_hr=_athlete_max_hr(zones_rows))
+    validation_errors = _validate_race_plan(
+        plan_input,
+        athlete_max_hr=_athlete_max_hr(zones_rows),
+        goal_id=goal.id,
+    )
     if validation_errors:
         logger.warning(
             "generate_race_plan: validation rejected plan for user %d, goal %d: %s",

--- a/tests/mcp/test_races.py
+++ b/tests/mcp/test_races.py
@@ -721,3 +721,48 @@ class TestGenerateRacePlanValidator:
         plan["legs"][0]["pacing"] = {"low": "easy", "target": "tempo", "cap": "threshold"}
         errors = _validate_race_plan(plan, athlete_max_hr=190)
         assert errors == []
+
+    def test_logs_unparseable_corridor_fields(self, caplog):
+        """END-70: every unparseable leg/field combo emits a structured log
+        tagged with goal_id, leg, field, value so we can eyeball the rate of
+        qualitative pacing labels after dog-food races land.
+        """
+        import logging
+
+        from mcp_server.tools.races import _validate_race_plan
+
+        plan = _valid_plan_input()
+        plan["legs"][0]["leg"] = "run"
+        plan["legs"][0]["pacing"] = {"low": "easy", "target": "tempo", "cap": "5:00/km"}
+
+        with caplog.at_level(logging.INFO, logger="mcp_server.tools.races"):
+            errors = _validate_race_plan(plan, athlete_max_hr=190, goal_id=42)
+
+        assert errors == []
+        skip_records = [
+            r for r in caplog.records if getattr(r, "race_plan_corridor_unparseable", False)
+        ]
+        # Two unparseable fields (low="easy", target="tempo"); cap="5:00/km" parses.
+        assert len(skip_records) == 2
+        fields_logged = {(r.leg, r.field, r.value) for r in skip_records}
+        assert fields_logged == {("run", "low", "easy"), ("run", "target", "tempo")}
+        for r in skip_records:
+            assert r.goal_id == 42
+
+    def test_unparseable_log_tolerates_missing_goal_id(self, caplog):
+        """goal_id is optional — older callers (or tests) shouldn't crash."""
+        import logging
+
+        from mcp_server.tools.races import _validate_race_plan
+
+        plan = _valid_plan_input()
+        plan["legs"][0]["pacing"] = {"low": "easy", "target": "tempo", "cap": "threshold"}
+
+        with caplog.at_level(logging.INFO, logger="mcp_server.tools.races"):
+            _validate_race_plan(plan, athlete_max_hr=190)
+
+        skip_records = [
+            r for r in caplog.records if getattr(r, "race_plan_corridor_unparseable", False)
+        ]
+        assert len(skip_records) == 3
+        assert all(r.goal_id is None for r in skip_records)


### PR DESCRIPTION
Non-blocking follow-up from CTO sign-off on [END-63](https://github.com/radikkhaziev/triathlon-agent/pull/287).

## Summary

- Instrument `_validate_race_plan` so every leg where `_parse_corridor_value` returns `None` emits a structured `logger.info` tagged with `goal_id`, `leg`, `field`, and the raw `value`.
- One log per unparseable field — qualitative-label triplets like `{"easy", "tempo", "threshold"}` produce three records, one per field — so we can see which slots the model gravitates toward.
- Threading: `_validate_race_plan(plan, *, athlete_max_hr, goal_id=None)`. `goal_id` is keyword-only and optional so existing tests/callers still compile; the production caller in `generate_race_plan` passes `goal.id`.
- Behavior is otherwise unchanged: the silent skip stays the V0 default, the inverted-corridor reject is preserved, and fully parseable plans emit no logs.

## Why

CTO sign-off on END-63 flagged this skip as a "silent escape hatch if the model starts trending qualitative." After 2-3 weeks of dog-food races we eyeball the rate: if <5% of plans, the trade-off stays as-is; if >5%, we either tighten the prompt to forbid qualitative labels (preferred) or flip the validator to reject.

## Verification

Pure unit-test change. New tests in `TestGenerateRacePlanValidator`:
- `test_logs_unparseable_corridor_fields` — asserts per-field logging tagged with `goal_id`, `leg`, `field`, `value` (mixed parseable + unparseable corridor → 2 logs, no errors).
- `test_unparseable_log_tolerates_missing_goal_id` — locks in the optional `goal_id` contract so older test callers don't break.

Sanity-checked locally with a captured logger:
- mixed parseable + unparseable → 2 logs, no errors
- all-unparseable + omitted goal_id → 3 logs, all `goal_id=None`, no errors
- fully parseable, valid corridor → 0 logs, 0 errors
- inverted parseable corridor → still rejects ("corridor not low<target<cap")

(CI runs the full pytest suite against the test database; local `pytest` requires a Postgres test DB I don't have wired here, so the validator tests were exercised directly via `_validate_race_plan(...)`.)

## Follow-up

Per the END-70 acceptance, I'll re-open the issue thread after the first 1-2 dog-food races and post the observed rate. Trigger to revisit is END-62 V0 landing in front of the first athletes.

Co-Authored-By: Paperclip <noreply@paperclip.ing>