### PR TITLE
Auto-detect Telegram client language on first /start

### DIFF
--- a/api/deps.py
+++ b/api/deps.py
@@ -29,6 +29,7 @@ async def get_current_user(authorization: str | None = Header(default=None)) -> 
     chat_id: str | None = None
     tg_username: str | None = None
     tg_display_name: str | None = None
+    tg_language_code: str | None = None
     from_init_data = False
     is_demo = False
 
@@ -52,6 +53,7 @@ async def get_current_user(authorization: str | None = Header(default=None)) -> 
                             first = user_data.get("first_name") or ""
                             last = user_data.get("last_name") or ""
                             tg_display_name = f"{first} {last}".strip() or None
+                            tg_language_code = user_data.get("language_code")
                             from_init_data = True
                     except (json.JSONDecodeError, TypeError):
                         pass
@@ -64,6 +66,7 @@ async def get_current_user(authorization: str | None = Header(default=None)) -> 
             chat_id=chat_id,
             username=tg_username,
             display_name=tg_display_name,
+            language_code=tg_language_code,
         )
     else:
         user = await User.get_by_chat_id(chat_id)

--- a/bot/main.py
+++ b/bot/main.py
@@ -70,6 +70,10 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         chat_id=chat_id,
         username=tg_user.username,
         display_name=tg_user.full_name,
+        # Telegram's client locale (BCP-47, e.g. "en", "ru-RU"). Honoured only
+        # on first /start — existing users keep whatever they last picked via
+        # /lang, so an English-speaker who once switched to ru stays ru.
+        language_code=tg_user.language_code,
     )
     # Explicit reactivation: /start is an unambiguous re-engagement signal.
     # Webapp/Login Widget auth paths intentionally do NOT reactivate — see

--- a/data/db/user.py
+++ b/data/db/user.py
@@ -27,6 +27,24 @@ from data.db.dto import (  # noqa: F401, E402
 from .common import Base
 from .decorator import dual, with_session
 
+_SUPPORTED_LANGUAGES = frozenset({"ru", "en"})
+
+
+def normalize_telegram_language(code: str | None) -> str:
+    """Map Telegram's BCP-47 ``language_code`` to our supported language set.
+
+    Telegram returns codes like ``"en"`` / ``"en-US"`` / ``"pt-br"``. We support
+    only ``ru`` and ``en``. Russian speakers get Russian; everyone else
+    (unsupported locale, or no ``language_code`` at all from older Telegram
+    clients) defaults to English — the international fallback rather than the
+    project owner's mother tongue. Returns the value to be stored in
+    ``users.language``.
+    """
+    if not code:
+        return "en"
+    short = code.split("-", 1)[0].lower()
+    return short if short in _SUPPORTED_LANGUAGES else "en"
+
 
 def parse_pace_to_sec(pace: str | None) -> int | None:
     """Parse a 'M:SS' pace string to seconds (per km), validated.
@@ -556,6 +574,7 @@ class User(Base):
         *,
         username: str | None = None,
         display_name: str | None = None,
+        language_code: str | None = None,
     ) -> User:
         """Fetch an existing user or create a new `viewer` from Telegram identity.
 
@@ -569,6 +588,10 @@ class User(Base):
         `athlete` stays manual via `cli shell`. We intentionally don't rely
         on `create()`'s default role, so a future change to that default
         cannot silently widen the widget-auth security posture.
+
+        ``language_code`` is Telegram's BCP-47 client locale (``"en"``,
+        ``"ru-RU"``, ``"pt-br"``, ...). Used **only on creation** — existing
+        users keep their explicitly-set ``language`` (e.g. via ``/lang``).
         """
         # `include_inactive=True` so a blocked user (is_active=False) is still
         # findable — prevents `IntegrityError` on the UNIQUE `chat_id` if we
@@ -585,6 +608,7 @@ class User(Base):
                 role="viewer",
                 username=username,
                 display_name=display_name,
+                language=normalize_telegram_language(language_code),
             )
         except IntegrityError:
             # Concurrent insert: another request created the row first.

--- a/tests/bot/test_main_start.py
+++ b/tests/bot/test_main_start.py
@@ -13,9 +13,20 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 
-def _make_update(chat_id: int, *, full_name: str = "Test User", username: str | None = "tester"):
+def _make_update(
+    chat_id: int,
+    *,
+    full_name: str = "Test User",
+    username: str | None = "tester",
+    language_code: str | None = None,
+):
     """Build a minimal ``Update`` stand-in with the fields ``start()`` reads."""
-    tg_user = SimpleNamespace(id=chat_id, username=username, full_name=full_name)
+    tg_user = SimpleNamespace(
+        id=chat_id,
+        username=username,
+        full_name=full_name,
+        language_code=language_code,
+    )
     message = SimpleNamespace(reply_text=AsyncMock())
     return SimpleNamespace(effective_user=tg_user, message=message)
 
@@ -107,3 +118,47 @@ class TestStartLanguageContract:
         assert order, "neither _set_lang nor _ was invoked"
         assert order[0] == "set_lang:en", f"first event must be set_lang:en, got {order[0]!r} (full order: {order})"
         assert "translate" in order, "expected at least one _() call after set_lang"
+
+
+class TestStartLanguageCodePropagation:
+    """``/start`` must forward Telegram's ``language_code`` to
+    ``get_or_create_from_telegram`` — that's how a new English-speaking user
+    gets the English welcome on their very first interaction (instead of being
+    pinned to the schema-level ``ru`` default until they tap ``/lang``)."""
+
+    @pytest.mark.asyncio
+    async def test_passes_telegram_language_code_to_get_or_create(self):
+        from bot.main import start
+
+        update = _make_update(chat_id=999, language_code="en-US")
+        user = _make_user(language="en", athlete_id="i123")
+
+        get_or_create = AsyncMock(return_value=user)
+        with (
+            patch("bot.main.User.get_or_create_from_telegram", new=get_or_create),
+            patch("bot.main._set_lang"),
+        ):
+            await start(update, MagicMock())
+
+        kwargs = get_or_create.call_args.kwargs
+        assert kwargs["language_code"] == "en-US", f"expected language_code='en-US', got {kwargs!r}"
+
+    @pytest.mark.asyncio
+    async def test_passes_none_when_telegram_omits_language_code(self):
+        """Telegram clients may omit ``language_code`` entirely (old clients,
+        some Web app contexts). Forwarded as ``None`` — DB-side normaliser
+        falls back to ``en`` (international default, not the owner's ``ru``)."""
+        from bot.main import start
+
+        update = _make_update(chat_id=999, language_code=None)
+        user = _make_user(language="ru", athlete_id="i123")
+
+        get_or_create = AsyncMock(return_value=user)
+        with (
+            patch("bot.main.User.get_or_create_from_telegram", new=get_or_create),
+            patch("bot.main._set_lang"),
+        ):
+            await start(update, MagicMock())
+
+        kwargs = get_or_create.call_args.kwargs
+        assert kwargs["language_code"] is None

--- a/tests/db/test_user_language.py
+++ b/tests/db/test_user_language.py
@@ -1,0 +1,35 @@
+"""Tests for ``data.db.user.normalize_telegram_language`` — BCP-47 → supported
+language set mapping. Used by ``User.get_or_create_from_telegram`` to seed
+``users.language`` from Telegram's client locale on first ``/start``.
+"""
+
+import pytest
+
+
+class TestNormalizeTelegramLanguage:
+    """``normalize_telegram_language`` maps Telegram's BCP-47 ``language_code``
+    to the project's supported set (``ru``/``en``). Used on first ``/start`` to
+    seed ``users.language``. Unsupported / missing → ``en`` (international
+    fallback, not the owner's native ``ru``)."""
+
+    @pytest.mark.parametrize(
+        "code,expected",
+        [
+            ("ru", "ru"),
+            ("en", "en"),
+            ("RU", "ru"),  # case insensitive
+            ("EN", "en"),
+            ("ru-RU", "ru"),  # region stripped
+            ("en-US", "en"),
+            ("en-GB", "en"),
+            ("pt-br", "en"),  # unsupported lang → en fallback
+            ("de", "en"),
+            ("zh-CN", "en"),
+            ("", "en"),  # empty string → en
+            (None, "en"),  # None (Telegram client omits) → en
+        ],
+    )
+    def test_normalization(self, code, expected):
+        from data.db.user import normalize_telegram_language
+
+        assert normalize_telegram_language(code) == expected


### PR DESCRIPTION
## Summary

Auto-detect the Telegram client locale on first `/start` and seed `users.language` from it. Previously every new account was pinned to `ru` regardless of the user's actual language; an English-speaker had to find `/lang` before they could read the welcome.

## What changed

- **`data/db/user.py`** — new `normalize_telegram_language(code: str | None) -> str`. Maps BCP-47 (`"en-US"` → `"en"`, case-insensitive). Supported set `{"ru", "en"}` (frozenset). Fallback `"en"` for unsupported / missing locale (international default, not the owner's native `ru`).
- `User.get_or_create_from_telegram` accepts new kwarg `language_code: str | None = None` and forwards normalized result to `cls.create(language=...)` **only on creation** — existing users keep whatever they last picked via `/lang`.
- **`bot/main.py:start`** — passes `tg_user.language_code`.
- **`api/deps.py:get_current_user`** — Mini App initData path forwards `user_data["language_code"]` too. JWT path untouched (existing users). Login Widget intentionally skipped (Telegram spec doesn't include language_code in widget payload).

## Tests

- `tests/db/test_user_language.py` — new dedicated file. `TestNormalizeTelegramLanguage` with 12 parametrized cases (ru/en, case-insensitive, regional strip, de/pt-br/zh-CN, empty, None).
- `tests/bot/test_main_start.py::TestStartLanguageCodePropagation` — 2 cases that `/start` correctly forwards `language_code` (including None for older clients).

## Notes

- `User.create()`'s Python kwarg default `language="ru"` stays as-is — the only caller (`get_or_create_from_telegram`) always passes `language=` explicitly now, so the default never fires through any code path.
- DB column-level default for `users.language` also stays `"ru"` (only relevant for raw SQL inserts, none in code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
