### PR TITLE
Adds support for run pace intervals

### DIFF
--- a/data/workout_adapter.py
+++ b/data/workout_adapter.py
@@ -61,6 +61,12 @@ _HR_LOW = re.compile(r"low:\s*([\d.]+)\s*bpm", re.IGNORECASE)
 _HR_HIGH = re.compile(r"high:\s*([\d.]+)\s*bpm", re.IGNORECASE)
 _PACE_LOW = re.compile(r"low:\s*(\d+):(\d+)\s*per\s*100\s*meters", re.IGNORECASE)
 _PACE_HIGH = re.compile(r"high:\s*(\d+):(\d+)\s*per\s*100\s*meters", re.IGNORECASE)
+# Run pace — HumanGo emits sec/km for run intervals (e.g. `low: 6:33 per km`).
+# Distinct regex from Swim (`per 100 meters`) to avoid cross-sport false matches.
+# Word boundary after `km` excludes false positives like `per kmh` (theoretical
+# but HumanGo never emits this; defensive only).
+_PACE_LOW_KM = re.compile(r"low:\s*(\d+):(\d+)\s*per\s*km\b", re.IGNORECASE)
+_PACE_HIGH_KM = re.compile(r"high:\s*(\d+):(\d+)\s*per\s*km\b", re.IGNORECASE)
 
 STEP_TYPES = {"warmup", "interval", "recovery", "cooldown", "rest"}
 
@@ -390,20 +396,22 @@ def _humango_power_pct(low_w: float, high_w: float, ftp: int) -> dict | None:
     return {"units": "%ftp", "start": start, "end": end}
 
 
-def _humango_pace_pct(low_sec_per_100m: int, high_sec_per_100m: int, css_sec_per_100m: float) -> dict | None:
-    """Convert HumanGo swim pace (sec/100m low=slower / high=faster) to ``%pace``.
+def _humango_pace_pct(low_sec: int, high_sec: int, threshold_sec: float) -> dict | None:
+    """Convert a HumanGo pace corridor (low=slower / high=faster) to ``%pace``.
 
-    Intervals' ``%pace`` is a velocity ratio (100 = threshold velocity, faster
-    = higher %). HumanGo's «low» pace is slower (more sec/100m), so it maps to
-    the LOWER velocity-ratio bound; «high» pace is faster, maps to the HIGHER
-    bound. Result: ``start < end`` preserves the corridor direction.
+    Unit-agnostic — caller passes matching units (Swim: sec/100m vs CSS;
+    Run: sec/km vs threshold_pace_run). Intervals' ``%pace`` is a velocity
+    ratio (100 = threshold velocity, faster = higher %). HumanGo's «low»
+    pace is slower (more sec per unit distance), so it maps to the LOWER
+    velocity-ratio bound; «high» pace is faster, maps to the HIGHER bound.
+    Result: ``start < end`` preserves the corridor direction.
     """
-    if not css_sec_per_100m or css_sec_per_100m <= 0:
+    if not threshold_sec or threshold_sec <= 0:
         return None
-    if not low_sec_per_100m or not high_sec_per_100m:
+    if not low_sec or not high_sec:
         return None
-    start = round(css_sec_per_100m / low_sec_per_100m * 100)  # slower → lower velocity %
-    end = round(css_sec_per_100m / high_sec_per_100m * 100)  # faster → higher velocity %
+    start = round(threshold_sec / low_sec * 100)  # slower → lower velocity %
+    end = round(threshold_sec / high_sec * 100)  # faster → higher velocity %
     return {"units": "%pace", "start": start, "end": end}
 
 
@@ -439,6 +447,22 @@ def _humango_target_for_step(
             lthr = thresholds.lthr_run if sport == "Run" else thresholds.lthr_bike
             target = _humango_hr_pct(float(low_m.group(1)), float(high_m.group(1)), lthr or 0)
             return ("hr", target) if target else (None, None)
+
+    # Run pace targets — HumanGo regularly emits run intervals with sec/km
+    # corridors (e.g. tempo / threshold sessions). Without this branch, such
+    # blocks come through target-less and watches alert on nothing. The
+    # `%pace` schema is the same as Swim — only the threshold differs
+    # (`threshold_pace_run` is sec/km, not sec/100m). HR check above takes
+    # precedence when both signals are present in the block (HR is the more
+    # universal Run target; pace breaks when GPS is poor or treadmill).
+    if sport == "Run":
+        low_m = _PACE_LOW_KM.search(text_block)
+        high_m = _PACE_HIGH_KM.search(text_block)
+        if low_m and high_m:
+            low_sec = int(low_m.group(1)) * 60 + int(low_m.group(2))
+            high_sec = int(high_m.group(1)) * 60 + int(high_m.group(2))
+            target = _humango_pace_pct(low_sec, high_sec, thresholds.threshold_pace_run or 0)
+            return ("pace", target) if target else (None, None)
 
     if sport == "Swim":
         low_m = _PACE_LOW.search(text_block)
@@ -518,8 +542,8 @@ def humango_to_intervals_steps(
     Returns ``None`` when the caller must skip pushing — either the converter
     cannot run, or it ran but found nothing pushable:
     - Sport not in ``{Run, Ride, Swim}`` (HumanGo doesn't push these structured).
-    - Threshold for the sport is missing / zero (LTHR for Run, FTP for Ride,
-      CSS for Swim) — cold-start athlete, see SPEC §6.
+    - Threshold for the sport is missing / zero (LTHR or threshold_pace_run for
+      Run, FTP or LTHR for Ride, CSS for Swim) — cold-start athlete, see SPEC §6.
     - Description parsed cleanly but yielded zero steps (defensive — in the
       normal call path ``is_humango_event`` already gates on the ``==========``
       separator, so empty-but-valid is unreachable from the actor).
@@ -532,8 +556,14 @@ def humango_to_intervals_steps(
         return None
 
     # Cold-start guard: each sport needs at least one usable threshold.
-    if sport == "Run" and not (thresholds.lthr_run and thresholds.lthr_run > 0):
-        logger.info("HumanGo enrichment skipped: missing LTHR for Run")
+    # Run accepts either LTHR (for HR-driven blocks) or threshold_pace_run
+    # (for pace-driven blocks) — empirically HumanGo emits one or the other
+    # per workout, not both.
+    if sport == "Run" and not (
+        (thresholds.lthr_run and thresholds.lthr_run > 0)
+        or (thresholds.threshold_pace_run and thresholds.threshold_pace_run > 0)
+    ):
+        logger.info("HumanGo enrichment skipped: missing LTHR and threshold_pace for Run")
         return None
     if sport == "Ride" and not (
         (thresholds.ftp and thresholds.ftp > 0) or (thresholds.lthr_bike and thresholds.lthr_bike > 0)
@@ -581,4 +611,33 @@ def humango_to_intervals_steps(
             steps.append(step)
         i += 1
 
-    return steps if steps else None
+    if not steps:
+        return None
+
+    # Fail-closed guard: cold-start check at function entry verifies «at least
+    # one threshold present», but a mismatched-pair case can still produce
+    # target-less steps — e.g. athlete has `lthr_run` set but HumanGo emits
+    # pace-only Run blocks (or symmetric: only `threshold_pace_run` set,
+    # description carries HR). The granular threshold check inside
+    # `_humango_target_for_step` returns `None` for the missing pair, but the
+    # step still gets emitted (with `hr=power=pace=None`). Pushing such steps
+    # would lock out future re-enrichment via `is_humango_event`'s idempotency
+    # guard (which only checks `workout_doc.steps` non-empty, not target presence).
+    # Drop the whole workout so the next sync tick can retry once thresholds
+    # are updated.
+    if all(_step_is_target_less(s) for s in steps):
+        logger.info(
+            "HumanGo enrichment skipped: parsed %d step(s) but none carry "
+            "hr/power/pace — likely description/threshold sport-target mismatch",
+            len(steps),
+        )
+        return None
+
+    return steps
+
+
+def _step_is_target_less(s: WorkoutStepDTO) -> bool:
+    """A step has no actionable target. For repeat groups, check sub-steps."""
+    if s.reps and s.steps:
+        return all(_step_is_target_less(sub) for sub in s.steps)
+    return s.hr is None and s.power is None and s.pace is None

--- a/docs/HUMANGO_ENRICHMENT_SPEC.md
+++ b/docs/HUMANGO_ENRICHMENT_SPEC.md
@@ -74,22 +74,34 @@ Watches see the **original HumanGo absolute corridor** because Intervals transla
 | Sport | HumanGo target | Threshold (`AthleteThresholdsDTO`) | Pushed units | Pushed shape |
 |---|---|---|---|---|
 | Run | `low/high: NN bpm` | `lthr_run` | `%lthr` | `{units: "%lthr", start, end}` |
+| Run | `low/high: M:SS per km` | `threshold_pace_run` (sec/km) | `%pace` | `{units: "%pace", start, end}` |
 | Ride | `low/high: NN W` | `ftp` | `%ftp` | `{units: "%ftp", start, end}` |
 | Ride | `low/high: NN bpm` (rare HR-driven ride) | `lthr_bike` | `%lthr` | `{units: "%lthr", start, end}` |
 | Swim | `low/high: M:SS per 100 meters` | `css` (Swim CSS, sec/100m) | `%pace` | `{units: "%pace", start, end}` |
 
-**Pace semantics:** HumanGo's `low` = slower pace (higher sec/100m), `high` = faster pace (lower sec/100m). Intervals' `%pace` is a **velocity ratio** (100 = threshold velocity, faster = higher %). So:
+**Run target precedence:** when a HumanGo block carries both HR _and_ pace (rare — empirically not observed in production but theoretically possible), HR wins. Rationale: HR is universal (treadmill / no-GPS works), pace is GPS-dependent and falls back to «open distance» on the watch when signal is poor. Pace-only blocks use the second Run row.
+
+**Pace semantics:** HumanGo's `low` = slower pace (higher sec per unit distance), `high` = faster pace. Intervals' `%pace` is a **velocity ratio** (100 = threshold velocity, faster = higher %). The math is unit-agnostic — same formula for Run sec/km vs Swim sec/100m, just plug in the matching threshold:
 
 ```
-start = css_sec_per_100m / humango_low_sec × 100   # lower velocity bound
-end   = css_sec_per_100m / humango_high_sec × 100  # higher velocity bound
+start = threshold_sec / humango_low_sec × 100   # lower velocity bound
+end   = threshold_sec / humango_high_sec × 100  # higher velocity bound
 ```
 
-`start < end` holds because `low_sec > high_sec` (slower has more seconds).
+`start < end` holds because `low_sec > high_sec` (slower has more seconds). Verified empirically 2026-05-16 on Run event 109976490 (threshold_pace_run=287, HumanGo 5:46-6:33/km → `start: 73, end: 83`).
+
+**Round-trip precision:** delta `≤ 1 sec` near threshold (interval/tempo paces), growing to **~2 sec** at slow warmup paces. Rounding-granularity = `threshold_sec / 100` per integer percent, so a 1% boundary maps to a larger sec/km step the further from threshold. Cosmetic only — watches use the % corridor verbatim, no FIT-export precision loss.
 
 ## 6. Cold-start fallback
 
-If `athlete_settings.{lthr|ftp|threshold_pace}` is missing for the event's sport, skip enrichment entirely:
+If the relevant threshold(s) for the event's sport are missing, skip enrichment entirely. Per-sport accept-either logic:
+
+| Sport | Required (any of) |
+|---|---|
+| Run | `lthr_run` OR `threshold_pace_run` |
+| Ride | `ftp` OR `lthr_bike` |
+| Swim | `css` |
+
 
 - Log `info`: `"HumanGo enrichment skipped for user %d event %d: missing threshold for sport %s"`.
 - Do NOT push absolute units as fallback — `WORKOUT_ABSOLUTE_TARGETS_SPEC` §12 Attempt 1 verified that `{units: "bpm", value, end}` flips FIT export into Lap-HR mode and the watch zone-clamps. Untested whether `{units: "bpm", start, end}` avoids that; defer to a future spike.
@@ -102,10 +114,12 @@ If `athlete_settings.{lthr|ftp|threshold_pace}` is missing for the event's sport
 | Sport not in `{Run, Ride, Swim}` (e.g. `WeightTraining`, `Other`) | Skip — HumanGo doesn't push these structured anyway. |
 | Repeat group inside description (`repeat N times`) | Honor — existing `parse_humango_description` already lifts these to `WorkoutStepDTO(reps=N, steps=[...])`. Sub-steps get the same %X conversion. |
 | Step with `distance:` but no `duration:` (interval distance reps) | Preserve `distance` (meters), set `duration=0`. Intervals/Garmin handle distance-based steps natively. |
-| Step with no parseable target (RPE-only, e.g. «easy effort») | Emit step with `duration` only. We deliberately bypass `PlannedWorkoutDTO._check_steps_have_targets` here — that validator gates our own AI-pushed workouts, but enrichment writes raw `workout_doc.steps` directly so Intervals.icu (not our DTO) decides whether to render. Empirically Intervals accepts target-less steps in calendar events; a future dev re-introducing the validator gate would regress this path. |
+| Step with no parseable target (RPE-only, e.g. «easy effort») | Emit step with `duration` only — **but** if EVERY step in the workout ends up target-less, the workout is dropped entirely (return `None`). See «fail-closed» below. |
 | Threshold value is zero / negative (corrupted DB) | Treat as missing; skip enrichment with the same log line as cold-start. |
 | Description contains `View on HumanGo` but no `==========` (rest day) | Skip (detection check 2). |
 | Event already has `workout_doc.steps` (we pushed earlier, or another integration did) | Skip (detection check 3, idempotency). |
+| Athlete has only `lthr_run` set, HumanGo emits pace-only Run blocks (symmetric: only `threshold_pace_run` set + HR-only description) | Cold-start passes (one threshold ≥ 0), but `_humango_target_for_step` returns `None` for the missing pair → all steps come back target-less → **fail-closed** post-build guard drops the workout (`None`). Pushing target-less steps would lock out future re-enrichment via `is_humango_event` idempotency (which only checks `workout_doc.steps` non-empty, not target presence). Athlete must add the missing threshold; next sync retries. |
+| Existing target-less workouts pushed before this fix landed | **Backfill gap:** `is_humango_event` idempotency returns `False` once `workout_doc.steps` is non-empty, regardless of target presence. Events enriched between «HumanGo parsing initial commit» and «Run pace fix» with pace-only descriptions stay target-less until manually re-pushed (script following `scripts/repush_ai_workouts_with_native_desc.py` pattern, or one-off `update_event` call). Single-user volume is single-digit; accept-as-is for now, document for next sweep. |
 
 ## 8. Architecture
 
@@ -141,11 +155,12 @@ actor_enrich_humango_workout (Dramatiq)
 - **Editing HumanGo description text** — we only write `workout_doc.steps`. Description retained verbatim.
 - **Push to HumanGo / coach feedback** — read-only on our side.
 - **Workout adaptation** based on HumanGo plan — separate flow in `actor_compose_user_morning_report` via `parse_humango_description` (compliance path, untouched here).
+- **Run pace targets on the compliance path** — `parse_humango_description` + `_parse_pace_target` only handle Swim sec/100m, NOT Run sec/km. When a Run pace-driven workout reaches morning-report compliance evaluation, pace targets are dropped → Δpace cannot be computed. Push path (this spec) is now sport-symmetric; compliance path is a known gap. Tracked separately when compliance UX needs it.
 
 ## 11. Acceptance criteria
 
 - [ ] `is_humango_event` returns True only for HumanGo-sourced events with parseable structure and no existing steps.
-- [ ] `humango_to_intervals_steps` round-trips a sample HumanGo description (Run/Ride/Swim) such that pushed `start`/`end` × threshold ≈ HumanGo's `low`/`high` within ±1 unit rounding.
+- [ ] `humango_to_intervals_steps` round-trips a sample HumanGo description (Run/Ride/Swim) such that pushed `start`/`end` × threshold ≈ HumanGo's `low`/`high` within ±1 unit rounding near threshold (`±2` at slow warmup paces — see §4 «Round-trip precision»).
 - [ ] Cold-start athlete (no thresholds) → converter returns `None`, actor skips with `info` log.
 - [ ] Idempotent: re-running the actor on an already-enriched event is a no-op (no PUT to Intervals).
 - [ ] Verified end-to-end on one real HumanGo event in production: open Intervals.icu calendar after enrichment → structured steps appear with target corridors.

--- a/tests/bot/test_workout_adapter.py
+++ b/tests/bot/test_workout_adapter.py
@@ -441,6 +441,76 @@ class TestHumangoToIntervalsStepsRoundTrip:
         assert abs(round(warmup.power["start"] * 200 / 100) - 116) <= 1
         assert abs(round(warmup.power["end"] * 200 / 100) - 151) <= 1
 
+    def test_run_pace_round_trip(self):
+        """HumanGo Run with pace-per-km targets (verified empirically 2026-05-16
+        on event 109976490 — caused target-less push before the fix)."""
+        run_desc = (
+            "View on HumanGo: https://app.humango.ai/myday?date=2026-05-16\n\n"
+            "==============================\n\n"
+            "warmup\n\nduration: 5 min\n\npace:\n\nlow: 8:11 per km\n\nhigh: 6:33 per km\n\n"
+            "==============================\n\n"
+            "interval\n\nduration: 15 min\n\npace:\n\nlow: 6:33 per km\n\nhigh: 5:46 per km\n\n"
+            "==============================\n\n"
+            "cooldown\n\nduration: 5 min\n\npace:\n\nlow: 8:11 per km\n\nhigh: 6:33 per km\n\n"
+            "==============================\n"
+        )
+        # threshold_pace_run = 5:30/km = 330 sec/km
+        thresholds = _thresholds(threshold_pace_run=330.0)
+        steps = humango_to_intervals_steps(run_desc, "Run", thresholds)
+        assert steps and len(steps) == 3
+
+        interval = steps[1]
+        assert interval.pace and interval.pace["units"] == "%pace"
+        # HumanGo: low=6:33 (393s/km), high=5:46 (346s/km). Threshold=330s/km.
+        # %pace = threshold/target × 100 (velocity ratio).
+        assert abs(round(330 / interval.pace["start"] * 100) - 393) <= 1
+        assert abs(round(330 / interval.pace["end"] * 100) - 346) <= 1
+        assert interval.pace["start"] < interval.pace["end"]  # slower < faster
+
+    def test_run_pace_only_description_with_hr_only_threshold_returns_none(self):
+        """Fail-closed: athlete has LTHR but no threshold_pace_run, HumanGo
+        emits pace-only Run blocks → cold-start guard passes (LTHR > 0) but
+        each step's pace converter fails (no threshold) → step emitted with
+        all-null targets. Without the post-build guard, those would be pushed
+        and lock out future re-enrichment via `is_humango_event` idempotency.
+
+        Symmetric case (pace threshold only, HR-only description) is the
+        same failure mode — covered by the second assertion below.
+        """
+        run_pace_desc = (
+            "==============================\n\n"
+            "interval\n\nduration: 10 min\n\npace:\n\nlow: 6:33 per km\n\nhigh: 5:46 per km\n\n"
+            "==============================\n"
+        )
+        # LTHR set, pace threshold absent → must return None, not target-less steps.
+        assert humango_to_intervals_steps(run_pace_desc, "Run", _thresholds(lthr_run=160)) is None
+
+        # Symmetric: pace threshold set, HR-only description → also None.
+        run_hr_desc = (
+            "==============================\n\n"
+            "interval\n\nduration: 10 min\n\nheart rate:\n\nlow: 130 bpm\n\nhigh: 150 bpm\n\n"
+            "==============================\n"
+        )
+        assert humango_to_intervals_steps(run_hr_desc, "Run", _thresholds(threshold_pace_run=330.0)) is None
+
+    def test_run_pace_cold_start_returns_none(self):
+        """Run with pace targets but missing threshold_pace_run → skip entirely.
+
+        Previously cold-start only checked lthr_run, so a pace-only run with
+        threshold_pace=None silently produced target-less steps. After the
+        fix, the guard accepts either threshold; absence of BOTH skips.
+        """
+        run_desc = (
+            "==============================\n\n"
+            "interval\n\nduration: 10 min\n\npace:\n\nlow: 6:33 per km\n\nhigh: 5:46 per km\n\n"
+            "==============================\n"
+        )
+        # Neither LTHR nor threshold_pace_run set → cold-start skip.
+        assert humango_to_intervals_steps(run_desc, "Run", _thresholds()) is None
+        # With ONLY threshold_pace_run → must work.
+        steps = humango_to_intervals_steps(run_desc, "Run", _thresholds(threshold_pace_run=330.0))
+        assert steps and steps[0].pace and steps[0].pace["units"] == "%pace"
+
     def test_swim_pace_round_trip(self):
         # CSS = 110 sec/100m (slower than HumanGo's «low»).
         thresholds = _thresholds(css=110.0)
@@ -524,24 +594,22 @@ class TestHumangoToIntervalsStepsEdgeCases:
         assert steps and len(steps) == 1
         assert steps[0].text == "Warm-up"
 
-    def test_sport_mismatch_yields_target_less_steps(self):
-        """If a Run description (HR targets only) is fed in with sport='Ride',
-        the Ride branch first looks for power → none → falls through to HR →
-        finds it. So this particular combination actually works. The truly
-        unsupported combo is a Ride power-block fed in as 'Run' — Run only
-        looks at HR, sees nothing, returns target-less step."""
+    def test_sport_mismatch_returns_none(self):
+        """A Ride-power-only block fed in as 'Run' produces zero targets per
+        step (Run branch only looks at HR/pace). The post-build fail-closed
+        guard then drops the whole workout to None instead of emitting
+        target-less steps — pushing target-less would lock out future
+        re-enrichment via `is_humango_event` idempotency.
+        """
         ride_power_desc = (
             "View on HumanGo: https://app.humango.ai/...\n\n"
             "==============================\n\n"
             "warmup\n\nduration: 5 min\n\npower:\n\nlow: 100 W\n\nhigh: 130 W\n\n"
             "==============================\n"
         )
-        # Run looks at HR only — finds nothing in this Ride-power-only block.
-        steps = humango_to_intervals_steps(ride_power_desc, "Run", _thresholds(lthr_run=160))
-        # Step is still emitted (step type + duration parse), but with no target.
-        # Documents the «target-less step» edge case from SPEC §7.
-        assert steps and len(steps) == 1
-        assert steps[0].hr is None and steps[0].power is None and steps[0].pace is None
+        # Run looks at HR + pace only — finds neither in a power-only block.
+        # All steps target-less → fail-closed guard returns None.
+        assert humango_to_intervals_steps(ride_power_desc, "Run", _thresholds(lthr_run=160)) is None
 
 
 class TestHumangoToIntervalsStepsRepeatGroup:


### PR DESCRIPTION
Enhances the system to interpret and handle run pace data for interval workouts, ensuring accurate targets for HumanGo run sessions. Supports pace-per-km targets and addresses the issue of target-less notifications for running intervals.

- Introduces regex patterns for parsing run pace
- Modifies core logic to be unit-agnostic, supporting both swim and run metrics
- Updates documentation to clarify pace semantics and logic around HR and pace priority
- Adds tests to validate run pace functionality and handle cold-start scenarios