### PR TITLE
END-69: cap fueling envelope at 100 g/hr

### DIFF
--- a/mcp_server/tools/races.py
+++ b/mcp_server/tools/races.py
@@ -671,8 +671,8 @@ _RACE_PLAN_SCHEMA: dict[str, Any] = {
                 "carbs_g_per_hour": {
                     "type": "integer",
                     "minimum": 30,
-                    "maximum": 120,
-                    "description": "Target carb intake g/hr. Conservative band 60-90 unless gut-trained.",
+                    "maximum": 100,
+                    "description": "Target carb intake g/hr. Conservative band 60-90; ceiling 100 reserves headroom for the gut-trained athlete.",
                 },
                 "fluid_ml_per_hour": {"type": "integer"},
                 "sodium_mg_per_hour": {"type": "integer"},


### PR DESCRIPTION
## Summary

Smallest-fix follow-up from the [END-69](/END/issues/END-69) thread. Tightens the `fueling.carbs_g_per_hour` cap in the race-plan tool schema from **120 → 100**.

## Why

The prompt's rule #3 already says "60-90 g/hr unless the athlete has explicit higher gut-training evidence in the activity log," but the schema does not enforce that gate. Today the model can structurally emit `carbs_g_per_hour: 110` for a recreational triathlete — real GI-distress territory for an untrained gut, and the kind of mistake we cannot recover from on race morning.

This is option 1 from the issue thread:

- Conservative band stays 60–90 (prompt-driven).
- 90–100 is preserved as headroom for the rare gut-trained athlete.
- 100–120 is bounded out at the schema until we capture an explicit attestation of gut-training (options 2 / 3 — both need data we don't have yet).

## Trigger to revisit

After the first 1–2 dog-food race plans, check whether the model overshoots 90 or stays inside the conservative band. If it consistently sits at 60–90, we can revisit pulling the cap to 90 (or wiring options 2/3).

## Test plan

- [ ] CI: existing race-plan validator tests still pass. The fixture in `tests/mcp/test_races.py::_valid_plan_input` uses `carbs_g_per_hour: 70`, well inside the new bound.
- [ ] Manual: re-generate a race plan via `generate_race_plan` and confirm the model can still hit 90 g/hr without rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)