### PR TITLE
Adds paired event ID tracking to activities

### DIFF
--- a/api/routers/activities.py
+++ b/api/routers/activities.py
@@ -108,6 +108,11 @@ async def activity_details(
         # Intervals.icu's native workout compliance % (planned vs actual,
         # 0-100). NULL when activity had no scheduled workout to compare.
         "compliance": round(activity.compliance, 1) if activity.compliance is not None else None,
+        # Intervals.icu's native planned-vs-actual pairing (FK-less reference to
+        # scheduled_workouts.id). Drives the «open planned workout» link on the
+        # activity detail page. NULL when Intervals didn't pair or pairing was
+        # cleaned up (planned event deleted).
+        "paired_event_id": activity.paired_event_id,
         "is_race": activity.is_race,
         "race": (
             {

--- a/data/db/activity.py
+++ b/data/db/activity.py
@@ -65,6 +65,11 @@ class Activity(Base):
     # compliance (`race_plan_compliance` table) and from per-workout-card
     # adherence (`workout_cards.compliance`).
     compliance: Mapped[float | None] = mapped_column(Float, nullable=True)
+    # Intervals.icu native planned-vs-actual pairing. References
+    # `scheduled_workouts.id` but stored as plain Integer (no FK) — Intervals
+    # rotates / deletes calendar events independently of activities, a hard FK
+    # would either cascade-delete activities on plan cleanup or 23503 on sync.
+    paired_event_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
     last_synced_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     fit_file_path: Mapped[str | None] = mapped_column(String, nullable=True)
     # Webhook-time noise classification (Phase 1.6, ML_RACE_PROJECTION_SPEC §6.4).
@@ -104,6 +109,7 @@ class Activity(Base):
                 "source": getattr(a, "source", None),
                 "rpe": getattr(a, "icu_rpe", None),
                 "compliance": getattr(a, "compliance", None),
+                "paired_event_id": getattr(a, "paired_event_id", None),
                 "last_synced_at": now,
             }
             for a in activities
@@ -134,6 +140,10 @@ class Activity(Base):
                 # Intervals as source of truth when it has a value; we don't
                 # forget the value when it temporarily doesn't.
                 "compliance": func.coalesce(stmt.excluded.compliance, cls.compliance),
+                # Same pattern: Intervals can drop `paired_event_id` when the
+                # planned event is deleted or the matcher fails. Keep the prior
+                # link so the «open paired plan» UX doesn't break temporarily.
+                "paired_event_id": func.coalesce(stmt.excluded.paired_event_id, cls.paired_event_id),
                 "last_synced_at": stmt.excluded.last_synced_at,
             },
         )

--- a/data/intervals/dto.py
+++ b/data/intervals/dto.py
@@ -181,6 +181,11 @@ class ActivityDTO(BaseModel):
     source: str | None = None  # e.g. "GARMIN_CONNECT", "OAUTH_CLIENT", "STRAVA"
     icu_rpe: int | None = None  # Borg CR-10 (1-10), from Intervals.icu / Garmin
     compliance: float | None = None  # Intervals.icu workout compliance % (0-100, planned vs actual)
+    # Intervals.icu native pairing — `scheduled_workouts.id` of the planned
+    # event that this activity was matched against. Set when Intervals' own
+    # planned-vs-actual matcher succeeds (sport + date proximity). Persists
+    # the link without us re-deriving it from `TrainingLog.original_*` snapshots.
+    paired_event_id: int | None = None
 
     # WEBHOOK_DATA_CAPTURE Phase 1: rolling power model + fitness snapshot per
     # activity. Arrive on ACTIVITY_ACHIEVEMENTS (~60s after upload) for every

--- a/migrations/versions/d2e3f4a5b6c7_add_paired_event_id_to_activities.py
+++ b/migrations/versions/d2e3f4a5b6c7_add_paired_event_id_to_activities.py
@@ -1,0 +1,31 @@
+"""add paired_event_id to activities
+
+Revision ID: d2e3f4a5b6c7
+Revises: c1d2e3f4a5b6
+Create Date: 2026-05-13 22:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d2e3f4a5b6c7"
+down_revision: Union[str, None] = "c1d2e3f4a5b6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Intervals.icu's native planned-vs-actual pairing. References
+    # `scheduled_workouts.id`, stored as plain Integer with NO foreign key —
+    # Intervals rotates / deletes calendar events independently of activities,
+    # so a hard FK would either cascade-delete activities on plan cleanup or
+    # 23503 on sync. Webhook source: ACTIVITY_UPLOADED `paired_event_id`.
+    op.add_column("activities", sa.Column("paired_event_id", sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("activities", "paired_event_id")

--- a/scripts/backfill_paired_event_id.py
+++ b/scripts/backfill_paired_event_id.py
@@ -1,0 +1,106 @@
+"""Backfill `activities.paired_event_id` for one user via single-activity fetches.
+
+Intervals.icu's list endpoint (`GET /athlete/{id}/activities`) does NOT include
+`paired_event_id` — only the single-activity endpoint (`GET /activity/{id}`)
+and the `ACTIVITY_UPLOADED` webhook do. So new activities arriving via webhook
+pick up the field automatically, but historical activities synced through the
+polling path stayed `paired_event_id=NULL`.
+
+Usage (in docker):
+
+    docker compose run --rm api python scripts/backfill_paired_event_id.py \\
+        --user-id 1 --from 2026-05-01 --to 2026-05-13
+
+Defaults to today-only when --from / --to are omitted. Rate-limits at ~5 req/s
+to be polite to Intervals.icu's API.
+"""
+
+import argparse
+import asyncio
+from datetime import date
+
+from sqlalchemy import select, update
+
+from data.db import Activity, get_session
+from data.intervals.client import IntervalsAccessError, IntervalsAsyncClient
+
+
+async def backfill(user_id: int, date_from: date, date_to: date) -> None:
+    date_from_s = date_from.isoformat()
+    date_to_s = date_to.isoformat()
+    async with get_session() as session:
+        result = await session.execute(
+            select(Activity.id)
+            .where(
+                Activity.user_id == user_id,
+                Activity.paired_event_id.is_(None),
+                Activity.start_date_local >= date_from_s,
+                Activity.start_date_local <= date_to_s,
+            )
+            .order_by(Activity.start_date_local.desc())
+        )
+        ids: list[str] = [r[0] for r in result]
+
+    if not ids:
+        print(f"No NULL-paired activities for user_id={user_id} in [{date_from_s}..{date_to_s}]")
+        return
+
+    print(f"Backfilling {len(ids)} activities for user_id={user_id} in [{date_from_s}..{date_to_s}]")
+    updated = 0
+    async with IntervalsAsyncClient.for_user(user_id) as client:
+        for i, aid in enumerate(ids, 1):
+            # Rate-limit at the TOP of the loop so it applies regardless of
+            # which branch we take (success / no-pairing / fetch-error).
+            # First iteration sleeps too — single tick is negligible.
+            await asyncio.sleep(0.2)
+            try:
+                data = await client.get_activity_detail(aid)
+            except IntervalsAccessError as e:
+                # 401 / 403 / 5xx after retries — log and skip the row.
+                # Continuing is safe; idempotent on next run.
+                print(f"  [{i}/{len(ids)}] {aid}: api access error: {e}")
+                continue
+            if data is None:
+                print(f"  [{i}/{len(ids)}] {aid}: 404 on Intervals")
+                continue
+            paired = data.get("paired_event_id")
+            if not paired:
+                print(f"  [{i}/{len(ids)}] {aid}: no pairing on Intervals side")
+                continue
+            async with get_session() as session:
+                await session.execute(
+                    update(Activity)
+                    .where(Activity.user_id == user_id, Activity.id == aid)
+                    .values(paired_event_id=paired)
+                )
+                await session.commit()
+            updated += 1
+            print(f"  [{i}/{len(ids)}] {aid}: paired_event_id={paired}")
+
+    print(f"Done. Updated {updated} / {len(ids)} rows.")
+
+
+def main() -> None:
+    today = date.today().isoformat()
+    parser = argparse.ArgumentParser(description="Backfill activities.paired_event_id from Intervals.icu")
+    parser.add_argument("--user-id", type=int, required=True)
+    parser.add_argument("--from", dest="date_from", default=today, help="YYYY-MM-DD (default: today)")
+    parser.add_argument("--to", dest="date_to", default=today, help="YYYY-MM-DD (default: today)")
+    args = parser.parse_args()
+
+    # Reject bad inputs early — `Activity.start_date_local` is a TEXT column,
+    # so lexicographic compare against a malformed `--from 2026-5-1` would
+    # silently produce the wrong window.
+    try:
+        date_from = date.fromisoformat(args.date_from)
+        date_to = date.fromisoformat(args.date_to)
+    except ValueError as e:
+        parser.error(f"invalid date: {e}")
+    if date_from > date_to:
+        parser.error(f"--from ({date_from}) must be <= --to ({date_to})")
+
+    asyncio.run(backfill(args.user_id, date_from, date_to))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/db/test_activity.py
+++ b/tests/db/test_activity.py
@@ -49,6 +49,50 @@ class TestSaveActivities:
         assert len(rows) == 1
         assert rows[0].average_hr == 142.0
 
+    async def test_insert_with_paired_event_id(self):
+        """Intervals.icu's native planned-vs-actual pairing is captured."""
+        act = ActivityDTO(
+            id="i_paired_1",
+            start_date_local=date(2026, 4, 1),
+            type="Run",
+            icu_training_load=50.0,
+            moving_time=2400,
+            paired_event_id=103471545,
+        )
+        await Activity.save_bulk(1, activities=[act])
+        rows = Activity.get_windowed(user_id=1, as_of=date(2026, 4, 1))
+        target = next((r for r in rows if r.id == "i_paired_1"), None)
+        assert target is not None
+        assert target.paired_event_id == 103471545
+
+    async def test_paired_event_id_preserved_on_resync_with_none(self):
+        """COALESCE invariant: Intervals can drop `paired_event_id` when the
+        planned event is deleted or matcher temporarily fails. We retain the
+        previously-captured link so the «open paired plan» UX stays stable.
+        """
+        dt = date(2026, 4, 2)
+        first = ActivityDTO(
+            id="i_paired_2",
+            start_date_local=dt,
+            type="Run",
+            moving_time=1800,
+            paired_event_id=999_111,
+        )
+        await Activity.save_bulk(1, activities=[first])
+
+        # Second sync omits paired_event_id (None).
+        second = ActivityDTO(
+            id="i_paired_2",
+            start_date_local=dt,
+            type="Run",
+            moving_time=1800,
+        )
+        await Activity.save_bulk(1, activities=[second])
+
+        rows = Activity.get_windowed(user_id=1, as_of=dt)
+        target = next(r for r in rows if r.id == "i_paired_2")
+        assert target.paired_event_id == 999_111  # preserved
+
     @pytest.mark.real_db
     @pytest.mark.skip(reason="Core setup commented out; i300 never created — needs rewrite")
     async def test_none_average_hr_stored(self):

--- a/webapp/src/api/types.ts
+++ b/webapp/src/api/types.ts
@@ -417,6 +417,9 @@ export interface ActivityDetailsResponse {
   // Intervals.icu native workout compliance (0-100 %, planned vs actual).
   // null when no scheduled workout matched the activity.
   compliance: number | null
+  // Intervals.icu native pairing — scheduled_workouts.id of the planned event
+  // this activity was matched against. Drives the «open planned workout» link.
+  paired_event_id: number | null
   is_race?: boolean
   race?: RaceInfo | null
   details: ActivityDetails | null

--- a/webapp/src/i18n/en.json
+++ b/webapp/src/i18n/en.json
@@ -124,7 +124,8 @@
     "no_details": "No detailed data for this activity.",
     "rest_day": "Rest day",
     "compliance": "Compliance",
-    "compliance_hint": "Planned vs actual workout match (Intervals.icu native)"
+    "compliance_hint": "Planned vs actual workout match (Intervals.icu native)",
+    "view_planned_workout": "View planned workout"
   },
   "plan": {
     "title": "Training Plan",

--- a/webapp/src/i18n/ru.json
+++ b/webapp/src/i18n/ru.json
@@ -124,7 +124,8 @@
     "no_details": "Нет детальных данных для этой активности.",
     "rest_day": "День отдыха",
     "compliance": "Соответствие",
-    "compliance_hint": "Соответствие плана и факта по версии Intervals.icu"
+    "compliance_hint": "Соответствие плана и факта по версии Intervals.icu",
+    "view_planned_workout": "Открыть плановую тренировку"
   },
   "plan": {
     "title": "План тренировок",

--- a/webapp/src/pages/Activity.tsx
+++ b/webapp/src/pages/Activity.tsx
@@ -1,4 +1,4 @@
-import { useParams } from 'react-router-dom'
+import { Link, useParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import Layout from '../components/Layout'
 import LoadingSpinner from '../components/LoadingSpinner'
@@ -72,6 +72,14 @@ export default function Activity() {
       <div className="py-4 pb-3">
         <div className="text-xl font-bold flex items-center gap-2">{icon} {sportLabel(data.type)} {data.is_race && <span className="text-sm">🏁</span>}</div>
         <div className="text-[13px] text-text-dim mt-1">{subParts.join(' \u00B7 ')}</div>
+        {data.paired_event_id != null && (
+          <Link
+            to={`/workout/${data.paired_event_id}`}
+            className="inline-flex items-center gap-1 text-[13px] text-accent no-underline mt-2 hover:underline"
+          >
+            {t('activities.view_planned_workout')} &rarr;
+          </Link>
+        )}
       </div>
 
       {data.is_race && data.race && <RaceSection race={data.race} />}


### PR DESCRIPTION
Introduces paired event ID feature to link activities with planned workouts:
- Updates database models and migrations to include a non-FK `paired_event_id`
- Enhances API and DTOs to expose this ID, aiding in the planned workout linkage
- Adds a script for backfilling `paired_event_id` for historical data
- Includes user interface updates for displaying a link to the paired workout
- Incorporates tests for ensuring consistent handling of the `paired_event_id`

This feature improves user experience by allowing seamless navigation to planned activities that have been matched with actual workouts.