### PR TITLE
Enhances athlete prompts with sport filtering

### DIFF
--- a/api/routers/auth.py
+++ b/api/routers/auth.py
@@ -263,6 +263,17 @@ async def auth_me(user: User | None = Depends(get_current_user)) -> dict:
         result["bot_chat_initialized"] = True
         # Pin sports for demo so the gate never blocks the read-only tour.
         # PUT /sports rejects demo separately so no actual write reaches DB.
+        #
+        # CAVEAT: this pin only affects the API response shape (drives the
+        # SportsPicker gate). The morning-report / chat prompt path reads
+        # ``User.sports`` directly via ``AthleteSettings.get_thresholds`` →
+        # ``render_athlete_block`` and is NOT pinned. If the demo row's DB
+        # value is NULL the prompt falls back to "render all sections"
+        # (legacy behaviour) and stays consistent with this response. But
+        # if anyone ever sets demo ``User.sports`` to a non-NULL subset
+        # (e.g. ``["run"]``), the API will still return all-three here
+        # while the prompt narrows — silent drift. Keep demo's DB row
+        # NULL or document the override before enabling the demo path.
         result["sports"] = ["ride", "run", "swim"]
     return result
 

--- a/bot/prompts.py
+++ b/bot/prompts.py
@@ -20,6 +20,7 @@ Today's date: {today}
 
 Athlete profile:
 - Age {athlete_age}
+- Sports: {sports}
 - Goal: {goal_event} ({goal_date})
 - LTHR Run: {lthr_run}, LTHR Bike: {lthr_bike}, FTP: {ftp}W, CSS: {css}s/100m
 - Data source: Intervals.icu (Garmin wearable sync)
@@ -110,6 +111,7 @@ Today's date: {today}
 
 Athlete profile:
 - Age {athlete_age}
+- Sports: {sports}
 - Goal: {goal_event} ({goal_date})
 - LTHR Run: {lthr_run}, LTHR Bike: {lthr_bike}, FTP: {ftp}W, CSS: {css}s/100m
 
@@ -156,6 +158,30 @@ def _lang_name(code: str) -> str:
     return "English" if code == "en" else "Russian"
 
 
+# Map lowercase enum to capitalized prompt-display name. Sourced separately
+# from data.sport_map.LOWER_TO_INTERVALS because that one targets the
+# Intervals.icu API casing (which happens to match) — keeping the prompt
+# rendering decoupled lets us drift display copy (e.g. "Bike" instead of
+# "Ride") without rippling into the API mapping.
+_SPORT_DISPLAY = {"swim": "Swim", "ride": "Ride", "run": "Run"}
+
+
+def _format_sports(sports: list[str] | None) -> str:
+    """Render ``user.sports`` for the prompt's profile block.
+
+    NULL (athlete hasn't passed through SportsPicker) → ``"all"`` so the
+    rendered line stays grammatical without leaking the gate's null-state
+    into Claude's context. Empty list is treated identically — the server
+    enforces ≥1 so it shouldn't happen, but ``[]`` and ``None`` MUST agree
+    with ``_zones_block`` (which also collapses both to "render all
+    sections"). Diverging defensive paths once produced "Sports: all" + zero
+    zone sections, see USER_SPORTS_SPEC code-review H1 (2026-05-08).
+    """
+    if not sports:
+        return "all"
+    return ", ".join(_SPORT_DISPLAY.get(s, s) for s in sports)
+
+
 def get_system_prompt_weekly(user_id: int, language: str = "ru") -> str:
     t: AthleteThresholdsDTO = AthleteSettings.get_thresholds(user_id)
     g: AthleteGoalDTO | None = AthleteGoal.get_goal_dto(user_id)
@@ -164,6 +190,7 @@ def get_system_prompt_weekly(user_id: int, language: str = "ru") -> str:
     return SYSTEM_PROMPT_WEEKLY.format(
         today=today,
         athlete_age=t.age or 0,
+        sports=_format_sports(t.sports),
         goal_event=g.event_name if g else "не задана",
         goal_date=g.event_date if g else "—",
         lthr_run=t.lthr_run or "—",
@@ -181,6 +208,7 @@ def get_system_prompt_v2(user_id: int, language: str = "ru") -> str:
     return SYSTEM_PROMPT_V2.format(
         today=today,
         athlete_age=t.age or 0,
+        sports=_format_sports(t.sports),
         goal_event=g.event_name if g else "не задана",
         goal_date=g.event_date if g else "—",
         lthr_run=t.lthr_run or "—",
@@ -267,6 +295,7 @@ Today's date: {today}
 
 Athlete profile:
 - Age {athlete_age}
+- Sports: {sports}
 - Goal: {goal_event} ({goal_date})
 - LTHR Run: {lthr_run}, LTHR Bike: {lthr_bike}, FTP: {ftp}W, CSS: {css}s/100m
 - Data source: Intervals.icu (Garmin wearable sync)
@@ -340,77 +369,101 @@ def _format_range_list(ranges: list[tuple[int, int]]) -> str:
     return ", ".join(f"Z{i + 1} {lo}-{hi}%" for i, (lo, hi) in enumerate(ranges))
 
 
-def _zones_block(settings_by_sport: dict[str, AthleteSettings], t: AthleteThresholdsDTO) -> str:
+def _zones_block(
+    settings_by_sport: dict[str, AthleteSettings],
+    t: AthleteThresholdsDTO,
+    sports: list[str] | None = None,
+) -> str:
     """Render the Run/Ride/Swim zone block for SYSTEM_PROMPT_CHAT.
 
     Uses real per-sport boundaries from ``athlete_settings`` (synced from
     Intervals.icu) when available; falls back to a Friel-like 5-zone model
     otherwise so new athletes still get sane defaults.
+
+    ``sports`` is the lowercase enum list from ``User.sports`` (subset of
+    ``{"swim","ride","run"}``). When provided, only those sport sections are
+    rendered — a runner-only athlete sees just the Run block, no irrelevant
+    Ride/Swim noise. Sections are emitted in fixed order **Run → Ride →
+    Swim** regardless of the input list ordering — input is membership-only.
+    ``None`` (gate not yet passed) renders all three to avoid silent
+    regression during the rollout window; the SportsPicker gate ensures
+    this branch only fires for migrating users. Empty list is normalised
+    to ``None`` so this function and ``_format_sports`` agree on the
+    "render all" semantics — diverging paths once produced "Sports: all"
+    + zero zones (USER_SPORTS_SPEC code-review H1, 2026-05-08).
     """
+    if sports is not None and not sports:
+        sports = None
     lines: list[str] = []
+    show_run = sports is None or "run" in sports
+    show_ride = sports is None or "ride" in sports
+    show_swim = sports is None or "swim" in sports
 
     # Run — %LTHR. Prefer Intervals synced zones whenever an LTHR is available
     # from either the sport-row or the thresholds DTO (historically some
     # athlete_settings rows had hr_zones populated but lthr=None — don't punish
     # them with Friel fallback when t.lthr_run is right there).
-    run = settings_by_sport.get("Run")
-    lthr_run = (run and run.lthr) or t.lthr_run
-    if run and run.hr_zones and lthr_run:
-        ranges = _pct_ranges_from_hr(run.hr_zones, lthr_run)
-        source = "from your Intervals.icu sport-settings"
-    else:
-        ranges = _FALLBACK_RUN_HR_PCT
-        source = "Friel fallback — athlete has no synced Run zones yet"
-    z2 = ranges[1] if len(ranges) >= 2 else (72, 82)
-    lines.append(
-        f"  - **Run**: use `hr` with `%lthr` units. LTHR = {lthr_run or '—'}. "
-        f"Ranges per zone ({source}): {_format_range_list(ranges)}. Example Z2 step: "
-        f'`{{"text": "Z2", "duration": 900, "hr": {{"units": "%lthr", "value": {z2[0]}, "end": {z2[1]}}}}}`.'
-    )
+    if show_run:
+        run = settings_by_sport.get("Run")
+        lthr_run = (run and run.lthr) or t.lthr_run
+        if run and run.hr_zones and lthr_run:
+            ranges = _pct_ranges_from_hr(run.hr_zones, lthr_run)
+            source = "from your Intervals.icu sport-settings"
+        else:
+            ranges = _FALLBACK_RUN_HR_PCT
+            source = "Friel fallback — athlete has no synced Run zones yet"
+        z2 = ranges[1] if len(ranges) >= 2 else (72, 82)
+        lines.append(
+            f"  - **Run**: use `hr` with `%lthr` units. LTHR = {lthr_run or '—'}. "
+            f"Ranges per zone ({source}): {_format_range_list(ranges)}. Example Z2 step: "
+            f'`{{"text": "Z2", "duration": 900, "hr": {{"units": "%lthr", "value": {z2[0]}, "end": {z2[1]}}}}}`.'
+        )
 
     # Ride — prefer %FTP (power). Intervals.icu stores power_zones already as
     # percentages of FTP (not absolute watts), so the zones themselves need no
     # FTP — it's only displayed as the watts reference in the prompt text.
-    ride = settings_by_sport.get("Ride")
-    ftp = (ride and ride.ftp) or t.ftp
-    if ride and ride.power_zones:
-        ranges = _pct_ranges(list(ride.power_zones))
-        z2 = ranges[1] if len(ranges) >= 2 else (55, 75)
-        source = "from your Intervals.icu sport-settings"
-        ftp_str = f"{ftp}W" if ftp else "—"
-        lines.append(
-            f"  - **Ride**: use `power` with `%ftp` units. FTP = {ftp_str}. "
-            f"Ranges per zone ({source}): {_format_range_list(ranges)}. Example Z2: "
-            f'`"power": {{"units": "%ftp", "value": {z2[0]}, "end": {z2[1]}}}`.'
-        )
-    elif t.ftp:
-        z2 = _FALLBACK_RIDE_POWER_PCT[1]
-        lines.append(
-            f"  - **Ride**: use `power` with `%ftp` units. FTP = {t.ftp}W. "
-            f"Ranges per zone (Friel fallback): {_format_range_list(_FALLBACK_RIDE_POWER_PCT)}. "
-            f'Example Z2: `"power": {{"units": "%ftp", "value": {z2[0]}, "end": {z2[1]}}}`.'
-        )
-    else:
-        lthr_bike = (ride and ride.lthr) or t.lthr_bike
-        z2 = _FALLBACK_BIKE_HR_PCT[1]
-        lines.append(
-            f"  - **Ride**: use `hr` with `%lthr` units. LTHR bike = {lthr_bike or '—'}. "
-            f"Ranges per zone (Friel fallback): {_format_range_list(_FALLBACK_BIKE_HR_PCT)}. "
-            f'Example Z2: `"hr": {{"units": "%lthr", "value": {z2[0]}, "end": {z2[1]}}}`.'
-        )
+    if show_ride:
+        ride = settings_by_sport.get("Ride")
+        ftp = (ride and ride.ftp) or t.ftp
+        if ride and ride.power_zones:
+            ranges = _pct_ranges(list(ride.power_zones))
+            z2 = ranges[1] if len(ranges) >= 2 else (55, 75)
+            source = "from your Intervals.icu sport-settings"
+            ftp_str = f"{ftp}W" if ftp else "—"
+            lines.append(
+                f"  - **Ride**: use `power` with `%ftp` units. FTP = {ftp_str}. "
+                f"Ranges per zone ({source}): {_format_range_list(ranges)}. Example Z2: "
+                f'`"power": {{"units": "%ftp", "value": {z2[0]}, "end": {z2[1]}}}`.'
+            )
+        elif t.ftp:
+            z2 = _FALLBACK_RIDE_POWER_PCT[1]
+            lines.append(
+                f"  - **Ride**: use `power` with `%ftp` units. FTP = {t.ftp}W. "
+                f"Ranges per zone (Friel fallback): {_format_range_list(_FALLBACK_RIDE_POWER_PCT)}. "
+                f'Example Z2: `"power": {{"units": "%ftp", "value": {z2[0]}, "end": {z2[1]}}}`.'
+            )
+        else:
+            lthr_bike = (ride and ride.lthr) or t.lthr_bike
+            z2 = _FALLBACK_BIKE_HR_PCT[1]
+            lines.append(
+                f"  - **Ride**: use `hr` with `%lthr` units. LTHR bike = {lthr_bike or '—'}. "
+                f"Ranges per zone (Friel fallback): {_format_range_list(_FALLBACK_BIKE_HR_PCT)}. "
+                f'Example Z2: `"hr": {{"units": "%lthr", "value": {z2[0]}, "end": {z2[1]}}}`.'
+            )
 
     # Swim — CSS corridor (no real zones in Intervals.icu sport-settings for swim).
-    css = t.css
-    if css:
-        mm = int(css // 60)
-        ss = int(css % 60)
-        css_str = f"{mm}:{ss:02d}/100m"
-    else:
-        css_str = "—"
-    lines.append(
-        f"  - **Swim**: use `pace` with `%pace` units. CSS = {css_str}. "
-        'Z2 corridor 95-105%. Example: `"pace": {"units": "%pace", "value": 95, "end": 105}`.'
-    )
+    if show_swim:
+        css = t.css
+        if css:
+            mm = int(css // 60)
+            ss = int(css % 60)
+            css_str = f"{mm}:{ss:02d}/100m"
+        else:
+            css_str = "—"
+        lines.append(
+            f"  - **Swim**: use `pace` with `%pace` units. CSS = {css_str}. "
+            'Z2 corridor 95-105%. Example: `"pace": {"units": "%pace", "value": 95, "end": 105}`.'
+        )
 
     return "\n".join(lines)
 
@@ -586,13 +639,14 @@ async def render_athlete_block(
     return _ATHLETE_BLOCK_TEMPLATE.format(
         today=today,
         athlete_age=t.age or 0,
+        sports=_format_sports(t.sports),
         goal_event=g.event_name if g else "не задана",
         goal_date=g.event_date if g else "—",
         lthr_run=t.lthr_run or "—",
         lthr_bike=t.lthr_bike or "—",
         ftp=t.ftp or "—",
         css=t.css or "—",
-        zones_block=_zones_block(settings_by_sport, t),
+        zones_block=_zones_block(settings_by_sport, t, sports=t.sports),
         facts_block=facts_section,
         personal_patterns_block=patterns_section,
         response_language=_lang_name(language),

--- a/docs/USER_SPORTS_SPEC.md
+++ b/docs/USER_SPORTS_SPEC.md
@@ -462,7 +462,7 @@ swim-ramp в `data/ramp_tests.create_ramp_test`.
 
 ## 13. Status
 
-- [ ] Phase 1 — Schema + API + Frontend gate + Settings + ramp-suggestion filter (эта спека)
-- [ ] Phase 2 — Прокидывание в промпт (`_ATHLETE_BLOCK_TEMPLATE`, conditional `_zones_block`)
+- [x] Phase 1 — Schema + API + Frontend gate + Settings + ramp-suggestion filter (приземлено 2026-05-08)
+- [x] Phase 2 — Прокидывание в промпт (`_ATHLETE_BLOCK_TEMPLATE`, conditional `_zones_block`) — приземлено 2026-05-08
 - [ ] Phase 3 — Tool filter + report adaptation
 - [ ] Phase 4 — Swim ramp-test support + detection routing

--- a/tests/bot/test_prompts_zones.py
+++ b/tests/bot/test_prompts_zones.py
@@ -5,11 +5,24 @@ Covers:
 - _pct_ranges_from_hr: bpm → %LTHR conversion.
 - _zones_block: Intervals.icu sport-settings are preferred, Friel fallback
   kicks in when a sport has no synced boundaries.
+- _format_sports: rendered profile-line for User.sports.
+- Phase-2 wiring: full prompt builders inject the Sports: line correctly.
 """
 
 from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
 
-from bot.prompts import _pct_ranges, _pct_ranges_from_hr, _zones_block
+import pytest
+
+from bot.prompts import (
+    _format_sports,
+    _pct_ranges,
+    _pct_ranges_from_hr,
+    _zones_block,
+    get_system_prompt_v2,
+    get_system_prompt_weekly,
+    render_athlete_block,
+)
 from data.db.dto import AthleteThresholdsDTO
 
 
@@ -146,3 +159,236 @@ class TestZonesBlock:
     def test_swim_css_missing(self):
         out = _zones_block({}, self._thresholds())
         assert "CSS = —" in out
+
+
+class TestZonesBlockSportsFilter:
+    """Phase 2 of USER_SPORTS_SPEC: ``sports`` arg restricts rendered sections.
+
+    NULL/missing keeps the legacy all-three rendering for backward compat
+    during the gate rollout. Non-empty list filters by lowercase enum.
+    """
+
+    def _thresholds(self, **kw):
+        return AthleteThresholdsDTO(
+            age=kw.get("age", 30),
+            lthr_run=kw.get("lthr_run"),
+            lthr_bike=kw.get("lthr_bike"),
+            ftp=kw.get("ftp"),
+            css=kw.get("css"),
+        )
+
+    def test_runner_only_renders_run_only(self):
+        out = _zones_block(
+            {},
+            self._thresholds(lthr_run=170, ftp=240, css=110.0),
+            sports=["run"],
+        )
+        assert "**Run**" in out
+        assert "**Ride**" not in out
+        assert "**Swim**" not in out
+
+    def test_swim_run_drops_ride(self):
+        """Swim+Run athlete gets Run + Swim sections, no Ride."""
+        out = _zones_block(
+            {},
+            self._thresholds(lthr_run=170, ftp=240, css=110.0),
+            sports=["swim", "run"],
+        )
+        assert "**Run**" in out
+        assert "**Swim**" in out
+        assert "**Ride**" not in out
+
+    def test_ride_only_drops_run_and_swim(self):
+        out = _zones_block(
+            {},
+            self._thresholds(lthr_run=170, ftp=240, css=110.0),
+            sports=["ride"],
+        )
+        assert "**Ride**" in out
+        assert "**Run**" not in out
+        assert "**Swim**" not in out
+
+    def test_null_renders_all_three_for_backward_compat(self):
+        """Athletes who haven't passed through the picker (NULL sports)
+        keep seeing all three sections — legacy behaviour. The gate
+        ensures only migrating users hit this branch."""
+        out = _zones_block(
+            {},
+            self._thresholds(lthr_run=170, ftp=240, css=110.0),
+            sports=None,
+        )
+        assert "**Run**" in out
+        assert "**Ride**" in out
+        assert "**Swim**" in out
+
+    def test_triathlete_unchanged_regression_guard(self):
+        """`sports=["swim","ride","run"]` must produce identical output to
+        the no-sports default (legacy triathlete path). If a future tweak
+        accidentally changes the all-three render path, this catches it.
+
+        Byte-for-byte comparison depends on the stable Run→Ride→Swim
+        section ordering inside ``_zones_block`` — input `sports` order
+        is membership-only. If someone refactors the function to a
+        dict-driven dispatch with non-deterministic iteration, this
+        assertion will start flaking. Read the docstring on _zones_block
+        for the order contract."""
+        thr = self._thresholds(lthr_run=170, ftp=240, css=110.0)
+        legacy = _zones_block({}, thr)
+        triathlete = _zones_block({}, thr, sports=["swim", "ride", "run"])
+        assert legacy == triathlete
+
+    def test_empty_list_normalises_to_none(self):
+        """USER_SPORTS_SPEC code-review H1 (2026-05-08): defensive paths
+        must agree on the [] case. ``_zones_block([])`` and
+        ``_zones_block(None)`` produce identical output (render all),
+        matching ``_format_sports([]) == _format_sports(None) == "all"``.
+        Without this normalisation, a stray empty list would render
+        "Sports: all" + zero zone sections — a contradictory prompt."""
+        thr = self._thresholds(lthr_run=170, ftp=240, css=110.0)
+        all_via_none = _zones_block({}, thr, sports=None)
+        all_via_empty = _zones_block({}, thr, sports=[])
+        assert all_via_none == all_via_empty
+        # Sanity: all three sport sections present.
+        assert "**Run**" in all_via_empty
+        assert "**Ride**" in all_via_empty
+        assert "**Swim**" in all_via_empty
+
+
+class TestFormatSports:
+    """Phase 2: ``_format_sports`` renders the profile-line value."""
+
+    def test_none_renders_all(self):
+        assert _format_sports(None) == "all"
+
+    def test_empty_list_renders_all(self):
+        """Defensive parity with ``_zones_block`` — see H1 normalisation."""
+        assert _format_sports([]) == "all"
+
+    def test_single_sport(self):
+        assert _format_sports(["run"]) == "Run"
+
+    def test_canonical_three_preserves_input_order(self):
+        """No re-sorting in the formatter — caller decides ordering. The
+        API canonicalises alphabetically, so the typical input is
+        ``["ride","run","swim"]`` and renders as 'Ride, Run, Swim'."""
+        assert _format_sports(["ride", "run", "swim"]) == "Ride, Run, Swim"
+
+    def test_unknown_enum_passes_through_silently(self):
+        """Unknown values fall through ``.get(s, s)`` to the raw lowercase.
+        Server-side ``Literal`` validation should prevent this from ever
+        reaching us, but a future enum extension would flow through here
+        without crashing — captured as documented behaviour."""
+        assert _format_sports(["run", "fitness"]) == "Run, fitness"
+
+
+class TestPromptBuilderSportsInjection:
+    """Phase 2 smoke: the three callers actually pass ``sports`` to
+    ``.format()``. A typo in any of them would surface as a runtime
+    KeyError on the morning-report cron — these tests catch it pre-deploy."""
+
+    def _thr(self, sports):
+        """Minimal thresholds DTO with sports set; other fields default to
+        None and the prompt still builds (renders '—' for missing values)."""
+        return AthleteThresholdsDTO(
+            age=30,
+            sports=sports,
+            lthr_run=170,
+            lthr_bike=150,
+            ftp=240,
+            css=110.0,
+        )
+
+    def test_get_system_prompt_v2_renders_sports_line(self):
+        with (
+            patch("bot.prompts.AthleteSettings.get_thresholds", return_value=self._thr(["run"])),
+            patch("bot.prompts.AthleteGoal.get_goal_dto", return_value=None),
+        ):
+            out = get_system_prompt_v2(user_id=1, language="ru")
+        assert "Sports: Run" in out
+        assert "Age 30" in out
+
+    def test_get_system_prompt_weekly_renders_sports_line(self):
+        with (
+            patch("bot.prompts.AthleteSettings.get_thresholds", return_value=self._thr(["ride", "run"])),
+            patch("bot.prompts.AthleteGoal.get_goal_dto", return_value=None),
+        ):
+            out = get_system_prompt_weekly(user_id=1, language="ru")
+        assert "Sports: Ride, Run" in out
+
+    def test_get_system_prompt_v2_renders_all_for_null_sports(self):
+        """Backward compat for users still in the gate rollout window."""
+        with (
+            patch("bot.prompts.AthleteSettings.get_thresholds", return_value=self._thr(None)),
+            patch("bot.prompts.AthleteGoal.get_goal_dto", return_value=None),
+        ):
+            out = get_system_prompt_v2(user_id=1, language="ru")
+        assert "Sports: all" in out
+
+    @pytest.mark.asyncio
+    async def test_render_athlete_block_renders_sports_and_zones(self):
+        """End-to-end: chat tail must show both ``Sports: Run`` (profile
+        line) and only the Run zone section (no Ride/Swim) for a runner."""
+        with (
+            patch(
+                "bot.prompts.AthleteSettings.get_thresholds",
+                new=AsyncMock(return_value=self._thr(["run"])),
+            ),
+            patch(
+                "bot.prompts.AthleteGoal.get_goal_dto",
+                new=AsyncMock(return_value=None),
+            ),
+            patch(
+                "bot.prompts.AthleteSettings.get_all",
+                new=AsyncMock(return_value=[]),
+            ),
+            patch(
+                "bot.prompts._safe_compute_personal_patterns",
+                new=AsyncMock(return_value={"entries_total": 0, "entries_complete": 0}),
+            ),
+            patch(
+                "data.db.UserFact.list_active",
+                new=AsyncMock(return_value=[]),
+            ),
+        ):
+            out = await render_athlete_block(user_id=1, language="ru")
+
+        # Profile line
+        assert "Sports: Run" in out
+        # Zones section narrowed to Run only
+        assert "**Run**" in out
+        assert "**Ride**" not in out
+        assert "**Swim**" not in out
+
+    @pytest.mark.asyncio
+    async def test_render_athlete_block_triathlete_keeps_all_three(self):
+        """Regression guard at the integration level: a triathlete sees
+        all three zone sections AND ``Sports: Ride, Run, Swim`` profile
+        line. Catches drift between the two prompt segments."""
+        with (
+            patch(
+                "bot.prompts.AthleteSettings.get_thresholds",
+                new=AsyncMock(return_value=self._thr(["ride", "run", "swim"])),
+            ),
+            patch(
+                "bot.prompts.AthleteGoal.get_goal_dto",
+                new=AsyncMock(return_value=None),
+            ),
+            patch(
+                "bot.prompts.AthleteSettings.get_all",
+                new=AsyncMock(return_value=[]),
+            ),
+            patch(
+                "bot.prompts._safe_compute_personal_patterns",
+                new=AsyncMock(return_value={"entries_total": 0, "entries_complete": 0}),
+            ),
+            patch(
+                "data.db.UserFact.list_active",
+                new=AsyncMock(return_value=[]),
+            ),
+        ):
+            out = await render_athlete_block(user_id=1, language="ru")
+
+        assert "Sports: Ride, Run, Swim" in out
+        assert "**Run**" in out
+        assert "**Ride**" in out
+        assert "**Swim**" in out


### PR DESCRIPTION
Updates prompt generation to include specific sports information and filters zone sections based on user sports preferences. 

Adds tests for new sports formatting and section filtering logic:
- Implements conditional rendering of sports sections in athlete prompts
- Ensures backward compatibility for users not yet migrated through sport selection
- Adds handling for "all" sports display for backward compatibility.

Relates to multi-tenant versioning