### PR TITLE
Add multi-goal support to dashboard goal tab

### DIFF
--- a/api/routers/dashboard.py
+++ b/api/routers/dashboard.py
@@ -15,6 +15,7 @@ from sqlalchemy import select
 from api.deps import get_data_user_id, require_viewer
 from config import settings
 from data.db import Activity, ActivityDetail, AthleteGoal, User, Wellness, get_session
+from data.db.dto import AthleteGoalDTO
 from data.utils import extract_sport_ctl, normalize_sport
 
 router = APIRouter()
@@ -270,33 +271,95 @@ async def weekly_recap(
     }
 
 
-@router.get("/api/goal")
-async def goal(user: User = Depends(require_viewer)) -> dict:
-    """Race goal progress for the Goal tab.
+def _goal_progress_dict(
+    g: AthleteGoalDTO,
+    today: date,
+    current_ctl: float | None,
+    sport_ctl: dict[str, float | None],
+) -> dict:
+    """Build a single goal's progress block for the Goal tab.
 
-    Returns ``{"has_goal": false}`` when the athlete has no active race —
-    the React Dashboard hides the Goal tab entirely in that case (per the
-    [END-12] scoping decision; we don't want to push users into a CTA they
-    didn't ask for, and the tab list is shorter and clearer with it gone).
-
-    When a goal exists, the response always includes the overall CTL bar
-    (``ctl_current`` / ``ctl_target`` / ``overall_pct``). Per-sport bars
-    are only included when ``per_sport_targets`` is set on the goal —
-    auto-splitting an overall target by canonical 70.3 ratios was rejected
-    because the per-sport mix varies too much between athletes to fake.
+    Extracted so the list endpoint (`/api/goal`) can map over all active
+    goals (#323 Strand C extension to Dashboard) — the formula is identical
+    for each row and only the input DTO differs.
     """
-    uid = get_data_user_id(user)
-    g = await AthleteGoal.get_goal_dto(uid)
-    if not g:
-        return {"has_goal": False}
-
-    today = _today_local()
-    # Clamp both to 0 if the athlete forgot to deactivate a past goal — a
+    # Clamp to 0 if the athlete forgot to deactivate a past goal — a
     # negative "days_remaining" in the JSON is misleading. Floor-divide
     # before clamping so day-of-event reads "0 weeks" instead of rounding
     # up to "1 week to go" the morning of.
     days_remaining = max(0, (g.event_date - today).days)
     weeks_remaining = max(0, days_remaining // 7)
+
+    # Explicit zero-guard — `g.ctl_target=0` is a legit value (full-taper anchor)
+    # but division by it would crash. ``is not None and > 0`` keeps the intent
+    # obvious and protects against any future negative-target bug.
+    overall_pct = (
+        round(100 * current_ctl / g.ctl_target)
+        if (current_ctl is not None and g.ctl_target is not None and g.ctl_target > 0)
+        else None
+    )
+
+    block: dict = {
+        "id": g.id,
+        "category": g.category,
+        "event_name": g.event_name,
+        "event_date": str(g.event_date),
+        "sport_type": g.sport_type,
+        "weeks_remaining": weeks_remaining,
+        "days_remaining": days_remaining,
+        "ctl_current": round(current_ctl, 1) if current_ctl is not None else None,
+        "ctl_target": g.ctl_target,
+        "overall_pct": overall_pct,
+    }
+
+    # Per-sport bars: only emit sports that actually have a target. A sport
+    # with target=0 or missing is treated as "not part of this race plan"
+    # and dropped, not rendered as 0% (which would look like a regression).
+    targets: dict = g.per_sport_targets or {}
+    per_sport: dict[str, dict] = {}
+    for sport in ("swim", "ride", "run"):
+        target = targets.get(sport)
+        if target is None or target <= 0:
+            continue
+        cur = sport_ctl.get(sport)
+        per_sport[sport] = {
+            "ctl_current": round(cur, 1) if cur is not None else None,
+            "ctl_target": target,
+            "pct": round(100 * cur / target) if cur is not None else None,
+        }
+    if per_sport:
+        block["per_sport"] = per_sport
+
+    return block
+
+
+@router.get("/api/goal")
+async def goal(user: User = Depends(require_viewer)) -> dict:
+    """Race-goal progress list for the Goal tab.
+
+    Returns ``{"has_goals": false, "goals": []}`` when the athlete has no
+    active future race — the React Dashboard hides the Goal tab in that
+    case (per the [END-12] scoping decision; we don't push users into a
+    CTA they didn't ask for, and the tab list is shorter and clearer
+    with it gone).
+
+    When goals exist, returns ``{"has_goals": true, "goals": [...]}`` with
+    one block per active future goal (sort: ``event_date ASC`` so the
+    nearest race is first). Each block always includes the overall CTL
+    bar (``ctl_current`` / ``ctl_target`` / ``overall_pct``); per-sport
+    bars are only included when ``per_sport_targets`` is set on the goal
+    — auto-splitting an overall target by canonical 70.3 ratios was
+    rejected because the per-sport mix varies too much between athletes
+    to fake.
+
+    Shape changed from single-goal to list in #323 Strand C — Dashboard's
+    Goal tab now mirrors Settings' all-goals view.
+    """
+    uid = get_data_user_id(user)
+    today = _today_local()
+    goals = await AthleteGoal.get_goals_for_settings(uid, today)
+    if not goals:
+        return {"has_goals": False, "goals": []}
 
     async with get_session() as session:
         result = await session.execute(
@@ -309,39 +372,11 @@ async def goal(user: User = Depends(require_viewer)) -> dict:
 
     current_ctl = float(row.ctl) if row and row.ctl is not None else None
     sport_ctl = extract_sport_ctl(row.sport_info) if row else {"swim": None, "ride": None, "run": None}
-    targets: dict = g.per_sport_targets or {}
 
-    overall_pct = round(100 * current_ctl / g.ctl_target) if (current_ctl is not None and g.ctl_target) else None
-
-    response: dict = {
-        "has_goal": True,
-        "event_name": g.event_name,
-        "event_date": str(g.event_date),
-        "weeks_remaining": weeks_remaining,
-        "days_remaining": days_remaining,
-        "ctl_current": round(current_ctl, 1) if current_ctl is not None else None,
-        "ctl_target": g.ctl_target,
-        "overall_pct": overall_pct,
+    return {
+        "has_goals": True,
+        "goals": [_goal_progress_dict(g, today, current_ctl, sport_ctl) for g in goals],
     }
-
-    # Per-sport bars: only emit sports that actually have a target. A sport
-    # with target=0 or missing is treated as "not part of this race plan"
-    # and dropped, not rendered as 0% (which would look like a regression).
-    per_sport: dict[str, dict] = {}
-    for sport in ("swim", "ride", "run"):
-        target = targets.get(sport)
-        if not target or target <= 0:
-            continue
-        cur = sport_ctl.get(sport)
-        per_sport[sport] = {
-            "ctl_current": round(cur, 1) if cur is not None else None,
-            "ctl_target": target,
-            "pct": round(100 * cur / target) if cur is not None else None,
-        }
-    if per_sport:
-        response["per_sport"] = per_sport
-
-    return response
 
 
 @router.get("/api/recovery-trend")

--- a/data/db/athlete.py
+++ b/data/db/athlete.py
@@ -252,9 +252,26 @@ class AthleteGoal(Base):
     @classmethod
     @dual
     def get_goal_dto(cls, user_id: int, *, session: Session) -> AthleteGoalDTO | None:
+        """Return the primary anchor goal as a single DTO. Used by `auth_me.goal`
+        (Dashboard tab gate) and `get_goal_progress` MCP tool.
+
+        Past races filtered out — same rule as `get_goals_for_settings` and
+        `get_goals_for_prompt` (#323 Strand C extension). Without this, an
+        athlete with only stale active rows would see a Goal-tab gate fire on
+        the dashboard but the list endpoint would return empty — a misleading
+        UX where the tab opens to «No race set».
+        """
+        # SQLAlchemy resolves Python's `date.today()` lazily inside the query,
+        # but @dual sync/async dispatch makes that finicky — pass the value in
+        # explicitly via a Python-level filter to keep behaviour deterministic.
+        today = date.today()
         result = session.execute(
             select(cls)
-            .where(cls.user_id == user_id, cls.is_active.is_(True))
+            .where(
+                cls.user_id == user_id,
+                cls.is_active.is_(True),
+                cls.event_date >= today,
+            )
             .order_by(cls.category.asc(), cls.event_date.asc())
             .limit(1)
         )

--- a/mcp_server/resources/athlete_profile.py
+++ b/mcp_server/resources/athlete_profile.py
@@ -30,14 +30,18 @@ def render_race_goal_resource(goals: list[AthleteGoalDTO]) -> str:
         lines.append(f"{prefix}{g.event_name}")
         lines.append(f"  Date: {g.event_date}")
         lines.append(f"  Sport: {g.sport_type}")
-        # ``is not None`` rather than truthy check — CTL=0 is a legitimate
-        # «no load» target during full taper / injury recovery, and we'd
-        # silently drop it with ``if g.ctl_target:`` (Copilot review #325).
+        # Overall ``ctl_target=0``: legit «no load» target during full taper /
+        # injury recovery — render it (``is not None`` not truthy, Copilot #325).
         if g.ctl_target is not None:
             lines.append(f"  CTL Target (total): {g.ctl_target}")
+        # Per-sport ``target=0``: by project convention means «not part of this
+        # race plan» (e.g. swim=0 on a run-only goal), not full taper. Drop to
+        # match the Dashboard endpoint's per-sport rule (api/routers/dashboard.py).
+        # Keeping the two consumers aligned avoids the «Claude sees swim=0,
+        # webapp doesn't» divergence flagged in code review.
         if g.per_sport_targets:
             for sport, target in g.per_sport_targets.items():
-                if target is None:
+                if target is None or target <= 0:
                     continue
                 lines.append(f"  CTL Target ({sport}): {target}")
 

--- a/tests/api/test_dashboard.py
+++ b/tests/api/test_dashboard.py
@@ -419,12 +419,17 @@ async def _seed_wellness_with_sport_ctl(
 
 
 class TestGoal:
-    async def test_no_goal_returns_has_goal_false(self, client):
+    """Shape changed in #323 Strand C: ``/api/goal`` now returns ``{"has_goals": bool, "goals": [...]}``
+    — a list of progress blocks, one per active future goal, sorted by ``event_date ASC``.
+    Past goals are filtered out (the helper ``get_goals_for_settings`` enforces it).
+    """
+
+    async def test_no_goal_returns_empty_list(self, client):
         async with client as c:
             resp = await c.get("/api/goal")
 
         assert resp.status_code == 200
-        assert resp.json() == {"has_goal": False}
+        assert resp.json() == {"has_goals": False, "goals": []}
 
     async def test_goal_without_per_sport_targets(self, client):
         """Athlete with overall target only — single overall bar, no per_sport block."""
@@ -435,16 +440,20 @@ class TestGoal:
             resp = await c.get("/api/goal")
 
         data = resp.json()
-        assert data["has_goal"] is True
-        assert data["event_name"] == "Ironman 70.3"
-        assert data["weeks_remaining"] == 10  # 70 // 7
-        assert data["days_remaining"] == 70
-        assert data["ctl_current"] == 60.0
-        assert data["ctl_target"] == 80.0
-        assert data["overall_pct"] == 75  # 60/80 * 100
+        assert data["has_goals"] is True
+        assert len(data["goals"]) == 1
+        g = data["goals"][0]
+        assert g["event_name"] == "Ironman 70.3"
+        assert g["category"] == "RACE_A"
+        assert g["sport_type"] == "triathlon"
+        assert g["weeks_remaining"] == 10  # 70 // 7
+        assert g["days_remaining"] == 70
+        assert g["ctl_current"] == 60.0
+        assert g["ctl_target"] == 80.0
+        assert g["overall_pct"] == 75  # 60/80 * 100
         # Per-sport block must be omitted when targets are absent (END-12 scoping
         # decision — don't fake bars from canonical 70.3 ratios).
-        assert "per_sport" not in data
+        assert "per_sport" not in g
 
     async def test_goal_with_per_sport_targets(self, client):
         await _seed_goal(
@@ -468,13 +477,45 @@ class TestGoal:
             resp = await c.get("/api/goal")
 
         data = resp.json()
-        assert data["has_goal"] is True
-        assert data["weeks_remaining"] == 12
-        assert data["per_sport"] == {
+        assert data["has_goals"] is True
+        g = data["goals"][0]
+        assert g["weeks_remaining"] == 12
+        assert g["per_sport"] == {
             "swim": {"ctl_current": 12.0, "ctl_target": 15.0, "pct": 80},
             "ride": {"ctl_current": 28.0, "ctl_target": 35.0, "pct": 80},
             "run": {"ctl_current": 20.0, "ctl_target": 25.0, "pct": 80},
         }
+
+    async def test_multiple_goals_returned_sorted_by_date(self, client):
+        """#323 Strand C: Dashboard Goal tab shows ALL active goals, nearest first.
+        Each goal carries its own progress block computed from the same wellness row."""
+        await _seed_goal(
+            1,
+            event_date=_FIXED_TODAY + timedelta(days=120),
+            ctl_target=80.0,
+            event_name="Far A-race",
+            category="RACE_A",
+        )
+        await _seed_goal(
+            1,
+            event_date=_FIXED_TODAY + timedelta(days=30),
+            ctl_target=60.0,
+            event_name="Near tune-up",
+            category="RACE_B",
+        )
+        await _seed_wellness(1, _FIXED_TODAY, ctl=50.0, atl=45.0)
+
+        async with client as c:
+            resp = await c.get("/api/goal")
+
+        data = resp.json()
+        assert data["has_goals"] is True
+        assert len(data["goals"]) == 2
+        # Sort: nearest first
+        assert data["goals"][0]["event_name"] == "Near tune-up"
+        assert data["goals"][0]["weeks_remaining"] == 4  # 30 // 7
+        assert data["goals"][1]["event_name"] == "Far A-race"
+        assert data["goals"][1]["weeks_remaining"] == 17  # 120 // 7
 
     async def test_per_sport_drops_sports_without_target(self, client):
         """A target=0 or missing entry means "not part of this race plan" — drop, don't render 0%."""
@@ -498,10 +539,10 @@ class TestGoal:
         async with client as c:
             resp = await c.get("/api/goal")
 
-        data = resp.json()
-        assert "per_sport" in data
-        assert set(data["per_sport"].keys()) == {"run"}
-        assert data["per_sport"]["run"]["pct"] == 72  # 18 / 25
+        g = resp.json()["goals"][0]
+        assert "per_sport" in g
+        assert set(g["per_sport"].keys()) == {"run"}
+        assert g["per_sport"]["run"]["pct"] == 72  # 18 / 25
 
     async def test_overall_pct_handles_missing_target(self, client):
         """Athlete set the race but never set a CTL target — overall_pct must be null, not /0."""
@@ -511,11 +552,10 @@ class TestGoal:
         async with client as c:
             resp = await c.get("/api/goal")
 
-        data = resp.json()
-        assert data["has_goal"] is True
-        assert data["ctl_target"] is None
-        assert data["overall_pct"] is None
-        assert data["ctl_current"] == 60.0
+        g = resp.json()["goals"][0]
+        assert g["ctl_target"] is None
+        assert g["overall_pct"] is None
+        assert g["ctl_current"] == 60.0
 
     async def test_zero_weeks_remaining_on_race_day(self, client):
         """Day-of-event reads "0 weeks", not rounded up to 1."""
@@ -525,22 +565,21 @@ class TestGoal:
         async with client as c:
             resp = await c.get("/api/goal")
 
-        data = resp.json()
-        assert data["weeks_remaining"] == 0
-        assert data["days_remaining"] == 0
+        g = resp.json()["goals"][0]
+        assert g["weeks_remaining"] == 0
+        assert g["days_remaining"] == 0
 
-    async def test_past_race_clamps_to_zero(self, client):
-        """Athlete forgot to deactivate a past goal — both counters clamp to 0
-        rather than returning a negative `days_remaining` in the JSON."""
+    async def test_past_race_filtered_out(self, client):
+        """``get_goals_for_settings`` filters past goals server-side — past races
+        no longer surface in the Dashboard list (was «clamps to 0» pre-Strand-C)."""
         await _seed_goal(1, event_date=_FIXED_TODAY - timedelta(days=10), ctl_target=80.0)
         await _seed_wellness(1, _FIXED_TODAY, ctl=70.0, atl=55.0)
 
         async with client as c:
             resp = await c.get("/api/goal")
 
-        data = resp.json()
-        assert data["weeks_remaining"] == 0
-        assert data["days_remaining"] == 0
+        # Past goal silently dropped — list is empty
+        assert resp.json() == {"has_goals": False, "goals": []}
 
     async def test_no_wellness_yet(self, client):
         """Brand-new athlete with a goal but no wellness rows yet renders an
@@ -551,9 +590,10 @@ class TestGoal:
             resp = await c.get("/api/goal")
 
         data = resp.json()
-        assert data["has_goal"] is True
-        assert data["ctl_current"] is None
-        assert data["overall_pct"] is None
+        assert data["has_goals"] is True
+        g = data["goals"][0]
+        assert g["ctl_current"] is None
+        assert g["overall_pct"] is None
 
     async def test_per_user_scoping(self, client):
         """Goal for another user must not leak into the response."""
@@ -566,7 +606,7 @@ class TestGoal:
             resp = await c.get("/api/goal")
 
         # User 1 has no goal of their own; user 2's must not leak through
-        assert resp.json() == {"has_goal": False}
+        assert resp.json() == {"has_goals": False, "goals": []}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/mcp/test_render_race_goal_resource.py
+++ b/tests/mcp/test_render_race_goal_resource.py
@@ -49,15 +49,18 @@ class TestRenderRaceGoalResource:
         out = render_race_goal_resource([_dto(ctl_target=0)])
         assert "CTL Target (total): 0" in out
 
-    def test_per_sport_zero_renders(self) -> None:
-        """Same invariant for per-sport CTL=0 — full taper sport-block."""
-        out = render_race_goal_resource([_dto(per_sport_targets={"swim": 0, "ride": 0, "run": 0})])
-        assert "CTL Target (swim): 0" in out
-        assert "CTL Target (ride): 0" in out
-        assert "CTL Target (run): 0" in out
+    def test_per_sport_zero_dropped(self) -> None:
+        """Per-sport ``target=0`` means «sport not in this race's plan» (project
+        convention — see Dashboard endpoint at api/routers/dashboard.py for the
+        same rule). Drop, don't render. Differs from the OVERALL ctl_target
+        which renders 0 as legit full-taper."""
+        out = render_race_goal_resource([_dto(per_sport_targets={"swim": 0, "ride": 35.0, "run": 25.0})])
+        assert "CTL Target (swim)" not in out
+        assert "CTL Target (ride): 35.0" in out
+        assert "CTL Target (run): 25.0" in out
 
     def test_per_sport_none_skipped(self) -> None:
-        """`None` per-sport target legitimately means «not set», skip it."""
+        """`None` per-sport target — same drop, same reason as `0`."""
         out = render_race_goal_resource([_dto(per_sport_targets={"swim": None, "ride": 35.0})])
         assert "CTL Target (swim)" not in out
         assert "CTL Target (ride): 35.0" in out

--- a/webapp/src/api/types.ts
+++ b/webapp/src/api/types.ts
@@ -366,28 +366,39 @@ export interface GoalSportProgress {
   pct: number | null
 }
 
-// Discriminated union: ``has_goal: false`` means the athlete has no active
-// race and the Goal tab is hidden. ``has_goal: true`` always carries the
-// overall CTL bar fields; ``per_sport`` is only present when
-// ``per_sport_targets`` is set on the AthleteGoal (END-12 scoping decision —
-// don't fake per-sport bars from a single overall target).
+// One goal's progress block — overall CTL bar always present, ``per_sport``
+// only when ``per_sport_targets`` is set on the AthleteGoal (END-12 scoping
+// decision — don't fake per-sport bars from a single overall target).
+export interface GoalProgress {
+  id: number
+  category: GoalCategory
+  event_name: string
+  event_date: string
+  sport_type: SportType
+  weeks_remaining: number
+  days_remaining: number
+  ctl_current: number | null
+  ctl_target: number | null
+  overall_pct: number | null
+  per_sport?: {
+    swim?: GoalSportProgress
+    ride?: GoalSportProgress
+    run?: GoalSportProgress
+  }
+}
+
+// Discriminated union: ``has_goals: false`` means the athlete has no active
+// future race and the Goal tab is hidden. ``has_goals: true`` carries one
+// progress block per active future goal (sort: ``event_date ASC``, nearest
+// first). Shape changed from single-goal to list in #323 Strand C — Dashboard
+// Goal tab now mirrors Settings' all-goals view.
+//
+// Both arms type ``goals`` as ``GoalProgress[]`` (rather than the empty tuple
+// on the false arm) so call sites that pass the array around generically
+// don't need extra narrowing — the discriminator stays ``has_goals``.
 export type GoalResponse =
-  | { has_goal: false }
-  | {
-      has_goal: true
-      event_name: string
-      event_date: string
-      weeks_remaining: number
-      days_remaining: number
-      ctl_current: number | null
-      ctl_target: number | null
-      overall_pct: number | null
-      per_sport?: {
-        swim?: GoalSportProgress
-        ride?: GoalSportProgress
-        run?: GoalSportProgress
-      }
-    }
+  | { has_goals: false; goals: GoalProgress[] }
+  | { has_goals: true; goals: GoalProgress[] }
 
 export interface WeeklyRecapBucket {
   week_start: string

--- a/webapp/src/pages/Dashboard.tsx
+++ b/webapp/src/pages/Dashboard.tsx
@@ -7,7 +7,7 @@ import ErrorMessage from '../components/ErrorMessage'
 import { ChartCard, chartOptions } from '../components/ChartCard'
 import { apiFetch } from '../api/client'
 import { CHART_COLORS, SPORT_ICONS, TSB_ZONE_COLORS } from '../lib/constants'
-import type { AuthMeResponse, TrainingLoadSeries, ActivitiesSeries, GoalResponse, WeeklyRecapBucket, WeeklyRecapResponse, RecoveryTrendSeries } from '../api/types'
+import type { AuthMeResponse, TrainingLoadSeries, ActivitiesSeries, GoalResponse, GoalProgress, WeeklyRecapBucket, WeeklyRecapResponse, RecoveryTrendSeries } from '../api/types'
 
 Chart.register(...registerables)
 
@@ -283,13 +283,13 @@ function ProgressBar({
 }
 
 function GoalTab() {
-  const [goal, setGoal] = useState<GoalResponse | null>(null)
+  const [goalsResponse, setGoalsResponse] = useState<GoalResponse | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
     apiFetch<GoalResponse>('/api/goal')
-      .then(setGoal)
+      .then(setGoalsResponse)
       .catch(err => setError(err instanceof Error ? err.message : 'Failed to load'))
       .finally(() => setLoading(false))
   }, [])
@@ -297,33 +297,43 @@ function GoalTab() {
   if (loading) return <LoadingSpinner />
   if (error) return <ErrorMessage message={error} />
   // The Dashboard shell already hides the Goal tab when the athlete has no
-  // race, so we should never actually hit `has_goal: false` here. Keep a
+  // race, so we should never actually hit `has_goals: false` here. Keep a
   // lightweight fallback in case the two fetches race (Dashboard reads
   // /api/auth/me, GoalTab reads /api/goal — the goal could be deleted
   // between the two).
-  if (!goal || !goal.has_goal) {
+  if (!goalsResponse || !goalsResponse.has_goals) {
     return <div className="text-center py-6 text-text-dim">No race set.</div>
   }
 
   return (
     <>
+      {goalsResponse.goals.map(g => (
+        <GoalCard key={g.id} goal={g} />
+      ))}
+    </>
+  )
+}
+
+function GoalCard({ goal: g }: { goal: GoalProgress }) {
+  return (
+    <>
       <div className="text-center py-4 text-xl font-bold">
-        <span className="text-[var(--button)]">{goal.weeks_remaining}</span> weeks to {goal.event_name}
+        <span className="text-[var(--button)]">{g.weeks_remaining}</span> weeks to {g.event_name}
       </div>
 
       <div className="bg-surface border border-border rounded-[14px] p-3 mb-3">
         <ProgressBar
           label={<span>Overall CTL</span>}
-          current={goal.ctl_current}
-          target={goal.ctl_target}
-          pct={goal.overall_pct}
+          current={g.ctl_current}
+          target={g.ctl_target}
+          pct={g.overall_pct}
           color={CHART_COLORS.ctl}
         />
 
-        {goal.per_sport && (
+        {g.per_sport && (
           <div className="mt-3 pt-3 border-t border-bg">
             {(['swim', 'ride', 'run'] as const).map(sport => {
-              const block = goal.per_sport?.[sport]
+              const block = g.per_sport?.[sport]
               if (!block) return null
               const meta = SPORT_META[sport]
               return (
@@ -340,7 +350,7 @@ function GoalTab() {
           </div>
         )}
 
-        {!goal.per_sport && goal.ctl_target && (
+        {!g.per_sport && g.ctl_target && (
           <div className="text-[11px] text-text-dim mt-3 pt-3 border-t border-bg">
             Set per-sport CTL targets in Settings to see swim / ride / run progress.
           </div>


### PR DESCRIPTION
Updates the dashboard goal tab to support displaying multiple active future goals. It introduces a list format that shows progress for each goal, sorted by event date. The change ensures that past goals are filtered out, enhancing user experience by aligning with the settings' all-goals view.

Key Changes:
- Refactors the API to return a list of active future goals instead of a single goal.
- Modifies the front-end to handle multiple goals and display progress bars for each.
- Updates tests to cover new multi-goal functionality, ensuring that only future goals are shown.
- Improves UX by sorting goals by proximity and omitting inactive goals.