### PR TITLE
Adds ML-based race time prediction to MarathonShape endpoint

### DIFF
--- a/api/routers/dashboard.py
+++ b/api/routers/dashboard.py
@@ -9,6 +9,7 @@ collisions that existed during the END-12/13 cut-over are gone.
 import zoneinfo
 from datetime import date, datetime, timedelta
 
+import sentry_sdk
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy import select
 
@@ -18,6 +19,7 @@ from data.db import Activity, ActivityDetail, AthleteGoal, User, Wellness, get_s
 from data.db.dto import AthleteGoalDTO
 from data.marathon_shape import DAYS_FOR_WEEK_KM, RunActivity, calculate_marathon_shape
 from data.metrics import PROJECTION_WINDOW_DAYS, project_ctl_target
+from data.ml.race_predict import predict_splits_with_ci
 from data.utils import extract_sport_ctl, normalize_sport
 
 router = APIRouter()
@@ -578,4 +580,57 @@ async def marathon_shape(
             "vo2max": weeks_out[0]["vo2max_used"],
         }
 
-    return {"weeks": weeks_out, "current_components": current_components}
+    # ── Phase 1.5: ML-based Predicted time + pace per distance.
+    # Sequential await — `predict_splits_with_ci` is async at the outer layer
+    # but `_predict_one` (joblib + XGBoost + bootstrap) is sync and blocks the
+    # loop; `asyncio.gather` wouldn't give parallelism (spec §13 Latency).
+    # Each call ~80ms × 3 = ~240ms total. `predict_splits_with_ci` catches
+    # ModelNotTrained / ModelBelowAcceptance internally and surfaces them via
+    # `not_available` / `below_acceptance` lists — we just check whether the
+    # "run" split landed in the envelope.
+    #
+    # Minor inefficiency: `_load_model` (data/ml/race_predict.py:97) has no
+    # cache, so the same `race_run_{user_id}.joblib` is read from disk 3× per
+    # request. ~50ms each is the dominant cost. Decoupling load from quality-
+    # gate enforcement would let us cache the bundle, but it's a cross-cutting
+    # change in shared infra — defer until joblib I/O becomes hot.
+    predicted_times: dict[str, dict | None] = {}
+    today_iso = today.isoformat()
+    for label, dist_m in (("10K", 10000), ("HM", 21097), ("Marathon", 42195)):
+        try:
+            env = await predict_splits_with_ci(
+                user_id=uid,
+                mode="today",
+                race_date=today_iso,  # spec §13: today_iso → days_to_race=0 → only intercept bias applied
+                race_distance_run_m=dist_m,
+            )
+        except Exception as e:  # noqa: BLE001 — defensive against joblib I/O / feature build failures
+            # `predict_splits_with_ci` already filters expected ML errors into
+            # envelope lists, so anything reaching here is unexpected and worth
+            # a Sentry alert (corrupt joblib, missing feature column, etc.).
+            sentry_sdk.capture_exception(e)
+            predicted_times[label] = None
+            continue
+
+        # Run leg is always pace-based — `total_sec_unavailable` flag is a
+        # Ride-only marker (power_only_phase1, see race_predict.py:449-451).
+        # If Run lacks `total_sec` here, the envelope is malformed; treat as
+        # null defensively.
+        run = env.get("splits", {}).get("run")
+        if run and run.get("total_sec") is not None:
+            predicted_times[label] = {
+                "total_sec": run["total_sec"],
+                "total_sec_ci_low": run["total_sec_ci_low"],
+                "total_sec_ci_high": run["total_sec_ci_high"],
+                "pace_sec_per_km": round(run["pred"], 1),
+                "pace_ci_low": round(run["ci_low"], 1),
+                "pace_ci_high": round(run["ci_high"], 1),
+            }
+        else:
+            predicted_times[label] = None
+
+    return {
+        "weeks": weeks_out,
+        "current_components": current_components,
+        "predicted_times": predicted_times,
+    }

--- a/docs/MARATHON_SHAPE_SPEC.md
+++ b/docs/MARATHON_SHAPE_SPEC.md
@@ -12,6 +12,8 @@ VO2max отвечает на «насколько быстро ты можешь
 
 В проекте нет run-volume-aware метрики готовности: TSS показывает нагрузку, CTL — фитнес, но «у меня хватит ножек на марафон/HM?» — не отвечается.
 
+**Disclaimer от первоисточника** (verbatim из [runalyze.com/help/article/marathon-shape](https://runalyze.com/help/article/marathon-shape), 2026-05-14): *«The Marathon Shape is **not scientifically based** and only serves as a rough estimate of whether you are sufficiently trained for a specific target distance (while the Effective VO2max only indicates the general performance level — independent of the distance/duration)»*. Это эмпирическая модель — наш виджет наследует тот же характер. В UI стоит держать tone «rough estimate», без претензии на научную точность.
+
 ## 2. Solution overview
 
 Виджет `MarathonShapeWidget` на `webapp/src/pages/Progress.tsx` при `sport='run'`, разместить **под `PolarizationWidget`** (см. `Progress.tsx:75`). Виджет показывает:
@@ -45,13 +47,24 @@ PERCENTAGE_LONGJOGS = 0.33
 
 ```python
 target_weekly_km(vo2max) = max(vo2max, 25) ** 1.135
-target_longjog_km(vo2max) = ln(max(vo2max, 25) / 4) * 12 - 13
+target_longjog_km(vo2max) = ln(max(vo2max, 25) / 4) * 12 - 13   # SCORING-INTERNAL
 ```
 
 Примеры (точные значения формул — issue body округлял):
 - VO2max 45 → weekly 75.2 км, longjog 16.0 км
 - VO2max 50 → weekly 84.8 км, longjog 17.3 км
 - VO2max 55 → weekly 94.5 км, longjog 18.5 км
+
+**Важное наблюдение — две разные «target long run» величины** (verified против Runalyze UI 2026-05-14):
+
+| Имя | Формула | Зачем |
+|---|---|---|
+| `target_longjog_km` | `ln(V/4)*12 − 13` | **scoring-internal**: используется в quadratic term `((distance − 13) / target_longjog_km)²`. Это «целевой избыток длинной пробежки над 13-км порогом». |
+| `displayed_long_run_target_km` | `ln(V/4)*12` | **UI-displayed**: «длина целевой длинной пробежки», как Runalyze показывает в колонке «Required Long Run». Для V=37 (marathon weekly 58 km на скриншоте) даёт 26.7 km ≈ 26 km, совпадает с upstream. |
+
+Тождество: `displayed = scoring + 13` (где 13 = `MIN_KM_FOR_LONGJOG`).
+
+Текущий shipped Components-блок (см. §6) показывает long-run percentage **от `target_longjog_km`** (scoring-internal). Это означает: при actual_longjog=18.2 км для VO2max=50 виджет рендерит «105% of required (18.2 km)» — потому что 18.2 / 17.3 ≈ 105. По Runalyze UX правильнее было бы «60% (18.2 / 30.3 km)» — потому что **displayed target — это 30.3 km**, не 17.3 km. Это **дельта семантики со стороны upstream**, не баг расчёта shape_pct (формула scoring корректна), но stylistic divergence от Runalyze UI. Phase 2: переключить Components-renderer на `displayed_long_run_target_km`, либо явно подписать «target excess over 13 km».
 
 ### Marathon Shape (%)
 
@@ -176,17 +189,23 @@ Newest first (как `weekly_recap`).
 │ Ready for HM:  90%                              │
 │ MS 38.2 / target 42.5                           │
 │                                                 │
+│ Predicted (HM)  ┌─────────────────────────┐    │
+│ Time   1:42:15  │  CI 1:38:25 – 1:46:20   │    │
+│ Pace   4:50/km  │  CI 4:40 – 5:01 /km     │    │
+│                                                 │
 │ ┌─ chart: 12 weeks ────────────────────┐       │
 │ │ ────────── required (42.5%) ─────────│       │
 │ │                          ▆▇▇         │       │
 │ │           ▃▄▅▅▆▆▆                    │       │
 │ └───────────────────────────────────────┘       │
 │                                                 │
-│ Weekly volume: 28.4 / 84.8 km   (33%)           │
-│ Long run:      18.2 / 17.3 km   (105%)          │
+│ Weekly volume:  33% of required   (28.4 km/wk)  │
+│ Long run:      105% of required   (18.2 km)     │
 │ VO2max:        50.2                             │
 └────────────────────────────────────────────────┘
 ```
+
+**Predicted block** — выводится между header'ом и chart'ом, привязан к **выбранной distance**. Берёт `total_sec` + `pace_sec_per_km` + соответствующие CI low/high из ML-predict pipeline (`predict_splits_with_ci(mode='today')`). При cold-start или below-acceptance модели — блок скрывается полностью (gracefully, без error-state). Подробно — §13.
 
 **Header badge logic:**
 
@@ -204,12 +223,14 @@ progress_pct = round(shape_pct / required_shape_for_distance(distance_km) * 100,
 
 **Chart Y axis:** остаётся **raw `shape_pct`** (objective metric, не меняется при переключении дистанции). Annotation line двигается — это и есть «required для выбранной дистанции». При переключении HM ↔ Marathon кривая не дрожит, меняется только threshold-line.
 
+**Precedent — Runalyze UI** (verified 2026-05-14 на реальном breakdown'е): их формат разбора буквально «In total, you have achieved **18% of your required weekly mileage** and **0% of your required long runs**. This results in a marathon shape of **12%** which equals a marathon in 5:52:04». То есть Runalyze тоже показывает компоненты как **% of required**, а не абсолютные км — `0.67 × 18% + 0.33 × 0% = 12.06% ≈ 12%`. Mirror их UI снимает confusion с absolute-target числом и согласован с тем как метрика была изначально задумана автором. Marathon-time projection (5:52:04) — отдельная модель `f(vo2max, shape_pct)` поверх MS, **out of scope этой фазы** (§9).
+
 ### Components
 
 - **Distance picker** — `TabSwitcher` с тремя опциями (`10K` / `HM` / `Marathon`), default `HM`. State в виджете, не в роутинге.
 - **Header badge** — current MS / required / Δpp с цветом (зелёный если ≥required, жёлтый 80-100%, красный <80%).
 - **Chart** — Chart.js line (как `EFChart`/`DecouplingChart`). X = `week_end` (12 точек), Y = `shape_pct`. Annotation plugin (уже импортирован в Progress.tsx:24) для horizontal `required` линии. Null-points (vo2max missing) — gap в линии.
-- **Components-блок** — простая таблица 3 строки из `current_components`.
+- **Components-блок** — 3 строки из `current_components`. **Формат: «N% of required (raw value)»** — главное число это процент достижения marathon-target, абсолютное значение в скобках для тех кто хочет fact-check. Targets (`target_weekly_km`/`target_longjog_km`) в виджете **не показываются** — они marathon-baseline (`vo2max ** 1.135` / `ln(vo2max/4)*12-13`) и зависят только от VO2max, не от выбранной дистанции. Показ абсолютного «28 / 89 km» при HM-picker'е вызывает confused «надо 89 км/нед на HM??», хотя 89 это для марафона.
 
 ### Empty/edge states
 
@@ -251,6 +272,16 @@ def test_required_shape_per_distance():
     assert round(required_shape_for_distance(42.195), 1) == 99.8   # Marathon
     assert round(required_shape_for_distance(10.0), 1) == 17.0     # 10K
 
+def test_runalyze_precedent_shape_combination():
+    """Regression — Runalyze UI 2026-05-14 stated: 18% weekly + 0% longjog → 12% MS.
+
+    Locks in PERCENTAGE_WEEK_KM (0.67) + PERCENTAGE_LONGJOGS (0.33) weights
+    against upstream drift. If Runalyze ever rebalances weights, this fails
+    loudly and we re-sync.
+    """
+    shape = 100 * (0.67 * 0.18 + 0.33 * 0.0)
+    assert round(shape, 0) == 12
+
 # + scenario tests:
 # - test_steady_weekly_volume_no_longjogs (26 нед × 80 км/нед без longjog'ов → 60-66%)
 # - test_recent_longjog_outweighs_old (today vs 35 дней назад → ratio ≈ 2×)
@@ -278,7 +309,20 @@ API integration (`tests/api/test_dashboard.py::TestMarathonShape`):
 - **Интеграция в утренний отчёт / prompt enrichment** — отдельная история, после валидации виджета.
 - **Distance options 5K / Ultra / 70.3 / IM** — picker сужен до 10K/HM/Marathon. 70.3 run-leg математически = HM (формула identical), IM-run = Marathon — без смысла дублировать.
 - **VO2max calculation from race results** — issue упоминал как fallback, но `wellness.vo2max` достаточно покрывает наших атлетов.
-- **MS per-discipline для triathlon (bike/swim shape)** — Runalyze считает только run-shape.
+- **Runalyze' VDOT-port + empirical shape-penalty.** Их UI считает «Optimum» через Daniels' VDOT (`Calculation/Performance/*.php`) и «Prognosis» через empirical Hannes Christiansen penalty в `plugin/RunalyzePluginPanel_Rechenspiele/`. Penalty **saturating sigmoid-like** (verified на скриншоте 2026-05-14, 5 точек):
+
+  | distance | achieved | penalty multiplier |
+  |---|---|---|
+  | 10K | 73% | 1.016 (+1.6%) |
+  | HM | 29% | 1.114 (+11.4%) |
+  | Marathon | 12% | 1.405 (+40.5%) |
+  | 100K | 4% | 1.483 (+48.3%) |
+  | 160.9K | 2% | 1.483 (+48.3%) ← plateau |
+
+  Penalty достигает потолка ≈+48% при очень низком achieved% — функция saturating, скорее всего logistic с asymptote `~0.48`. Хороший artifact если когда-то решим porting; точная форма лежит в PHP-плагине Runalyze. **Мы это НЕ портим** — у нас есть свой `predict_splits_with_ci` (`data/ml/race_predict.py`), тренированный на личной истории, с 90% CI bootstrap, bias-corrected (Run-only Phase 2.0β2). См. §13 для интеграции. Прямой VDOT-port — out of scope навсегда.
+- **Distance-adjusted weekly/long-run targets per distance** (Runalyze «Other distances» table). Их UI table показывает required weekly mileage и long run per dist (5K=6km, 10K=15km, HM=33km, Marathon=58km — для V≈37). Формула scaling не выводится из `V^1.135` напрямую (`marathon × required/100` даёт 25km для HM, факт 33km). Лежит в `RunalyzePluginPanel_Rechenspiele/` PHP-плагине. Phase 2 enhancement: full-table layout вместо distance picker'а.
+- **«Achieved % per distance» inline list** — дешёвое расширение: рядом с header'ом показать «5K ✓ 170% · 10K ✗ 73% · HM ✗ 29% · Marathon ✗ 12%». Не требует новых формул — `achieved_pct[d] = current_shape_pct / required_shape_pct(d) × 100`. Дает Runalyze-like контекст «куда я готов сейчас», не теряя текущий picker. ~10 строк tsx.
+- **MS per-discipline для triathlon (bike/swim shape)** — Runalyze считает только run-shape. Для bike — см. отдельный [`BIKE_READINESS_SPEC.md`](BIKE_READINESS_SPEC.md).
 - **Historical MS chart >12 нед** — `weeks` param ограничен 24, виджет всегда 12. Расширение — Phase 2 если попросят.
 
 ## 10. Phases
@@ -286,8 +330,9 @@ API integration (`tests/api/test_dashboard.py::TestMarathonShape`):
 | Phase | Scope | Status |
 |---|---|---|
 | **1** | Формулы (`data/marathon_shape.py`) + API endpoint + `MarathonShapeWidget` + unit-тесты | ✅ shipped |
+| **1.5** | ML-based Predicted time + pace block в widget (`predict_splits_with_ci` integration, §13) | 🔵 pending |
 
-Single-phase спека. Phase 2 — только если появится явный запрос (MCP-tool, morning report integration, история >12 нед, ultra/5K расширение picker'а).
+Phase 2 — только если появится явный запрос (MCP-tool, morning report integration, история >12 нед, ultra/5K расширение picker'а, distance-adjusted weekly/long-run targets table per §9).
 
 ## 11. Acceptance criteria
 
@@ -300,6 +345,16 @@ Single-phase спека. Phase 2 — только если появится яв
 - [x] При полном отсутствии run history виджет рендерит badge `Building for {distance}` без crash'а (shape=0, progress=0).
 - [x] Tenant isolation: `user_id` фильтр на activities + wellness, регрессионный тест.
 
+### Phase 1.5 — ML predicted time
+
+- [ ] `/api/marathon-shape` response расширен `predicted_times: {10K, HM, Marathon}` с `total_sec` + `pace_sec_per_km` + `total_sec_ci_low/high` + `pace_ci_low/high` для каждой дистанции.
+- [ ] Cold-start (`ModelNotTrained`) / below-acceptance / отсутствие run-модели → соответствующая дистанция = `null`, остальные могут быть filled. Никаких 500-ок.
+- [ ] Widget показывает Predicted block (Time + Pace + CI), привязанный к выбранной distance из picker'а. При `predicted_times[distance] === null` — блок скрывается, остальной UI рендерится без crash'а.
+- [ ] Pace формат — `M:SS/km` (290 sec → `4:50/km`). Time — `H:MM:SS` для >1h, `MM:SS` иначе.
+- [ ] **Uncertainty-aware UI**: при CI spread > 20% от center value — footnote «model uncertainty high, limited race history» под Predicted block. Test покрывает.
+- [ ] Integration test: endpoint mock'ит `predict_splits_with_ci` (`ModelNotTrained` для одной distance, valid для другой) → response корректно отражает оба случая.
+- [ ] (optional) Redis cache `(user_id, today_iso)` с TTL до полуночи Belgrade. Если skip — задокументировать в PR что cumulative latency на повторных visits приемлема.
+
 ## 12. Phasing & GitHub issues
 
 - [x] **MS-1 — `data/marathon_shape.py` (pure formulas) + unit-тесты.** 87 строк модуль + 22 теста (`tests/data/test_marathon_shape.py`).
@@ -307,11 +362,137 @@ Single-phase спека. Phase 2 — только если появится яв
 - [x] **MS-3 — `MarathonShapeWidget` на Progress.tsx.** Distance picker + chart с annotation line + components-блок. Без i18n — Progress.tsx использует English-литералы inline, виджет в той же стилистике.
 - [x] **MS-4 — Empty/edge states.** «Marathon Shape unavailable» badge при no-data, «VO2max unavailable» при missing vo2max, `spanGaps: true` в chart, скрытие chart'а если все weeks NULL.
 
-## 13. Related
+### Phase 1.5 punch-list
 
-- [BasicEndurance.php — Runalyze source](https://github.com/Runalyze/Runalyze/blob/master/inc/core/Calculation/BasicEndurance.php)
-- [Marathon Shape help](https://runalyze.com/help/article/marathon-shape)
+- [ ] **MS-5 — Endpoint extension.** `/api/marathon-shape` вызывает `predict_splits_with_ci(user_id, mode='today', race_date=today, race_distance_run_m=X)` для 10000 / 21097 / 42195 м **sequentially** через `for`-loop (`asyncio.gather` не даёт parallelism — `_predict_one` sync блокирует loop, см. §13 «Latency»). Try/except каждый — `ModelNotTrained` / `ModelBelowAcceptance` → null для дистанции. ~50 строк в `api/routers/dashboard.py`. Latency overhead: ~240ms.
+- [ ] **MS-6 — Response types + widget render.** `MarathonShapeResponse.predicted_times` поле в `webapp/src/api/types.ts`. Widget рендерит Predicted block (Time / Pace + CI low/high) под header'ом badge'а. Format helpers: `formatHMS(sec)` + `formatPace(sec_per_km)`. ~40 строк tsx.
+- [ ] **MS-7 — Integration test.** Mock `predict_splits_with_ci` → endpoint собирает корректный `predicted_times` envelope, cold-start = null для одной дистанции, valid для другой. ~50 строк.
+
+## 13. ML-based time prediction (Phase 1.5)
+
+### Зачем не Runalyze' VDOT
+
+Runalyze считает «Prognosis» через Daniels' VDOT × empirical Hannes Christiansen shape-penalty (`plugin/RunalyzePluginPanel_Rechenspiele/`). Хорошая first-order модель, но:
+
+- **Универсальная** (general athlete), не personalised — Daniels' tables усреднены по сотням тысяч runner'ов.
+- **Без CI** — точечная оценка, атлет не видит uncertainty.
+- **Empirical shape-penalty** — нелинейная функция от achieved%, требует port отдельного PHP-плагина.
+
+У нас уже есть **`data/ml/race_predict.py:predict_splits_with_ci`** — XGBoost per-discipline, тренированный на личной истории атлета, с **90% CI** через bootstrap-residuals, **bias-corrected** (β2). Включает CTL/ATL/recent-volume/HRV/eFTP features — то есть shape-penalty в Runalyze-смысле уже встроена через ML-features. Сильнее чем Runalyze' эмпирическая формула, не требует port.
+
+### Источник данных
+
+```python
+from data.ml.race_predict import predict_splits_with_ci, ModelNotTrained, ModelBelowAcceptance
+
+# Per-distance Run prediction для widget'а. Sequential, НЕ gather — см. ниже.
+for label, dist_m in [("10K", 10000), ("HM", 21097), ("Marathon", 42195)]:
+    try:
+        env = await predict_splits_with_ci(
+            user_id=uid,
+            mode="today",                        # current state, не race_day projection
+            race_date=today.isoformat(),         # см. note о bias-correction ниже
+            race_distance_run_m=dist_m,
+        )
+        run = env["splits"].get("run")
+        if run and "total_sec" in run:
+            predicted_times[label] = {
+                "total_sec": run["total_sec"],
+                "total_sec_ci_low": run["total_sec_ci_low"],
+                "total_sec_ci_high": run["total_sec_ci_high"],
+                "pace_sec_per_km": round(run["pred"], 1),  # `pred` это sec/km для Run, units field == "sec_per_km"
+                "pace_ci_low": round(run["ci_low"], 1),
+                "pace_ci_high": round(run["ci_high"], 1),
+            }
+        else:
+            predicted_times[label] = None  # power_only_phase1 / total_sec_unavailable
+    except (ModelNotTrained, ModelBelowAcceptance):
+        predicted_times[label] = None      # joblib missing или below-acceptance gate
+```
+
+**Important — `race_date` semantic в `mode='today'`** (verified в `_predict_one`, `data/ml/race_predict.py:341`): даже в today mode `race_date` используется для **bias correction**:
+```
+days_to_race = max((target_date - local_today()).days, 0)
+bias_applied = bias_intercept + bias_slope × days_to_race
+pred -= bias_applied
+```
+Для widget'а передаём `race_date=today.isoformat()` → `days_to_race=0` → applied только intercept (~6 sec/km для Run). Это стабильное поведение. **Не передавайте future race_date** — slope term начнёт двигать pred (~25 sec/km @ 150d), что некорректно для «текущая форма» semantics виджета.
+
+**Latency — sequential, не parallel.** Хотя `predict_splits_with_ci` async, тяжёлая часть `_predict_one` (joblib load + XGBoost predict + bootstrap CI) — **sync, blocking event loop** (см. docstring `race_predict.py:477-479`: *«Heavy ML work stays sync — pandas / joblib don't benefit from async»*). Поэтому `await predict_splits_with_ci()` × 3 в for-loop = `3 × ~80ms = ~240ms` total. `asyncio.gather` поверх трёх `await` не даст parallelism — каждый вызов всё равно блокирует loop через sync `_predict_one`.
+
+Чтобы получить реальный parallelism нужно `asyncio.gather(*[asyncio.to_thread(_sync_call_wrapper, ...) for ...])` — wrapper создаёт fresh event loop для каждого `predict_splits_with_ci` call. Это +complexity ради ~160ms экономии — не стоит для Phase 1.5. Sequential implementation simpler, latency приемлемая.
+
+### Response envelope
+
+```json
+{
+  "weeks": [...],
+  "current_components": {...},
+  "predicted_times": {
+    "10K":      { "total_sec": 3340,  "total_sec_ci_low": 3210,  "total_sec_ci_high": 3490,
+                  "pace_sec_per_km": 334.0, "pace_ci_low": 321.0, "pace_ci_high": 349.0 },
+    "HM":       { "total_sec": 6135,  "total_sec_ci_low": 5905,  "total_sec_ci_high": 6380,
+                  "pace_sec_per_km": 290.7, "pace_ci_low": 280.0, "pace_ci_high": 302.4 },
+    "Marathon": null
+  }
+}
+```
+
+Newest first для `weeks` (как Phase 1). `predicted_times` — dict с фиксированными ключами `10K`/`HM`/`Marathon`, value либо envelope либо null.
+
+### UI rendering
+
+Под header'ом badge'а (`Ready for X: N%`) рендерится **Predicted block**:
+
+```
+Predicted (HM):
+  Time   1:42:15   (CI 1:38:25 – 1:46:20)
+  Pace   4:50/km   (CI 4:40 – 5:01 /km)
+```
+
+Format helpers:
+- `formatHMS(sec)` — `H:MM:SS` для ≥3600 сек, `M:SS` иначе. `6135` → `1:42:15`.
+- `formatPace(sec_per_km)` — `M:SS/km`. `290.7` → `4:50/km` (округление к ближайшей секунде).
+
+Привязано к **выбранной distance** из picker'а — переключение мгновенное, без re-fetch (все три предсказания пришли одним response).
+
+### Edge cases
+
+| Случай | Поведение |
+|---|---|
+| `ModelNotTrained` (нет joblib) для всех дистанций | Predicted block не рендерится, остальной widget работает |
+| `ModelNotTrained` для одной distance, valid для других | Скрываем block только когда picker = эта distance; для остальных показываем |
+| `ModelBelowAcceptance` (R²/MAE ниже threshold) | Аналогично ModelNotTrained — скрываем, не показываем шумную оценку |
+| CI bands пересекают physiological floor (`run` floor = 150 sec/km = 2:30/km) | Уже clamp'ится в `_predict_one` (`race_predict.py:357-364`) — берём как есть |
+| User свежий, нет race history → cold-start | Все 3 = null, block скрыт. Widget работает как Phase 1 only |
+| Mode = `today` vs `race_day` | Используем только `today` — это «текущая форма», не «предсказание на дату». `race_day` нужен для отдельной race-prep страницы, не для виджета базовой выносливости |
+| **Wide CI (uncertainty visibility)** | Если `(total_sec_ci_high − total_sec_ci_low) / total_sec > 0.20` (≥20% spread от center) — UI рендерит footnote «model uncertainty high, limited race history». Атлет с 2-3 races в БД получит wide CI типа «1:32:00 – 1:54:00» что выглядит useless без контекста. Threshold 0.20 эмпирический — соответствует ~10 race samples в training set по нашей калибровке. Альтернатива: при `spread > 0.30` прятать CI bands полностью, оставить только central estimate. |
+
+### Performance / caching
+
+- ML retrain — Sunday 03:00 (`ml-worker` container, isolated queue). Модели стабильны в течение недели.
+- Endpoint вызывается на каждом visit Progress page (sport=run). 3 sequential inference calls × ~80ms = ~240ms latency overhead (см. note выше — gather не дал бы parallelism).
+- **Caching не делаем в core Phase 1.5** — оценки меняются медленно (CTL drifts ~1 unit/day, predicted HM time меняется ~1-2 сек между понедельником и пятницей), +250ms latency приемлемо для диагностического widget'а.
+
+  **Однако** — атлет typically заходит 2-3× в день на dashboard, cumulative экономия 480-720ms на повторные visits. Если widget heat picks up — добавить Redis cache `(user_id, today_iso)` с TTL до полуночи Belgrade. ~15 строк в endpoint, риск нулевой (cache miss работает так же как сейчас). Включено в Phase 1.5 acceptance как **optional**.
+
+### Чего НЕ делаем в Phase 1.5
+
+- **Race-day mode prediction** — `predict_splits_with_ci(mode='race_day')` хорошо бы для race-prep страницы, но не для этого widget'а. Widget показывает «текущая форма», не «куда я приду к дате».
+- **Bike / Swim прогнозы** — спека про MS только Run. Bike прогноз — отдельный widget на bike-tab (см. §14 Related, `BIKE_READINESS_SPEC.md`).
+- **Historical pace trend** — chart показывает MS%, не predicted pace. Time-series predicted pace требовал бы run inference per week — слишком дорого.
+- **Comparison vs Runalyze' Optimum** — у нас нет VDOT-table (и не планируем). Сравнения нет, есть только наш ML.
+
+## 14. Related
+
+- [BasicEndurance.php — Runalyze source](https://github.com/Runalyze/Runalyze/blob/master/inc/core/Calculation/BasicEndurance.php) — calculation layer, формулы shape_pct + target_weekly + target_longjog (scoring-internal).
+- `plugin/RunalyzePluginPanel_Rechenspiele/` (Runalyze repo) — UI panel, рендерит «Other distances» table + Prognosis column. **Where to look for**: distance-adjusted weekly/long-run scaling formula + Prognosis penalty function. Not yet ported — см. §9 Phase 2 ideas.
+- `inc/core/Calculation/Performance/` (Runalyze repo) — VDOT-related race-time prediction. Источник `Optimum` колонки.
+- [Marathon Shape help-article](https://runalyze.com/help/article/marathon-shape) — UI screenshots, formal disclaimer «not scientifically based», examples for distance-adjusted targets.
 - `webapp/src/pages/Progress.tsx` — placement target (line 75, после `PolarizationWidget`)
 - `api/routers/dashboard.py:140` — `weekly_recap` как референс для weekly-bucket pattern
 - `webapp/src/pages/Dashboard.tsx:546` — `WeekCard` как пример рендера weekly данных
 - `data/metrics.py` — соседство для pure-формулы модуля
+- `data/ml/race_predict.py:predict_splits_with_ci` — ML pipeline для Phase 1.5 Predicted time/pace (§13).
+- `mcp_server/tools/race_projection.py` — MCP wrapper над `predict_splits_with_ci` (ссылка для понимания envelope).
+- [`BIKE_READINESS_SPEC.md`](BIKE_READINESS_SPEC.md) — bike-side parallel widget.

--- a/tests/api/test_dashboard.py
+++ b/tests/api/test_dashboard.py
@@ -8,7 +8,7 @@ We only validate the contract the React Dashboard depends on:
 """
 
 from datetime import date, datetime, timedelta, timezone
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import FastAPI
@@ -995,3 +995,191 @@ class TestMarathonShape:
         assert data["current_components"] is not None
         assert data["current_components"]["vo2max"] == 50.0
         assert data["current_components"]["actual_longjog_km"] == 14.0
+
+
+# ---------------------------------------------------------------------------
+# /api/marathon-shape — predicted_times (Phase 1.5)
+# ---------------------------------------------------------------------------
+
+
+def _ml_envelope(*, pred: float, total_sec: int, ci_spread_sec_per_km: float = 10.0) -> dict:
+    """Build a minimal `predict_splits_with_ci` envelope with `run` populated.
+
+    Tests mock the ML call rather than train a real model — we only care that
+    the endpoint plumbs the envelope into `predicted_times` correctly.
+    """
+    ci_low = pred - ci_spread_sec_per_km
+    ci_high = pred + ci_spread_sec_per_km
+    # total_sec_ci scales proportionally to pace CI (same multiplier on distance)
+    total_ci_low = int(total_sec * (ci_low / pred))
+    total_ci_high = int(total_sec * (ci_high / pred))
+    return {
+        "mode": "today",
+        "splits": {
+            "run": {
+                "pred": pred,
+                "ci_low": ci_low,
+                "ci_high": ci_high,
+                "units": "sec_per_km",
+                "total_sec": total_sec,
+                "total_sec_ci_low": total_ci_low,
+                "total_sec_ci_high": total_ci_high,
+            }
+        },
+        "not_available": [],
+        "below_acceptance": [],
+        "warnings": [],
+    }
+
+
+def _ml_envelope_cold_start() -> dict:
+    """Envelope shape when ModelNotTrained is caught internally."""
+    return {
+        "mode": "today",
+        "splits": {},
+        "not_available": ["run"],
+        "below_acceptance": [],
+        "warnings": ["race_run model not trained — call `train-race-models` first"],
+    }
+
+
+def _ml_envelope_below_acceptance() -> dict:
+    """Envelope shape when ModelBelowAcceptance gate trips (CV R²/MAE under floor)."""
+    return {
+        "mode": "today",
+        "splits": {},
+        "not_available": [],
+        "below_acceptance": ["run"],
+        "warnings": ["race_run model below acceptance floor — needs more / cleaner data"],
+    }
+
+
+class TestMarathonShapePredictedTimes:
+    async def test_all_three_distances_filled(self, client):
+        await _seed_vo2max(1, _MS_WINDOW_END, vo2max=50.0)
+
+        def mock_predict(*, race_distance_run_m, **_kwargs):
+            # 10K: 5:34/km, 55:40; HM: 4:51/km, 1:42:15; Marathon: 5:05/km, 3:34:50
+            mapping = {
+                10000: _ml_envelope(pred=334.0, total_sec=3340),
+                21097: _ml_envelope(pred=290.7, total_sec=6135),
+                42195: _ml_envelope(pred=305.4, total_sec=12890),
+            }
+            return mapping[race_distance_run_m]
+
+        with patch(
+            "api.routers.dashboard.predict_splits_with_ci",
+            new=AsyncMock(side_effect=mock_predict),
+        ):
+            async with client as c:
+                resp = await c.get("/api/marathon-shape?weeks=12")
+
+        pt = resp.json()["predicted_times"]
+        assert set(pt.keys()) == {"10K", "HM", "Marathon"}
+        assert pt["10K"]["total_sec"] == 3340
+        assert pt["10K"]["pace_sec_per_km"] == 334.0
+        assert pt["HM"]["total_sec"] == 6135
+        assert pt["Marathon"]["total_sec"] == 12890
+        # CI bounds — assert values, not just key-existence (regression guard:
+        # a future swap of pace_ci_low ↔ total_sec_ci_low would otherwise pass).
+        # _ml_envelope uses ±10 sec/km spread, total_sec scaled proportionally.
+        assert pt["10K"]["pace_ci_low"] == 324.0  # 334 − 10
+        assert pt["10K"]["pace_ci_high"] == 344.0  # 334 + 10
+        assert pt["HM"]["pace_ci_low"] == 280.7  # 290.7 − 10
+        assert pt["HM"]["pace_ci_high"] == 300.7  # 290.7 + 10
+        # total_sec_ci scales as `total × (ci_pace / pred_pace)` per _ml_envelope
+        assert pt["10K"]["total_sec_ci_low"] == int(3340 * (324.0 / 334.0))
+        assert pt["10K"]["total_sec_ci_high"] == int(3340 * (344.0 / 334.0))
+
+    async def test_below_acceptance_distance_null(self, client):
+        """`below_acceptance` envelope path → predicted_times[label] = null.
+
+        Structurally identical to cold-start at the endpoint layer (no `run`
+        key → null), but exercised as a separate path so a future refactor
+        that splits the two doesn't silently regress.
+        """
+        await _seed_vo2max(1, _MS_WINDOW_END, vo2max=50.0)
+
+        with patch(
+            "api.routers.dashboard.predict_splits_with_ci",
+            new=AsyncMock(return_value=_ml_envelope_below_acceptance()),
+        ):
+            async with client as c:
+                resp = await c.get("/api/marathon-shape?weeks=12")
+
+        pt = resp.json()["predicted_times"]
+        assert pt == {"10K": None, "HM": None, "Marathon": None}
+
+    async def test_partial_cold_start_some_distances_null(self, client):
+        """Marathon = cold start, 10K + HM valid — picker switches must still work."""
+        await _seed_vo2max(1, _MS_WINDOW_END, vo2max=50.0)
+
+        def mock_predict(*, race_distance_run_m, **_kwargs):
+            if race_distance_run_m == 42195:
+                return _ml_envelope_cold_start()
+            return _ml_envelope(pred=300.0, total_sec=6000)
+
+        with patch(
+            "api.routers.dashboard.predict_splits_with_ci",
+            new=AsyncMock(side_effect=mock_predict),
+        ):
+            async with client as c:
+                resp = await c.get("/api/marathon-shape?weeks=12")
+
+        pt = resp.json()["predicted_times"]
+        assert pt["10K"] is not None
+        assert pt["HM"] is not None
+        assert pt["Marathon"] is None  # cold start → null
+
+    async def test_total_predict_failure_all_null(self, client):
+        """ML call raises (e.g. joblib I/O fail) → graceful null, no 500."""
+        await _seed_vo2max(1, _MS_WINDOW_END, vo2max=50.0)
+
+        with patch(
+            "api.routers.dashboard.predict_splits_with_ci",
+            new=AsyncMock(side_effect=RuntimeError("joblib load failed")),
+        ):
+            async with client as c:
+                resp = await c.get("/api/marathon-shape?weeks=12")
+
+        assert resp.status_code == 200
+        pt = resp.json()["predicted_times"]
+        assert pt == {"10K": None, "HM": None, "Marathon": None}
+
+    async def test_today_iso_passed_as_race_date(self, client):
+        """Verify spec §13 contract: race_date == today.isoformat() (days_to_race=0)."""
+        await _seed_vo2max(1, _MS_WINDOW_END, vo2max=50.0)
+
+        mock = AsyncMock(return_value=_ml_envelope(pred=300.0, total_sec=6000))
+        with patch("api.routers.dashboard.predict_splits_with_ci", new=mock):
+            async with client as c:
+                await c.get("/api/marathon-shape?weeks=12")
+
+        # 3 calls (10K, HM, Marathon), each with mode='today' + race_date=today
+        assert mock.call_count == 3
+        for call in mock.call_args_list:
+            assert call.kwargs["mode"] == "today"
+            assert call.kwargs["race_date"] == "2026-04-30"  # _FIXED_TODAY
+
+    async def test_total_sec_unavailable_treated_as_null(self, client):
+        """Run envelope without total_sec (e.g. Ride power_only flag) → predicted_times[label] = null."""
+        await _seed_vo2max(1, _MS_WINDOW_END, vo2max=50.0)
+
+        # Pretend run leg came back without total_sec (edge: should never happen
+        # for Run, but the endpoint must be robust)
+        broken_env = {
+            "mode": "today",
+            "splits": {"run": {"pred": 290.0, "ci_low": 280.0, "ci_high": 300.0, "units": "sec_per_km"}},
+            "not_available": [],
+            "below_acceptance": [],
+            "warnings": [],
+        }
+        with patch(
+            "api.routers.dashboard.predict_splits_with_ci",
+            new=AsyncMock(return_value=broken_env),
+        ):
+            async with client as c:
+                resp = await c.get("/api/marathon-shape?weeks=12")
+
+        pt = resp.json()["predicted_times"]
+        assert pt == {"10K": None, "HM": None, "Marathon": None}

--- a/webapp/src/api/types.ts
+++ b/webapp/src/api/types.ts
@@ -743,7 +743,20 @@ export interface MarathonShapeWeek {
   components: MarathonShapeComponents | null
 }
 
+// Phase 1.5 — ML-predicted finish time + pace per distance. Each value is
+// either a full envelope or null (cold-start / below-acceptance / ML failure).
+// See spec §13.
+export interface MarathonShapePredicted {
+  total_sec: number
+  total_sec_ci_low: number
+  total_sec_ci_high: number
+  pace_sec_per_km: number
+  pace_ci_low: number
+  pace_ci_high: number
+}
+
 export interface MarathonShapeResponse {
   weeks: MarathonShapeWeek[]
   current_components: (MarathonShapeComponents & { vo2max: number }) | null
+  predicted_times: Record<'10K' | 'HM' | 'Marathon', MarathonShapePredicted | null>
 }

--- a/webapp/src/pages/Progress.tsx
+++ b/webapp/src/pages/Progress.tsx
@@ -525,6 +525,37 @@ const MS_DISTANCE_TABS = [
   { key: 'Marathon', label: 'Marathon' },
 ]
 
+// Format helpers for the Predicted block (Phase 1.5).
+// `H:MM:SS` for ≥1h, `M:SS` otherwise. 6135 → "1:42:15". 3340 → "55:40".
+// Negative / zero treated as "—" — envelope filtering upstream prevents these,
+// but the guard is free defence against future degenerate model output.
+function formatHMS(sec: number): string {
+  if (!(sec > 0)) return '—'
+  const total = Math.round(sec)
+  const h = Math.floor(total / 3600)
+  const m = Math.floor((total % 3600) / 60)
+  const s = total % 60
+  const ss = String(s).padStart(2, '0')
+  if (h > 0) {
+    const mm = String(m).padStart(2, '0')
+    return `${h}:${mm}:${ss}`
+  }
+  return `${m}:${ss}`
+}
+
+// `M:SS/km`. 290.7 → "4:51/km" (rounded to nearest second).
+function formatPace(secPerKm: number): string {
+  if (!(secPerKm > 0)) return '—'
+  const total = Math.round(secPerKm)
+  const m = Math.floor(total / 60)
+  const s = total % 60
+  return `${m}:${String(s).padStart(2, '0')}/km`
+}
+
+// Spec §13 — surface a footnote when CI is wide enough that the point estimate
+// stops being actionable. Threshold 0.20 = ±10% of central value.
+const MS_WIDE_CI_THRESHOLD = 0.20
+
 function MarathonShapeWidget() {
   const [data, setData] = useState<MarathonShapeResponse | null>(null)
   const [distance, setDistance] = useState<MSDistance>('HM')
@@ -664,6 +695,14 @@ function MarathonShapeWidget() {
   // than helpful. The "VO2max unavailable" message above covers the state.
   const hasAnyData = chronological.some(w => w.shape_pct !== null)
 
+  // Phase 1.5 — ML-predicted finish time + pace for the currently-selected
+  // distance. null when the run model is cold-start / below-acceptance / failed.
+  const predicted = data.predicted_times?.[distance] ?? null
+  const ciSpread = predicted
+    ? (predicted.total_sec_ci_high - predicted.total_sec_ci_low) / predicted.total_sec
+    : 0
+  const wideCi = predicted && ciSpread > MS_WIDE_CI_THRESHOLD
+
   return (
     <div className="bg-surface border border-border rounded-[14px] p-4 mb-3">
       <div className="flex items-center justify-between mb-3">
@@ -687,6 +726,33 @@ function MarathonShapeWidget() {
       ) : (
         <div className="mb-3 mt-2 text-[13px] text-text-dim">
           {newest === null ? 'No data' : 'VO2max unavailable for the most recent week'}
+        </div>
+      )}
+
+      {predicted && (
+        <div className="mb-3 pb-3 border-b border-border">
+          <div className="text-[12px] text-text-dim mb-1.5">Predicted ({distance})</div>
+          <div className="flex gap-6 text-[13px]">
+            <div>
+              <div className="text-text-dim text-[11px]">Time</div>
+              <div className="font-mono font-semibold">{formatHMS(predicted.total_sec)}</div>
+              <div className="text-text-dim text-[11px] font-mono">
+                {formatHMS(predicted.total_sec_ci_low)} – {formatHMS(predicted.total_sec_ci_high)}
+              </div>
+            </div>
+            <div>
+              <div className="text-text-dim text-[11px]">Pace</div>
+              <div className="font-mono font-semibold">{formatPace(predicted.pace_sec_per_km)}</div>
+              <div className="text-text-dim text-[11px] font-mono">
+                {formatPace(predicted.pace_ci_low)} – {formatPace(predicted.pace_ci_high)}
+              </div>
+            </div>
+          </div>
+          {wideCi && (
+            <div className="text-[10px] text-text-dim mt-1.5 italic">
+              Model uncertainty high — limited race history; bands will tighten as more data arrives.
+            </div>
+          )}
         </div>
       )}
 


### PR DESCRIPTION
Integrates machine learning-based prediction of race completion times and paces into the "MarathonShape" API endpoint to enhance diagnostic insights for athletes:

- Introduces asynchronous inference for 10K, Half Marathon, and Marathon distances based on current data
- Displays predicted times and paces with confidence intervals in the UI, informing athletes of model estimations 
- Handles scenarios with cold-start, below-acceptance, and model errors gracefully without crashing the UI
- Updates documentation to reflect changes and limitations in the new integration 

Includes testing for various scenarios:
- Full prediction availability, partial availability, and model failures 
- Ensures robustness against configuration changes in the ML model and backend errors