### PR TITLE
Adds caching for marathon prediction results

### DIFF
--- a/api/routers/dashboard.py
+++ b/api/routers/dashboard.py
@@ -6,6 +6,8 @@ in place for the Today tab and the as-yet-unwired job buttons; the path
 collisions that existed during the END-12/13 cut-over are gone.
 """
 
+import json
+import logging
 import zoneinfo
 from datetime import date, datetime, timedelta
 
@@ -20,7 +22,10 @@ from data.db.dto import AthleteGoalDTO
 from data.marathon_shape import DAYS_FOR_WEEK_KM, RunActivity, calculate_marathon_shape
 from data.metrics import PROJECTION_WINDOW_DAYS, project_ctl_target
 from data.ml.race_predict import predict_splits_with_ci
+from data.redis_client import get_redis
 from data.utils import extract_sport_ctl, normalize_sport
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -40,6 +45,17 @@ _SPORT_MAP = {
 
 def _today_local() -> date:
     return datetime.now(zoneinfo.ZoneInfo(settings.TIMEZONE)).date()
+
+
+def _ttl_until_midnight_local() -> int:
+    """Seconds until next midnight in `settings.TIMEZONE`. Used as TTL for
+    same-day caches (e.g. marathon-shape predicted_times) so the cache flushes
+    exactly when «today» rolls over. Floor at 60s to avoid pathological
+    sub-minute TTLs near midnight from a clock skew."""
+    tz = zoneinfo.ZoneInfo(settings.TIMEZONE)
+    now = datetime.now(tz)
+    midnight = (now + timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
+    return max(60, int((midnight - now).total_seconds()))
 
 
 def _nearest_wellness(
@@ -581,25 +597,76 @@ async def marathon_shape(
         }
 
     # ── Phase 1.5: ML-based Predicted time + pace per distance.
-    # Sequential await — `predict_splits_with_ci` is async at the outer layer
-    # but `_predict_one` (joblib + XGBoost + bootstrap) is sync and blocks the
-    # loop; `asyncio.gather` wouldn't give parallelism (spec §13 Latency).
-    # Each call ~80ms × 3 = ~240ms total. `predict_splits_with_ci` catches
-    # ModelNotTrained / ModelBelowAcceptance internally and surfaces them via
-    # `not_available` / `below_acceptance` lists — we just check whether the
-    # "run" split landed in the envelope.
-    #
-    # Minor inefficiency: `_load_model` (data/ml/race_predict.py:97) has no
-    # cache, so the same `race_run_{user_id}.joblib` is read from disk 3× per
-    # request. ~50ms each is the dominant cost. Decoupling load from quality-
-    # gate enforcement would let us cache the bundle, but it's a cross-cutting
-    # change in shared infra — defer until joblib I/O becomes hot.
-    predicted_times: dict[str, dict | None] = {}
     today_iso = today.isoformat()
-    for label, dist_m in (("10K", 10000), ("HM", 21097), ("Marathon", 42195)):
+    predicted_times = await _compute_predicted_times(uid, today_iso)
+
+    return {
+        "weeks": weeks_out,
+        "current_components": current_components,
+        "predicted_times": predicted_times,
+    }
+
+
+_MS_PREDICT_CACHE_KEY = "marathon_shape_pred:{user_id}:{today_iso}"
+_MS_DISTANCES: tuple[tuple[str, int], ...] = (("10K", 10000), ("HM", 21097), ("Marathon", 42195))
+
+
+async def _compute_predicted_times(user_id: int, today_iso: str) -> dict[str, dict | None]:
+    """Return per-distance ML predictions (10K / HM / Marathon) for user.
+
+    Backed by a Redis cache keyed on ``(user_id, today_iso)`` with TTL to the
+    next local midnight — predictions shift slowly within a day (CTL drifts
+    ~1 unit/day), so per-day staleness is acceptable for this diagnostic view.
+    Cache miss / Redis unavailable / Redis errors fall through to fresh
+    computation. Cache write failures are logged but don't break the response.
+    """
+    cache_key = _MS_PREDICT_CACHE_KEY.format(user_id=user_id, today_iso=today_iso)
+    redis_client = get_redis()
+    if redis_client is not None:
+        try:
+            cached = await redis_client.get(cache_key)
+            if cached is not None:
+                return json.loads(cached)
+        except Exception as e:  # noqa: BLE001 — Redis errors must never break the endpoint
+            logger.warning("Marathon-shape predict cache read failed: %s", e)
+
+    predicted_times = await _predict_times_fresh(user_id, today_iso)
+
+    if redis_client is not None:
+        try:
+            await redis_client.set(
+                cache_key,
+                json.dumps(predicted_times),
+                ex=_ttl_until_midnight_local(),
+            )
+        except Exception as e:  # noqa: BLE001 — same: cache-write failure must not break the response
+            logger.warning("Marathon-shape predict cache write failed: %s", e)
+
+    return predicted_times
+
+
+async def _predict_times_fresh(user_id: int, today_iso: str) -> dict[str, dict | None]:
+    """Cache-free per-distance ML prediction. Sequential await — see notes below.
+
+    Sequential reasoning: `predict_splits_with_ci` is async at the outer layer
+    but `_predict_one` (joblib + XGBoost + bootstrap) is sync and blocks the
+    loop; `asyncio.gather` wouldn't give parallelism (spec §13 Latency).
+    Each call ~80ms × 3 = ~240ms total. `predict_splits_with_ci` catches
+    ModelNotTrained / ModelBelowAcceptance internally and surfaces them via
+    `not_available` / `below_acceptance` lists — we just check whether the
+    "run" split landed in the envelope.
+
+    Minor inefficiency: `_load_model` (data/ml/race_predict.py:97) has no
+    cache, so the same `race_run_{user_id}.joblib` is read from disk 3× per
+    request. ~50ms each is the dominant cost. Decoupling load from quality-
+    gate enforcement would let us cache the bundle, but it's a cross-cutting
+    change in shared infra — defer until joblib I/O becomes hot.
+    """
+    predicted_times: dict[str, dict | None] = {}
+    for label, dist_m in _MS_DISTANCES:
         try:
             env = await predict_splits_with_ci(
-                user_id=uid,
+                user_id=user_id,
                 mode="today",
                 race_date=today_iso,  # spec §13: today_iso → days_to_race=0 → only intercept bias applied
                 race_distance_run_m=dist_m,
@@ -608,29 +675,43 @@ async def marathon_shape(
             # `predict_splits_with_ci` already filters expected ML errors into
             # envelope lists, so anything reaching here is unexpected and worth
             # a Sentry alert (corrupt joblib, missing feature column, etc.).
-            sentry_sdk.capture_exception(e)
+            # `push_scope` keeps the tags/context scoped to this one capture
+            # — doesn't leak into Sentry events fired by later requests on the
+            # same worker.
+            with sentry_sdk.push_scope() as scope:
+                scope.set_tag("endpoint", "marathon_shape")
+                scope.set_context(
+                    "predict",
+                    {
+                        "user_id": user_id,
+                        "label": label,
+                        "race_distance_m": dist_m,
+                    },
+                )
+                sentry_sdk.capture_exception(e)
             predicted_times[label] = None
             continue
 
         # Run leg is always pace-based — `total_sec_unavailable` flag is a
         # Ride-only marker (power_only_phase1, see race_predict.py:449-451).
-        # If Run lacks `total_sec` here, the envelope is malformed; treat as
-        # null defensively.
-        run = env.get("splits", {}).get("run")
-        if run and run.get("total_sec") is not None:
-            predicted_times[label] = {
-                "total_sec": run["total_sec"],
-                "total_sec_ci_low": run["total_sec_ci_low"],
-                "total_sec_ci_high": run["total_sec_ci_high"],
-                "pace_sec_per_km": round(run["pred"], 1),
-                "pace_ci_low": round(run["ci_low"], 1),
-                "pace_ci_high": round(run["ci_high"], 1),
-            }
-        else:
+        # Defensive `.get()` across the full key set: if the envelope is ever
+        # partial (e.g. upstream contract change leaves one CI bound missing),
+        # we degrade to null instead of raising KeyError into the outer except
+        # (which would over-fire Sentry on a *malformed* envelope rather than
+        # a *crashed* model — different signal entirely).
+        run = env.get("splits", {}).get("run") or {}
+        expected = ("total_sec", "total_sec_ci_low", "total_sec_ci_high", "pred", "ci_low", "ci_high")
+        values = {k: run.get(k) for k in expected}
+        if any(v is None for v in values.values()):
             predicted_times[label] = None
+            continue
 
-    return {
-        "weeks": weeks_out,
-        "current_components": current_components,
-        "predicted_times": predicted_times,
-    }
+        predicted_times[label] = {
+            "total_sec": values["total_sec"],
+            "total_sec_ci_low": values["total_sec_ci_low"],
+            "total_sec_ci_high": values["total_sec_ci_high"],
+            "pace_sec_per_km": round(values["pred"], 1),
+            "pace_ci_low": round(values["ci_low"], 1),
+            "pace_ci_high": round(values["ci_high"], 1),
+        }
+    return predicted_times

--- a/docs/MARATHON_SHAPE_SPEC.md
+++ b/docs/MARATHON_SHAPE_SPEC.md
@@ -330,7 +330,7 @@ API integration (`tests/api/test_dashboard.py::TestMarathonShape`):
 | Phase | Scope | Status |
 |---|---|---|
 | **1** | Формулы (`data/marathon_shape.py`) + API endpoint + `MarathonShapeWidget` + unit-тесты | ✅ shipped |
-| **1.5** | ML-based Predicted time + pace block в widget (`predict_splits_with_ci` integration, §13) | 🔵 pending |
+| **1.5** | ML-based Predicted time + pace block в widget (`predict_splits_with_ci` integration, §13) + Redis cache | ✅ shipped |
 
 Phase 2 — только если появится явный запрос (MCP-tool, morning report integration, история >12 нед, ultra/5K расширение picker'а, distance-adjusted weekly/long-run targets table per §9).
 
@@ -353,7 +353,7 @@ Phase 2 — только если появится явный запрос (MCP-
 - [ ] Pace формат — `M:SS/km` (290 sec → `4:50/km`). Time — `H:MM:SS` для >1h, `MM:SS` иначе.
 - [ ] **Uncertainty-aware UI**: при CI spread > 20% от center value — footnote «model uncertainty high, limited race history» под Predicted block. Test покрывает.
 - [ ] Integration test: endpoint mock'ит `predict_splits_with_ci` (`ModelNotTrained` для одной distance, valid для другой) → response корректно отражает оба случая.
-- [ ] (optional) Redis cache `(user_id, today_iso)` с TTL до полуночи Belgrade. Если skip — задокументировать в PR что cumulative latency на повторных visits приемлема.
+- [x] Redis cache `(user_id, today_iso)` с TTL до полуночи Belgrade. `_compute_predicted_times` / `_predict_times_fresh` в `api/routers/dashboard.py`. Graceful fallback при Redis disabled / unreachable / get-write errors — endpoint никогда не падает из-за cache. 4 теста (`test_cache_hit_skips_ml_call`, `test_cache_miss_writes_through`, `test_cache_disabled_falls_through`, `test_cache_write_failure_does_not_break_response`).
 
 ## 12. Phasing & GitHub issues
 
@@ -364,9 +364,10 @@ Phase 2 — только если появится явный запрос (MCP-
 
 ### Phase 1.5 punch-list
 
-- [ ] **MS-5 — Endpoint extension.** `/api/marathon-shape` вызывает `predict_splits_with_ci(user_id, mode='today', race_date=today, race_distance_run_m=X)` для 10000 / 21097 / 42195 м **sequentially** через `for`-loop (`asyncio.gather` не даёт parallelism — `_predict_one` sync блокирует loop, см. §13 «Latency»). Try/except каждый — `ModelNotTrained` / `ModelBelowAcceptance` → null для дистанции. ~50 строк в `api/routers/dashboard.py`. Latency overhead: ~240ms.
-- [ ] **MS-6 — Response types + widget render.** `MarathonShapeResponse.predicted_times` поле в `webapp/src/api/types.ts`. Widget рендерит Predicted block (Time / Pace + CI low/high) под header'ом badge'а. Format helpers: `formatHMS(sec)` + `formatPace(sec_per_km)`. ~40 строк tsx.
-- [ ] **MS-7 — Integration test.** Mock `predict_splits_with_ci` → endpoint собирает корректный `predicted_times` envelope, cold-start = null для одной дистанции, valid для другой. ~50 строк.
+- [x] **MS-5 — Endpoint extension.** `/api/marathon-shape` вызывает `predict_splits_with_ci(user_id, mode='today', race_date=today_iso, race_distance_run_m=X)` для 10000 / 21097 / 42195 м **sequentially** через `for`-loop в `_predict_times_fresh` (`asyncio.gather` не даёт parallelism — `_predict_one` sync блокирует loop, см. §13 «Latency»). Try/except каждый — `ModelNotTrained` / `ModelBelowAcceptance` → null для дистанции; unexpected errors → Sentry + null. ~80 строк в `api/routers/dashboard.py`.
+- [x] **MS-6 — Response types + widget render.** `MarathonShapeResponse.predicted_times` + `MarathonShapePredicted` в `webapp/src/api/types.ts`. Widget рендерит Predicted block (Time / Pace + CI low/high) под header'ом badge'а с `formatHMS` / `formatPace` helpers (защита от `sec <= 0` через `'—'`). Wide-CI footnote при spread > 20%.
+- [x] **MS-7 — Integration test.** Mock `predict_splits_with_ci` → endpoint собирает корректный `predicted_times` envelope, cold-start = null для одной дистанции, valid для другой. 10 тестов в `TestMarathonShapePredictedTimes` (6 endpoint + 4 cache).
+- [x] **MS-8 — Redis cache layer.** `_compute_predicted_times` обёртка над `_predict_times_fresh`, key `marathon_shape_pred:{user_id}:{today_iso}`, TTL через `_ttl_until_midnight_local()`. Graceful fallback на каждом из 3 cache failure mode'ов.
 
 ## 13. ML-based time prediction (Phase 1.5)
 

--- a/tests/api/test_dashboard.py
+++ b/tests/api/test_dashboard.py
@@ -7,6 +7,7 @@ We only validate the contract the React Dashboard depends on:
 - per-user scoping.
 """
 
+import json
 from datetime import date, datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -1160,6 +1161,91 @@ class TestMarathonShapePredictedTimes:
         for call in mock.call_args_list:
             assert call.kwargs["mode"] == "today"
             assert call.kwargs["race_date"] == "2026-04-30"  # _FIXED_TODAY
+
+    async def test_cache_hit_skips_ml_call(self, client):
+        """When Redis returns cached predicted_times, ML inference is skipped."""
+        await _seed_vo2max(1, _MS_WINDOW_END, vo2max=50.0)
+        cached = {
+            "10K": {
+                "total_sec": 3340,
+                "total_sec_ci_low": 3210,
+                "total_sec_ci_high": 3490,
+                "pace_sec_per_km": 334.0,
+                "pace_ci_low": 321.0,
+                "pace_ci_high": 349.0,
+            },
+            "HM": None,
+            "Marathon": None,
+        }
+        mock_redis = MagicMock()
+        mock_redis.get = AsyncMock(return_value=json.dumps(cached))
+        mock_redis.set = AsyncMock()
+        ml_mock = AsyncMock(return_value=_ml_envelope(pred=999.9, total_sec=99999))
+
+        with (
+            patch("api.routers.dashboard.get_redis", return_value=mock_redis),
+            patch("api.routers.dashboard.predict_splits_with_ci", new=ml_mock),
+        ):
+            async with client as c:
+                resp = await c.get("/api/marathon-shape?weeks=12")
+
+        assert resp.json()["predicted_times"] == cached
+        ml_mock.assert_not_called()  # cache hit skipped all 3 inference calls
+
+    async def test_cache_miss_writes_through(self, client):
+        """Cache miss → ML called → result written to Redis with TTL."""
+        await _seed_vo2max(1, _MS_WINDOW_END, vo2max=50.0)
+        mock_redis = MagicMock()
+        mock_redis.get = AsyncMock(return_value=None)  # miss
+        mock_redis.set = AsyncMock()
+        ml_mock = AsyncMock(return_value=_ml_envelope(pred=300.0, total_sec=6000))
+
+        with (
+            patch("api.routers.dashboard.get_redis", return_value=mock_redis),
+            patch("api.routers.dashboard.predict_splits_with_ci", new=ml_mock),
+        ):
+            async with client as c:
+                await c.get("/api/marathon-shape?weeks=12")
+
+        assert ml_mock.call_count == 3
+        mock_redis.set.assert_called_once()
+        # set(key, json_value, ex=ttl) — verify TTL is positive
+        _kwargs = mock_redis.set.call_args.kwargs
+        assert _kwargs["ex"] > 0  # TTL until midnight
+
+    async def test_cache_disabled_falls_through(self, client):
+        """`get_redis() is None` (Redis disabled) → endpoint computes fresh, no error."""
+        await _seed_vo2max(1, _MS_WINDOW_END, vo2max=50.0)
+        ml_mock = AsyncMock(return_value=_ml_envelope(pred=300.0, total_sec=6000))
+
+        with (
+            patch("api.routers.dashboard.get_redis", return_value=None),
+            patch("api.routers.dashboard.predict_splits_with_ci", new=ml_mock),
+        ):
+            async with client as c:
+                resp = await c.get("/api/marathon-shape?weeks=12")
+
+        assert resp.status_code == 200
+        assert ml_mock.call_count == 3
+        assert resp.json()["predicted_times"]["10K"] is not None
+
+    async def test_cache_write_failure_does_not_break_response(self, client):
+        """Redis.set raising must not 500 — response still carries fresh ML output."""
+        await _seed_vo2max(1, _MS_WINDOW_END, vo2max=50.0)
+        mock_redis = MagicMock()
+        mock_redis.get = AsyncMock(return_value=None)
+        mock_redis.set = AsyncMock(side_effect=RuntimeError("Redis unreachable"))
+        ml_mock = AsyncMock(return_value=_ml_envelope(pred=300.0, total_sec=6000))
+
+        with (
+            patch("api.routers.dashboard.get_redis", return_value=mock_redis),
+            patch("api.routers.dashboard.predict_splits_with_ci", new=ml_mock),
+        ):
+            async with client as c:
+                resp = await c.get("/api/marathon-shape?weeks=12")
+
+        assert resp.status_code == 200
+        assert resp.json()["predicted_times"]["10K"] is not None
 
     async def test_total_sec_unavailable_treated_as_null(self, client):
         """Run envelope without total_sec (e.g. Ride power_only flag) → predicted_times[label] = null."""


### PR DESCRIPTION
Implements Redis caching for marathon time predictions to improve response times. 

- Introduces a cache layer that stores ML prediction results with a TTL set to the next local midnight.
- Fallback methods are in place for cache misses, Redis unavailability, or write failures to ensure the endpoint remains operational.
- Updates associated tests to cover new cache logic, ensuring comprehensive test coverage.

Addresses performance concerns by reducing redundant ML model loads.