### PR TITLE
Fix description handling to prevent workout step loss

### DIFF
--- a/data/intervals/dto.py
+++ b/data/intervals/dto.py
@@ -645,16 +645,21 @@ class PlannedWorkoutDTO(BaseModel):
 
         Sports listed in ``_NO_TARGET_SPORTS`` (currently just ``Other``) skip
         the native renderer: native grammar requires an intensity target on
-        every step and yoga/mobility steps don't have one. Workout cards
-        (``compose_workout``) set their own top-level description with the
-        HTML link, which Intervals stores as plain text.
+        every step and yoga/mobility steps don't have one. The resulting
+        ``description=None`` is intentional — see strip rule below. Workout
+        cards (``compose_workout``) keep top-level description at ``None`` for
+        the same reason and stash their HTML link inside
+        ``workout_doc.description`` (Garmin Connect note channel) instead.
 
-        Historical note: a 2026-04-30 regression caused Intervals to silently
-        drop ``workout_doc.steps`` for Swim events when top-level description
-        was present. Probes on 2026-05-12 showed the drop only happens when
-        Intervals' parser fails to recognise the description as native
-        format — successful parses preserve steps for every sport. Passing a
-        validated native render through is safe.
+        Strip rule: Intervals.icu silently empties ``workout_doc.steps`` to
+        ``[]`` whenever top-level ``description`` is set to text its
+        native-format parser doesn't recognise — regardless of sport.
+        Originally diagnosed 2026-04-30 as Swim-only because top-level desc
+        was being set only for Swim at the time; re-verified 2026-05-14 on
+        Other (event 109994999, URL summary as top-level desc → empty steps,
+        watch shows zero-step workout). A successful native parse preserves
+        steps for every sport, which is why this method renders top-level
+        desc only when the renderer can produce native-format output.
         """
         # Top-level event target. Default `None` → Intervals.icu maps to `AUTO`
         # which Garmin then resolves to HR for Run / power for Ride. We must

--- a/mcp_server/tools/workout_cards.py
+++ b/mcp_server/tools/workout_cards.py
@@ -19,18 +19,6 @@ logger = logging.getLogger(__name__)
 
 VALID_SPORTS = frozenset({"Swim", "Ride", "Run", "Other"})
 
-# Sports for which we mirror the workout-card prefix into top-level
-# ``event.description`` so the URL is visible in Intervals.icu web UI.
-# Explicitly enumerated (NOT derived as ``VALID_SPORTS - {"Swim"}``) so a
-# future swim-like sport added to ``VALID_SPORTS`` (e.g. ``OpenWaterSwim``)
-# does NOT auto-classify as safe and silently re-enable the regression that
-# strips ``workout_doc.steps`` whenever a Swim event has top-level
-# ``description`` set (observed 2026-04-30, see
-# ``PlannedWorkoutDTO.to_intervals_event`` docstring). Adding a new sport
-# here must be a deliberate decision after verifying it doesn't trigger the
-# Intervals.icu strip-on-description regression.
-_TOP_LEVEL_DESC_SPORTS = frozenset({"Run", "Ride", "Other"})
-
 
 _PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 _TEMPLATES_DIR = os.path.join(_PROJECT_ROOT, "templates")
@@ -405,29 +393,29 @@ async def compose_workout(
                 target_date=dt,
             )
             event = pw.to_intervals_event()
-            # ``workout_doc.description`` is read by Garmin (sent down with the
-            # FIT). Intervals.icu web UI shows the top-level ``description`` —
-            # leaving it empty made the HTML link invisible there even though
-            # Garmin saw it. The Swim-strip regression that motivated nesting
-            # (see ``PlannedWorkoutDTO.to_intervals_event``) only triggers for
-            # Swim, so for any other sport we mirror the prefix into both
-            # fields and the athlete sees the link in both places.
+            # URL goes only into ``workout_doc.description`` (Garmin Connect
+            # surfaces it as the workout note; the webapp ``/workout/:id``
+            # page reads the same field after Intervals round-trip; the tool's
+            # own return string also includes the URL so Claude relays it in
+            # chat). Top-level ``event.description`` is left as produced by
+            # ``to_intervals_event`` — for ``Other`` that's ``None``, because
+            # Intervals' parser fails on any non-native top-level text and
+            # silently strips ``workout_doc.steps`` to ``[]`` on the server,
+            # leaving watches with an empty workout (verified 2026-05-14 on
+            # event 109994999). The URL is not surfaced in Intervals web UI
+            # for workout-card events — acceptable trade vs. losing every step.
             desc_prefix = f"Exercises: {len(exercises)}, ~{total_duration_min} min\n{url}"
             new_doc = dict(event.workout_doc or {})
             existing = new_doc.get("description")
             new_doc["description"] = f"{desc_prefix}\n\n{existing}" if existing else desc_prefix
-            update = {
-                "start_date_local": f"{date_str}T06:00:00",
-                "name": name,  # no "AI:" prefix for workout cards
-                "external_id": ext_id,
-                "workout_doc": new_doc,
-            }
-            # Allow-list, not deny-list: a future ``OpenWaterSwim`` would
-            # silently re-trigger the steps-strip regression with the negative
-            # form. ``_TOP_LEVEL_DESC_SPORTS`` is the canonical safe set.
-            if sport in _TOP_LEVEL_DESC_SPORTS:
-                update["description"] = desc_prefix
-            event = event.model_copy(update=update)
+            event = event.model_copy(
+                update={
+                    "start_date_local": f"{date_str}T06:00:00",
+                    "name": name,  # no "AI:" prefix for workout cards
+                    "external_id": ext_id,
+                    "workout_doc": new_doc,
+                }
+            )
             async with IntervalsAsyncClient.for_user(user_id) as client:
                 result = await client.create_event(event)
             intervals_id = result.id

--- a/tests/ai/test_workout_cards.py
+++ b/tests/ai/test_workout_cards.py
@@ -615,32 +615,21 @@ class TestComposeWorkoutPushDescription:
         assert "event" in captured, "create_event was never called"
         return captured["event"]
 
-    async def test_non_swim_mirrors_url_into_top_level_description(self, tmp_path):
-        event = await self._push_and_capture_event(tmp_path, sport="Other")
-        # Top-level description carries the URL — visible in Intervals.icu web UI.
-        assert event.description is not None
-        assert "https://bot.example.com/static/workouts/" in event.description
-        # And workout_doc.description still has it for Garmin.
-        assert "https://bot.example.com/static/workouts/" in event.workout_doc.get("description", "")
+    async def test_top_level_description_left_unset(self, tmp_path):
+        """Regression guard: ``compose_workout`` must leave top-level
+        ``event.description`` unset (``None``) and stash the URL only in
+        ``workout_doc.description``.
 
-    def test_swim_excluded_from_top_level_desc_allow_list(self):
-        """End-to-end push for Swim is hard to drive (compose_workout's card
-        builder emits target-less steps which fail PlannedWorkoutDTO
-        validation, and pydantic's @model_validator can't be cleanly
-        monkeypatched per-test). Pin the allow-list constant directly —
-        adding "Swim" (or any future swim-like sport) to it would re-trigger
-        the Intervals workout_doc.steps regression on Swim events.
-
-        We assert the explicit set, NOT a derivation from ``VALID_SPORTS`` —
-        the whole point of switching from a deny-list to an allow-list is
-        that a new sport added to ``VALID_SPORTS`` must NOT auto-include
-        here. If you add a new sport that genuinely needs top-level
-        description, update this test together with the source constant.
+        Setting top-level desc to any non-native-format text makes
+        Intervals.icu's parser fail and silently strips
+        ``workout_doc.steps`` to ``[]`` on the server — verified 2026-05-14
+        on event 109994999. Garmin still surfaces the URL because it reads
+        ``workout_doc.description`` (FIT note); Intervals web UI loses the
+        link for workout-card events, which is the accepted trade.
         """
-        from mcp_server.tools.workout_cards import _TOP_LEVEL_DESC_SPORTS
-
-        assert _TOP_LEVEL_DESC_SPORTS == frozenset({"Run", "Ride", "Other"})
-        assert "Swim" not in _TOP_LEVEL_DESC_SPORTS
+        event = await self._push_and_capture_event(tmp_path, sport="Other")
+        assert event.description is None
+        assert "https://bot.example.com/static/workouts/" in event.workout_doc.get("description", "")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Addresses a regression that leads to step loss in workouts by ensuring top-level descriptions are left unset, to maintain compatibility with Intervals.icu's parser.

- The `PlannedWorkoutDTO` no longer sets non-native descriptions, avoiding step stripping.
- Description URL for Garmin is consistently stored in `workout_doc.description`, preserving workout integrity across platforms.
- Tests updated to confirm top-level descriptions remain unset to prevent regression.

Ensures workouts are properly rendered and synced without data loss.