### PR TITLE
Pre-checks user state to prevent invalid report generation

### DIFF
--- a/tasks/actors/reports.py
+++ b/tasks/actors/reports.py
@@ -225,6 +225,29 @@ def actor_compose_user_morning_report(
     # catch is needed. The MCPTool path has its own HTTPStatusError handling.
     _dt = local_today().isoformat()
 
+    # Pre-check tenant state BEFORE sentinel acquisition. Scheduler filters at
+    # dispatch, but Telegram 403 (user blocked the bot) flips `is_active=False`
+    # mid-flight via `User.set_active_by_chat_id`. Without this guard the actor
+    # would claim the sentinel, then call MCP — where `MCPAuthMiddleware.
+    # get_by_mcp_token` rejects an inactive user with 401 (Sentry stack trace).
+    # Early-out avoids the wasted SELECT FOR UPDATE + sentinel claim/release.
+    #
+    # Race window: user can still flip inactive (or be deleted) AFTER this
+    # pre-check but BEFORE the sentinel/MCP. That's OK — MCP middleware will
+    # 401 on the now-invalid token, the `except Exception` at the MCP call
+    # (line ~276 below) catches it and calls `_clear_sentinel`. No code path
+    # leaks a stuck sentinel: pre-check returns BEFORE any sentinel write,
+    # and every post-sentinel exit (success/error/disappeared-wellness-row)
+    # either writes the real value or runs `_clear_sentinel`.
+    with get_sync_session() as session:
+        _user_orm = session.get(User, user.id)
+    if _user_orm is None:
+        logger.warning("Morning report skipped: user %d no longer exists", user.id)
+        return
+    if not _user_orm.is_active:
+        logger.info("Morning report skipped: user %d is inactive", user.id)
+        return
+
     # Transaction 1: short lock — claim the slot with sentinel, release immediately.
     # Prevents race: two concurrent actors both see ai_recommendation=None.
     with get_sync_session() as session:
@@ -253,14 +276,6 @@ def actor_compose_user_morning_report(
 
         _wellness_row.ai_recommendation = f"__generating__:{time.time():.0f}"
         session.commit()
-
-    # Fetch user credentials (outside lock)
-    with get_sync_session() as session:
-        _user_orm = session.get(User, user.id)
-    if _user_orm is None:
-        logger.warning("Morning report skipped: user %d no longer exists", user.id)
-        _clear_sentinel(user.id, _dt)
-        return
 
     # Generate report (no DB lock held — can take 30-120s)
     try:
@@ -338,6 +353,12 @@ def generate_and_save_weekly_report(user: UserDTO) -> tuple[str, date] | None:
         _user_orm = session.get(User, user.id)
     if _user_orm is None:
         logger.warning("Weekly report skipped: user %d no longer exists", user.id)
+        return None
+    # Same is_active re-check as in the morning report — MCPAuthMiddleware
+    # filters by `is_active=True`, so a Telegram-block flip mid-flight would
+    # surface as 401 from /mcp/.
+    if not _user_orm.is_active:
+        logger.info("Weekly report skipped: user %d is inactive", user.id)
         return None
     mcp = MCPTool(token=_user_orm.mcp_token, user_id=user.id, language=user.language)
     text = mcp.generate_weekly_report_via_mcp()

--- a/tests/tasks/test_activity_actors.py
+++ b/tests/tasks/test_activity_actors.py
@@ -957,6 +957,61 @@ class TestActorComposeMorningReport:
 
         mock_mcp_cls.assert_not_called()
 
+    def test_returns_early_when_user_is_inactive(self):
+        """Pre-check race regression: Telegram-403 sendMessage flips
+        `users.is_active=False` (via `User.set_active_by_chat_id`) while the
+        morning-report message is in flight in the Dramatiq queue. Without the
+        pre-check the actor would claim the sentinel, instantiate MCPTool, and
+        the MCP middleware's `get_by_mcp_token(... AND is_active=True)` would
+        reject → unhandled HTTPStatusError(401) → Sentry stack.
+
+        The pre-check must run BEFORE the SELECT FOR UPDATE sentinel claim:
+        - no `MCPTool` instantiation
+        - no `session.execute(...)` (sentinel SELECT FOR UPDATE) call
+        """
+        from tasks.actors import actor_compose_user_morning_report
+
+        user = _user(id=1)
+        # User row with is_active=False — the smoking gun.
+        inactive_user = MagicMock(is_active=False)
+
+        session = MagicMock()
+        session.__enter__ = MagicMock(return_value=session)
+        session.__exit__ = MagicMock(return_value=False)
+        session.get.return_value = inactive_user
+
+        with (
+            patch("tasks.actors.reports.get_sync_session", return_value=session),
+            patch("tasks.actors.reports.MCPTool") as mock_mcp_cls,
+        ):
+            actor_compose_user_morning_report(user.model_dump())
+
+        mock_mcp_cls.assert_not_called()
+        # Sentinel claim must NOT have been attempted — pre-check is the
+        # FIRST thing the actor does, so nothing should have run yet.
+        session.execute.assert_not_called()
+
+    def test_returns_early_when_user_missing(self):
+        """If `session.get(User, user.id)` returns None (row deleted between
+        scheduler dispatch and actor run) — same early-out, no sentinel claim."""
+        from tasks.actors import actor_compose_user_morning_report
+
+        user = _user(id=1)
+
+        session = MagicMock()
+        session.__enter__ = MagicMock(return_value=session)
+        session.__exit__ = MagicMock(return_value=False)
+        session.get.return_value = None
+
+        with (
+            patch("tasks.actors.reports.get_sync_session", return_value=session),
+            patch("tasks.actors.reports.MCPTool") as mock_mcp_cls,
+        ):
+            actor_compose_user_morning_report(user.model_dump())
+
+        mock_mcp_cls.assert_not_called()
+        session.execute.assert_not_called()
+
     def test_returns_early_when_rhr_row_missing(self):
         """Missing RHR analysis row → MCPTool not called."""
         from tasks.actors import actor_compose_user_morning_report
@@ -1209,3 +1264,53 @@ class TestActivityNotificationTenantGuard:
 
         # Cross-tenant data must NOT be rendered into this user's chat.
         tg_mock.send_message.assert_not_called()
+
+
+class TestGenerateAndSaveWeeklyReport:
+    """`generate_and_save_weekly_report` mirrors the morning-report pre-check
+    contract: bail out cleanly when the user no longer exists / is inactive
+    rather than letting `MCPTool` hit a 401 from the MCP middleware."""
+
+    def test_returns_none_when_user_is_inactive(self):
+        """Telegram-block race: scheduler dispatched the weekly cron while the
+        user was active, but a parallel `sendMessage` 403'd and flipped
+        `is_active=False` before this actor ran. Must short-circuit BEFORE
+        MCPTool — the middleware filters `is_active=True` and would 401."""
+        from tasks.actors.reports import generate_and_save_weekly_report
+
+        user = _user(id=1)
+        inactive_user = MagicMock(is_active=False)
+
+        session = MagicMock()
+        session.__enter__ = MagicMock(return_value=session)
+        session.__exit__ = MagicMock(return_value=False)
+        session.get.return_value = inactive_user
+
+        with (
+            patch("tasks.actors.reports.get_sync_session", return_value=session),
+            patch("tasks.actors.reports.MCPTool") as mock_mcp_cls,
+        ):
+            result = generate_and_save_weekly_report(user)
+
+        assert result is None
+        mock_mcp_cls.assert_not_called()
+
+    def test_returns_none_when_user_missing(self):
+        """User row deleted between dispatch and run → same early-out, no MCP call."""
+        from tasks.actors.reports import generate_and_save_weekly_report
+
+        user = _user(id=1)
+
+        session = MagicMock()
+        session.__enter__ = MagicMock(return_value=session)
+        session.__exit__ = MagicMock(return_value=False)
+        session.get.return_value = None
+
+        with (
+            patch("tasks.actors.reports.get_sync_session", return_value=session),
+            patch("tasks.actors.reports.MCPTool") as mock_mcp_cls,
+        ):
+            result = generate_and_save_weekly_report(user)
+
+        assert result is None
+        mock_mcp_cls.assert_not_called()


### PR DESCRIPTION
Enhances the report generation process by implementing early user state checks:
- Validates user existence and activity status before acquiring resources, preventing unnecessary operations
- Avoids potential errors and improves efficiency by skipping report generation for inactive or non-existent users
- Includes unit tests to ensure functionality of added checks