### PR TITLE
END-100: misfire_grace_time + coalesce on weekly/evening reports

### DIFF
--- a/bot/scheduler.py
+++ b/bot/scheduler.py
@@ -233,12 +233,16 @@ async def create_scheduler() -> AsyncIOScheduler:
         hour=19,
         minute=0,
         id="scheduler_evening_report_job",
+        misfire_grace_time=3600,
+        coalesce=True,
     )
 
     scheduler.add_job(
         scheduler_weekly_report_job,
         trigger=CronTrigger(day_of_week="sun", hour=19, minute=0, timezone=settings.TIMEZONE),
         id="scheduler_weekly_report_job",
+        misfire_grace_time=7200,
+        coalesce=True,
     )
 
     scheduler.add_job(


### PR DESCRIPTION
## Summary

- `scheduler_weekly_report_job`: `misfire_grace_time=7200` (2h), `coalesce=True` — cover Sun 19:00 hang/restart without spilling into Monday.
- `scheduler_evening_report_job`: `misfire_grace_time=3600` (1h), `coalesce=True` — evening report is about today; >1h late is meaningless.
- All other jobs (wellness, activities, watchdog, sync_goals, scheduled_workouts, onboarding_hey, progression_model) untouched — their natural cadence already provides retries, or they are backend-only.

Fixes the underlying cause of the missed 2026-05-03 weekly report: APScheduler default `misfire_grace_time=1` permanently skips any cron firing >1s late, so any hang/deploy/restart at 19:00 silently kills the user-facing message.

Spec: [END-100](/END/issues/END-100). Built on top of [END-98](/END/issues/END-98) (already merged in `versions/multi-tenant`).

## Test plan

- [x] Smoke-tested `create_scheduler()` locally — verified `j.misfire_grace_time` and `j.coalesce` for the two target jobs match spec.
- [ ] Post-deploy: confirm a normal Sun 19:00 weekly still fires on time.
- [ ] Post-deploy: if bot restarts between 18:30–21:00 Sunday, weekly is delivered on startup (log line `Dispatched weekly report for N athletes`).
- [ ] Post-deploy: if bot was dead the entire Sunday evening (>2h past 19:00), weekly is NOT sent (grace expired) — desired, no Monday-stale weekly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)