### PR TITLE
Revert PR #295 (END-98) — squash message carried END-63 noise

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -383,7 +383,7 @@ Multi-stage build: Node 20 → React SPA, Python 3.12 → serves built assets. N
 
 ## Key Implementation Notes
 
-- **Intervals.icu API** — wellness every 10 min (4-8h) then every 30 min (9-22h), workouts hourly at :00 (4-23h), activities every 10 min (4-23h), DFA every 5 min (5-22h), evening report at 19:00 (Mon-Sat; Sun suppressed — weekly covers it), weekly report Sunday at 19:00
+- **Intervals.icu API** — wellness every 10 min (4-8h) then every 30 min (9-22h), workouts hourly at :00 (4-23h), activities every 10 min (4-23h), DFA every 5 min (5-22h), evening report at 19:00, weekly report Sunday 18:00
 - **Both HRV algorithms** always computed; `HRV_ALGORITHM` selects primary
 - **Claude API** once per day to minimize costs (morning report). Chat uses per-request calls. Prompt caching: **two `cache_control: ephemeral` segments** — `get_static_system_prompt()` (instructions, never changes) and `render_athlete_block(...)` (today + profile + goal + zones + facts + language). `save_fact` / goal update invalidates only the ~240-tok tail; the ~780-tok static prefix stays hot on Anthropic's prefix cache (see USER_CONTEXT_SPEC §6). Tool filtering: 6 groups, keyword-based, core+tracking+workouts always included (~75% token reduction for simple messages)
 - **All timestamps** UTC in DB, local timezone for display

--- a/bot/scheduler.py
+++ b/bot/scheduler.py
@@ -229,7 +229,6 @@ async def create_scheduler() -> AsyncIOScheduler:
     scheduler.add_job(
         scheduler_evening_report_job,
         trigger="cron",
-        day_of_week="mon-sat",
         hour=19,
         minute=0,
         id="scheduler_evening_report_job",
@@ -237,7 +236,7 @@ async def create_scheduler() -> AsyncIOScheduler:
 
     scheduler.add_job(
         scheduler_weekly_report_job,
-        trigger=CronTrigger(day_of_week="sun", hour=19, minute=0, timezone=settings.TIMEZONE),
+        trigger=CronTrigger(day_of_week="sun", hour=18, minute=0, timezone=settings.TIMEZONE),
         id="scheduler_weekly_report_job",
     )
 


### PR DESCRIPTION
Reverts #295 per CEO request.

The squash commit `fd97340` only landed the END-98 diff (`bot/scheduler.py +2/-1`, `CLAUDE.md +1/-1`), but the **commit message** carried in the END-63 commit text because the feature branch was based off a stale point that included an unmerged END-63 snapshot. The actual code on `versions/multi-tenant` is correct, but the commit message reads like two PRs.

This PR rolls the merge back so I can re-open END-98 as a clean single-commit PR off the current base.

Net diff: undoes the 3-line END-98 change.

Plan after merge:
1. CEO merges this revert.
2. I open a fresh `feat/END-98-weekly-time-19` PR rebased onto post-revert `versions/multi-tenant`, single commit, clean message. CEO merges that.

Please **do not** ask me to merge — `END-98` thread carries the standing instruction "никогда не мерж".