### PR TITLE
Add bike readiness feature to the dashboard API

### DIFF
--- a/api/routers/dashboard.py
+++ b/api/routers/dashboard.py
@@ -24,6 +24,7 @@ from data.metrics import PROJECTION_WINDOW_DAYS, project_ctl_target
 from data.ml.race_predict import predict_splits_with_ci
 from data.redis_client import get_redis
 from data.utils import extract_sport_ctl, normalize_sport
+from mcp_server.tools.progress import compute_efficiency_trend
 
 logger = logging.getLogger(__name__)
 
@@ -743,3 +744,141 @@ async def _predict_times_fresh(user_id: int, today_iso: str) -> dict[str, dict |
             "pace_ci_high": round(values["ci_high"], 1),
         }
     return predicted_times
+
+
+@router.get("/api/bike-readiness")
+async def bike_readiness(
+    weeks: int = Query(default=12, ge=1, le=24),
+    user: User = Depends(require_viewer),
+) -> dict:
+    """Bike readiness — CTL_bike trend + current 3-signal snapshot.
+
+    For each of the last ``weeks`` Mon-Sun weeks (ending at the most recent
+    Sunday ≤ today), returns the CTL_bike value extracted from
+    ``wellness.sport_info``. ``current_components`` carries the longest ride
+    in the last 28 days, the median decoupling of the last 5 valid bike
+    rides over 84 days, and the EF trend over that same window — the inputs
+    to the widget's 3-signal traffic-light verdict.
+
+    Distance-specific targets (Olympic / 70.3 / IM) and the verdict itself
+    are computed CLIENT-side — endpoint returns absolute values only
+    (spec §3, §5).
+    """
+    today = _today_local()
+    days_since_sunday = (today.weekday() + 1) % 7
+    window_end = today - timedelta(days=days_since_sunday)
+    window_start = window_end - timedelta(weeks=weeks - 1, days=6)
+    # 7-day back-walk per spec §7: a Sunday with NULL `sport_info` falls
+    # back to the most recent earlier day with a value (CTL drifts slowly,
+    # τ=42d, so 7d-stale is safe).
+    wellness_start = window_start - timedelta(days=7)
+    longest_window_start = today - timedelta(days=28)
+
+    uid = get_data_user_id(user)
+    async with get_session() as session:
+        wellness_result = await session.execute(
+            select(Wellness.date, Wellness.sport_info).where(
+                Wellness.user_id == uid,
+                Wellness.date >= wellness_start.isoformat(),
+                Wellness.date <= window_end.isoformat(),
+            )
+        )
+        wellness_rows = wellness_result.all()
+
+        # Longest training ride in 28d: race-effort excluded (spec §3.2, §7) —
+        # `is_race=True` is peak load, not training base. Activity.type is
+        # canonical post-normalisation (data/intervals/dto.py:_normalize_type
+        # maps VirtualRide / GravelRide / etc → "Ride"), so a single
+        # `type == "Ride"` filter covers all bike variants. `start_date_local`
+        # is a String column ("YYYY-MM-DD"), iso compare is correct.
+        longest_result = await session.execute(
+            select(Activity.start_date_local, Activity.moving_time)
+            .where(
+                Activity.user_id == uid,
+                Activity.type == "Ride",
+                Activity.is_race.is_(False),
+                Activity.start_date_local >= longest_window_start.isoformat(),
+            )
+            .order_by(Activity.moving_time.desc())
+            .limit(1)
+        )
+        longest_row = longest_result.first()
+
+    ctl_bike_by_date: dict[str, float | None] = {
+        dt_str: extract_sport_ctl(sport_info).get("ride") for dt_str, sport_info in wellness_rows
+    }
+
+    def _ctl_bike_at(anchor: date, back_days: int = 7) -> float | None:
+        for delta in range(back_days + 1):
+            v = ctl_bike_by_date.get((anchor - timedelta(days=delta)).isoformat())
+            if v is not None:
+                return v
+        return None
+
+    weeks_out: list[dict] = []
+    for i in range(weeks):
+        wk_start = window_start + timedelta(weeks=i)
+        wk_end = wk_start + timedelta(days=6)
+        weeks_out.append(
+            {
+                "week_start": wk_start.isoformat(),
+                "week_end": wk_end.isoformat(),
+                "ctl_bike": _ctl_bike_at(wk_end),
+            }
+        )
+    # Newest first — consistent with `/api/marathon-shape` and `/api/weekly-recap`.
+    weeks_out.reverse()
+
+    longest_ride_hours: float | None = None
+    longest_ride_date: str | None = None
+    if longest_row is not None:
+        dt_str, mt = longest_row
+        if mt is not None and mt > 0:
+            longest_ride_hours = round(mt / 3600.0, 2)
+            longest_ride_date = dt_str
+
+    # Single helper call gives both Durability median and supplementary EF
+    # trend (spec §5). `strict_filter=True` applies `is_valid_for_decoupling`
+    # (VI ≤ 1.10, >70% Z1+Z2, ride ≥ 60 min) — no duplicate pipeline here.
+    eff = await compute_efficiency_trend(
+        user_id=uid,
+        sport="bike",
+        days_back=84,
+        group_by="week",
+        strict_filter=True,
+    )
+    # `compute_efficiency_trend` collapses to a single-sport dict when only
+    # one sport is requested; `decoupling_trend` is absent when no valid
+    # rides cleared the filter, and `trend` is `insufficient_data` when
+    # there's < 2 weekly EF samples — guard both.
+    decoup_trend = eff.get("decoupling_trend") if isinstance(eff, dict) else None
+    trend = eff.get("trend") if isinstance(eff, dict) else None
+
+    if isinstance(decoup_trend, dict):
+        decoupling_median_pct = decoup_trend.get("median")
+        decoupling_status = decoup_trend.get("status")
+        decoupling_n = decoup_trend.get("last_n", 0)
+    else:
+        decoupling_median_pct = None
+        decoupling_status = None
+        decoupling_n = 0
+
+    if isinstance(trend, dict) and trend.get("direction") != "insufficient_data":
+        ef_trend_pct: float | None = trend.get("pct")
+    else:
+        ef_trend_pct = None
+
+    current_components = {
+        "ctl_bike": weeks_out[0]["ctl_bike"] if weeks_out else None,
+        "longest_ride_hours": longest_ride_hours,
+        "longest_ride_date": longest_ride_date,
+        "decoupling_median_pct": decoupling_median_pct,
+        "decoupling_status": decoupling_status,
+        "decoupling_n": decoupling_n,
+        "ef_trend_pct": ef_trend_pct,
+    }
+
+    return {
+        "weeks": weeks_out,
+        "current_components": current_components,
+    }

--- a/docs/BIKE_READINESS_SPEC.md
+++ b/docs/BIKE_READINESS_SPEC.md
@@ -1,0 +1,601 @@
+# Bike Readiness — durability-aware bike-leg readiness widget
+
+> Status: 🔵 **Draft** — single-phase webapp widget. No new MCP tool, no morning report, no schema changes.
+>
+> Companion to [`MARATHON_SHAPE_SPEC.md`](MARATHON_SHAPE_SPEC.md) — the bike side of «am I ready for the race-leg».
+
+---
+
+## 1. Problem
+
+Для бега у нас есть `Marathon Shape` — volume + longjog в одном проценте. На велике аналогичной готовности нет, и в индустрии **общепринятого «Bike Shape %» не существует** (Runalyze явно отказались — см. §13; TrainingPeaks / Intervals.icu / Xert также не выпускают единого процента). Причина методологическая: distance на велике плохой прокси для базовой выносливости (60 км по горам ≠ 60 км в парке, indoor — distance фиктивна), поэтому индустрия меряет bike-готовность через **kJ/TSS + duration + decoupling**, а не через distance.
+
+При этом у Радика конкретный продуктовый вопрос «хватит ли мне ножек на 90 км bike-leg в Кальяри 28 июня» — и текущий стек метрик (CTL_bike, Pa:Hr, EF) хорошо отвечает на него **по отдельности**, но не собран в одну карточку с явным verdict'ом. Виджет на `/progress` решает именно эту сборку, не вводя новой синтетической математики.
+
+### Declarative stance
+
+**No industry precedent → no synthetic combo.** В велоспорте нет общепринятой «Bike Shape %» метрики (Runalyze явно отказался, TrainingPeaks/Intervals/Xert — тоже). Поэтому мы **не изобретаем weighted-combo формулу** с весами «пальцем в небо». Вместо этого виджет показывает **три well-validated independent signal'а** (CTL_bike, longest ride duration, decoupling) с traffic-light verdict-логикой — mirror практический pattern Joel Filliol / Coggan style readiness assessment, не новый index.
+
+**Phase 1.5 единственный value-add — ML Predicted Power.** Симметрично Marathon Shape §1: за base readiness берём industry-best multi-signal pattern, добавляем сверху ML inference как value-add. Bike-leg pacing band («target 240W, CI 230-250W») actionable для race-day — это и есть наша инновация над industry baseline.
+
+Decision rule для будущих изменений: «если найдём industry precedent (Runalyze добавит bike, или Coggan published explicit formula) — фиксим в сторону upstream. До тех пор — three signals stay independent, no synthetic».
+
+---
+
+## 2. Solution overview
+
+Виджет `BikeReadinessWidget` на `webapp/src/pages/Progress.tsx` при `sport='bike'`, разместить **после `ProgressionWidget`** (см. `Progress.tsx:77`). Виджет показывает:
+
+1. **Distance picker** — `Olympic / 70.3 / IM` (3 опции, default `70.3`).
+2. **Header verdict** — «Ready / Almost ready / Building for {distance}» по логике 3-сигнальной оценки.
+3. **Volume chart** — CTL_bike trend за 12 недель + horizontal annotation line на `target_ctl_for_distance`.
+4. **Components-блок** — три карточки: Volume (CTL_bike actual/target), Long ride (max ride duration за 4 нед / target), Durability (avg decoupling за 4 нед).
+
+Backend: один endpoint `GET /api/bike-readiness?weeks=12` отдаёт time-series для CTL chart'а + текущие значения трёх сигналов. Distance-specific targets — табличные (см. §3), вычисляются на клиенте.
+
+Никаких изменений схемы — читаем `wellness.sport_info` (CTL_bike), `activities` (longest ride), `activity_details.decoupling` (+ `is_valid_for_decoupling` filter).
+
+**Принципиальное решение:** виджет **не считает синтетический Bike Shape %**. Three signals + traffic-light verdict, без weighted-combo формулы. Обоснование см. §12 Considered alternatives — там же зафиксированы два отвергнутых варианта.
+
+---
+
+## 3. Метрики
+
+Три независимых сигнала. Без weighted combo, без синтетических процентов.
+
+### 3.1 Volume — CTL_bike
+
+Источник: `Wellness.sport_info` (JSON, заполняется из Intervals.icu pipeline) → `extract_sport_ctl(sport_info)["ride"]` из `data/utils.py:81`.
+
+```python
+# За newest week_end в окне:
+ctl_bike = extract_sport_ctl(wellness_row.sport_info)["ride"]
+ctl_ratio = ctl_bike / target_ctl_for_distance(distance)
+```
+
+**Targets** (calibrated empirical, AG-athlete reference range):
+
+| Distance | target_ctl_bike |
+|---|---|
+| Olympic (40 km bike) | 50 |
+| 70.3 (90 km bike) | 75 |
+| IM (180 km bike) | 100 |
+
+**Provenance:** числа калиброваны под mid-pack AG-triathlete profile (FTP 200-250W, weekly bike training 4-8h, CTL 50-100 range). Источники inspiration — Joe Friel «The Triathlete's Training Bible» (CTL bands per race distance, без точных цифр), Joel Filliol practitioner posts, общие Coggan/Allen «Training and Racing with a Power Meter» CTL guidance. **В литературе точные цифры 50/75/100 не написаны** — bands там приведены приблизительно (например Friel: «70.3 athlete CTL range 60-90 во время peak phase»). Наш table — midpoint этих bands, calibrated на Радика 2026.
+
+**Calibration caveat:** табличные значения не валидированы на elite (CTL 120+ для 70.3) и beginner (CTL 30-50) brackets. Для Радика и AG-аудитории работают. Если в production обнаружим material drift на других уровнях — escalate via §10 Phase 2 (parameterise от FTP+age, либо двигать table values после feedback от других атлетов).
+
+Это **табличные значения**, не функция FTP. Альтернатив (степенная формула от FTP/VO2max) для bike-CTL в литературе нет; я искал и не нашёл, ровно поэтому здесь таблица.
+
+**Traffic light:**
+- 🟢 ctl_ratio ≥ 1.00 (CTL ≥ target)
+- 🟡 0.80 ≤ ctl_ratio < 1.00
+- 🔴 ctl_ratio < 0.80
+
+### 3.2 Long ride — longest ride за DAYS_FOR_LONGRIDE окно
+
+```python
+DAYS_FOR_LONGRIDE = 28  # 4 недели
+longest_ride_hours = max(act.moving_time for act in bike_activities_last_28d) / 3600
+long_ride_ratio = longest_ride_hours / target_long_ride_hours(distance)
+```
+
+**Targets** (long ride должен покрывать race-bike-leg duration с небольшим запасом по верху):
+
+| Distance | target_long_ride_hours | Обоснование |
+|---|---|---|
+| Olympic | 1.5 | Race bike ~1ч @ 35 km/h → tolerance margin |
+| 70.3 | 3.0 | Race bike ~2.5-3ч → ride хотя бы как race |
+| IM | 5.0 | Race bike ~5-6ч → стандарт IM-prep |
+
+**Olympic — informational only.** Threshold 1.5h осознанно низкий: bike-leg Olympic короткая, любой consistent rider (4+ часов в неделю) набирает 1.5h ride без специальных усилий. Signal **не дискриминирует** Olympic-ready vs не-готов — для коротких дистанций Volume и Durability сигналы информативнее. Снижать дальше (e.g. 1.2h = race duration) не имеет смысла — атлет на race-leg 1ч должен иметь long ride хотя бы 1.5x race. Олимпийку оставили в picker'е для completeness виджета (другие атлеты могут гоняться Olympic); если будет feedback что эта дистанция misleading — drop из picker'а в Phase 2.
+
+**Filter for «ride»:** `Activity.type IN ('Ride', 'VirtualRide')`, `is_race=False`. Race-effort исключаем — race это пиковая нагрузка, не индикатор тренировочной готовности (consistent с MS §7).
+
+**Traffic light:**
+- 🟢 long_ride_ratio ≥ 1.00
+- 🟡 0.80 ≤ long_ride_ratio < 1.00
+- 🔴 long_ride_ratio < 0.80
+
+### 3.3 Durability — median decoupling из последних 5 валидных rides
+
+**Переиспользуем** `compute_efficiency_trend(user_id, sport='bike', days_back=84, strict_filter=True)` из `mcp_server/tools/progress.py:99`. Эта функция уже возвращает `decoupling_trend` с фиксированной агрегацией:
+
+```python
+# Из существующего output:
+decoupling_trend = {
+  "last_n": 5,                       # сколько rides взято
+  "median": 4.2,                     # %, median of last 5 valid rides
+  "status": "green",                 # decoupling_status(median) → green/yellow/red
+  "values": [3.8, 4.5, 4.2, 3.9, 5.1],
+  "latest": {"value": 5.1, "status": "green", "date": "2026-05-10"},
+}
+```
+
+`strict_filter=True` применяет `is_valid_for_decoupling` (VI ≤ 1.10, >70% Z1+Z2, ride ≥ 60 min, decoupling not NULL — `data/metrics.py:594`). `days_back=84` (12 недель) даёт окно для накопления как минимум 5 валидных rides — у атлета бывает sparse-неделя без long ride'а, 28-дневное окно слишком жёсткое.
+
+**Не пишем свой SQL/Python pipeline для decoupling.** Переиспользуем existing helper, иначе разъедутся definitions «valid ride» в проекте.
+
+**Traffic light** — берём прямо `decoupling_trend.status` (already computed via `decoupling_status()` helper, thresholds 5% / 10% — consistent across project, см. `docs/knowledge/decoupling.md`):
+- 🟢 median ≤ 5.0
+- 🟡 5.0 < median ≤ 10.0
+- 🔴 median > 10.0
+- ⚪ `decoupling_trend` отсутствует или `last_n=0` → «insufficient data», не учитывается в verdict'е
+
+### 3.4 Header verdict logic
+
+```python
+signals = [volume_signal, long_ride_signal, durability_signal]
+greens = signals.count("green")
+yellows = signals.count("yellow")
+reds = signals.count("red")
+insufficient = signals.count("insufficient")
+available = 3 - insufficient
+
+if insufficient >= 2:
+    verdict = "insufficient_data"
+    label = "Not enough data for {distance}"
+    subtext = None
+elif reds >= 1:
+    verdict = "building"
+    label = "Building for {distance}"
+    subtext = f"{available - reds} of {available} signals on track"
+elif greens == available:
+    verdict = "ready"
+    label = "Ready for {distance}"
+    subtext = "All signals on track ✓"
+else:
+    verdict = "almost"
+    label = "Almost ready for {distance}"
+    subtext = f"{greens} of {available} signals on track"
+```
+
+Один красный — `building`. Все зелёные (из доступных) — `ready`. Иначе — `almost ready`.
+
+**Subtext под verdict'ом** — gradient information без extra verdict state (YYY и GGY оба «almost», но subtext различает «1 of 3» vs «2 of 3»). Это снимает claim что «almost — too broad»: верхняя категория одна, но точная диспозиция читается субтекстом.
+
+Цвет header'а — те же три (green / yellow / red), что у CTL-delta в `Dashboard.tsx:506-512` (consistent palette across the app).
+
+---
+
+## 4. Data model
+
+**Никаких изменений схемы.** Источники:
+
+| Поле | Таблица | Колонка | Notes |
+|---|---|---|---|
+| CTL_bike per day | `wellness` | `sport_info` (JSON) | extracted via `extract_sport_ctl(sport_info)["ride"]`. **Sport key normalisation:** Intervals.icu может писать `"type": "Ride"`/`"Bike"`/`"bike"` в JSON entry — `extract_sport_ctl` нормализует через `SPORT_MAP.get(raw_type)` → всегда возвращает под ключом `"ride"`. Edge: missing field → `None` (handled). |
+| Bike activity | `activities` | `type`, `is_race`, `moving_time`, `start_date_local` | filter `type IN ('Ride','VirtualRide') AND is_race=False` |
+| Ride details for decoupling | `activity_details` | `decoupling`, `variability_index`, `hr_zone_times` | JOIN by `activity_id`. Filter via `is_valid_for_decoupling` |
+
+**Windows** (разные по rationale):
+
+| Signal | Window | Почему именно столько |
+|---|---|---|
+| CTL chart | 12 weeks (84d) | Standard fitness-trend window, consistent с MS chart и `weekly_recap`. Sunday snapshot `sport_info.ride` per week. |
+| Long ride | 28d (4 недели) | Один валидный long ride достаточно показателен; 28d покрывает 1 monthly cycle + tolerance для отпуска/болезни. Меньше окно (14d) — слишком чувствительно к пропуску; больше (8 недель) — затягивает старые данные после смены формы. |
+| Durability | 84d (12 weeks) | Нужно accumulate **5 valid rides** для stable median (`is_valid_for_decoupling` фильтр requires ride ≥ 60min + VI ≤ 1.10 + >70% Z1+Z2). У атлета может быть sparse-неделя без long ride'а — 28d window недостаточен (1-2 valid rides → noisy median). 84d = реалистичный 5-sample horizon для AG-атлета. |
+
+Inconsistency между long-ride 28d и durability 84d сознательная: long ride — **single best workout** demonstration, durability — **trend стабильности** требующий N samples.
+
+---
+
+## 5. API endpoint
+
+```python
+# api/routers/dashboard.py — рядом с marathon_shape endpoint
+
+@router.get("/api/bike-readiness")
+async def bike_readiness(
+    weeks: int = Query(default=12, ge=1, le=24),
+    user: User = Depends(require_viewer),
+) -> dict:
+    """Bike readiness — CTL_bike trend + current 3-signal snapshot.
+
+    For each of the last `weeks` Mon-Sun weeks (ending most recent Sunday),
+    returns CTL_bike snapshot. `current_components` carries the latest
+    longest-ride / decoupling-median / ef-trend for the badge logic.
+
+    Distance-specific targets (Olympic/70.3/IM) and verdict are computed
+    CLIENT-side — endpoint returns absolute values only.
+    """
+```
+
+**Response shape:**
+
+```json
+{
+  "weeks": [
+    {
+      "week_start": "2026-02-23",
+      "week_end": "2026-03-01",
+      "ctl_bike": 68.4                // null если sport_info недоступен
+    }
+    // ... newest first ...
+  ],
+  "current_components": {
+    "ctl_bike": 68.4,                 // newest week's CTL
+    "longest_ride_hours": 2.25,       // max moving_time за 28d, hours
+    "longest_ride_date": "2026-05-10",
+    "decoupling_median_pct": 4.2,     // median последних 5 valid rides
+    "decoupling_status": "green",     // green | yellow | red — из decoupling_status(median)
+    "decoupling_n": 5,                // last_n — сколько rides попало
+    "ef_trend_pct": 2.3               // % change in EF over period, sign matters: >0 — улучшение, supplementary
+  }
+}
+```
+
+Newest first (consistent с `weekly_recap` и `marathon-shape`).
+
+**Реализация подсказок:**
+- CTL_bike per week — single query на `wellness` за `weeks` Sundays, parse JSON через `extract_sport_ctl`.
+- Longest ride — single query на `activities` `WHERE type IN ('Ride','VirtualRide') AND is_race=False AND start_date_local >= today-28d ORDER BY moving_time DESC LIMIT 1`.
+- Decoupling **и** EF trend — **один вызов** `compute_efficiency_trend(user_id, sport='bike', days_back=84, group_by='week', strict_filter=True)`. Берём из его output'а: `decoupling_trend.{median, status, last_n}` для durability сигнала + `trend` (percentage) для `ef_trend_pct` supplementary. Не дублируем pipeline.
+
+Three signals → один endpoint, два запроса (wellness + activities) + один helper call (`compute_efficiency_trend`). Linear, без N+1.
+
+---
+
+## 6. Webapp widget
+
+### Placement
+
+В `webapp/src/pages/Progress.tsx:77` после `<ProgressionWidget />` добавить:
+
+```tsx
+{sport === 'bike' && <BikeReadinessWidget />}
+```
+
+### Layout
+
+```
+┌────────────────────────────────────────────────────┐
+│ Bike Readiness                                      │
+│ ┌──────────────────────────────────┐               │
+│ │  Olympic  |  70.3  |  IM         │               │
+│ └──────────────────────────────────┘               │
+│                                                     │
+│ Building for 70.3                                   │
+│ 2 of 3 signals on track                             │
+│                                                     │
+│ Predicted (70.3 bike):                              │
+│   Power   240W   (CI 230 – 250W)                    │
+│                                                     │
+│ ┌─ chart: CTL_bike, 12 weeks ─────────┐            │
+│ │ ───────────── target (75) ──────────│            │
+│ │                          ▆▇▇        │            │
+│ │           ▃▄▅▅▆▆▆                   │            │
+│ └─────────────────────────────────────┘            │
+│                                                     │
+│ ┌─────────────────────────────────────┐            │
+│ │ 🟡 Volume      CTL 68 / 75   (91%)  │            │
+│ │ 🔴 Long ride   2:15 / 3:00   (75%)  │            │
+│ │ 🟢 Durability  Pa:Hr 4.2% (5 rides) │            │
+│ │    📈 EF trend +2.3% (12w)          │            │
+│ └─────────────────────────────────────┘            │
+└─────────────────────────────────────────────────────┘
+```
+
+Three signals → один red ⇒ verdict «Building for 70.3», subtext «2 of 3 signals on track» (volume + durability green/yellow, long ride red). Атлет видит, что именно подтянуть — long ride. Volume почти на месте, durability ок. EF trend supplementary sub-line под Durability — долгосрочное улучшение aerobic fitness (positive = improving). Predicted Power block — Phase 1.5 (см. §13).
+
+### Components
+
+- **Distance picker** — `TabSwitcher` с тремя опциями (`Olympic` / `70.3` / `IM`), default `70.3`. State в виджете, не в роутинге.
+- **Header badge + subtext** — verdict text (Ready/Almost/Building/Insufficient) + соответствующий цвет (зелёный/жёлтый/красный/серый) + sub-line «N of M signals on track». При переключении дистанции пересчитывается клиентом без re-fetch'а.
+- **Predicted block** (Phase 1.5) — рядом с verdict'ом, под header'ом, перед chart'ом. Watts + CI для выбранной distance. Cold-start / below-acceptance — block скрывается. См. §13.
+- **Chart** — Chart.js line (как `EFChart`/`MarathonShapeWidget chart`). X = week_end (12 точек), Y = CTL_bike. Annotation plugin (уже импортирован в `Progress.tsx:24`) для horizontal `target_ctl` линии. Null-points (нет sport_info) — gap в линии. Annotation двигается при переключении дистанции — кривая не дрожит.
+- **Components-блок** — три строки, каждая с traffic-light dot, label, actual/target, и процентом-в-скобках. Цвет dot'а — current traffic light per signal. **Durability row** дополняется sub-line `📈 EF trend ±X.X% (12w)` — supplementary, не влияет на signal status, но complement к decoupling: decoupling = durability сегодня, EF trend = долгосрочное улучшение aerobic fitness через `compute_efficiency_trend.trend` (positive % = improving). Если `ef_trend_pct` null — sub-line скрыта.
+
+### Empty/edge states
+
+- **No bike activities за 28 дней** → Long ride card: «No bike rides last 28 days», Durability: «No valid rides». Volume может оставаться валидным (CTL обновляется в wellness даже без новых активностей через decay).
+- **No CTL_bike** (sport_info не заполнен, например, бэкфилл атлета) → chart показывает gap, Volume card: «CTL unavailable», verdict идёт по двум оставшимся сигналам.
+- **Все 3 сигнала insufficient** → header «Not enough data for {distance}», без цвета.
+
+---
+
+## 7. Edge cases / fallbacks
+
+| Случай | Поведение |
+|---|---|
+| `wellness.sport_info` NULL на week_end | Walk back до 7 дней, взять последнее значение. CTL медленно меняется (τ=42d), 7-дневный fallback безопасен. Если за 7d тоже нет — `ctl_bike: null` для этой недели. |
+| Бэкфилл атлета — sport_info неполный | Те же fallback'и. Chart покажет gap'ы, viewer-friendly. |
+| Indoor ride (VirtualRide) без power — попадёт в `is_valid_for_decoupling`? | Да, если есть HR + decoupling рассчитан. Если decoupling NULL — отфильтруется. Existing contract. |
+| Race-effort `is_race=True` | **Исключаем** из всех компонентов (consistent c MS §7). Race ≠ training base. |
+| Athlete с CTL_bike=0 (после длинного перерыва) | Volume → 🔴, остальные сигналы могут быть insufficient (нет recent rides) → verdict «Building». |
+| Outlier — одна 6-часовая туристическая поездка повышает long_ride | Не фильтруем. Это и есть нужное — атлет реально может проехать длинно. Если ровно один outlier и далее ничего — durability card покажет «1 ride» и atlete увидит контекст. |
+| FTP не задан → power-based durability невалидна? | Decoupling рассчитывается из HR drift (Pa:Hr), не требует FTP. Работает на HR-only rides. |
+
+---
+
+## 8. Tests
+
+```python
+# tests/api/test_dashboard.py::TestBikeReadiness
+
+async def test_returns_12_weeks_newest_first(client):
+    """Endpoint returns 12 ctl_bike points, newest first."""
+
+async def test_ctl_bike_extracted_from_sport_info_json(client):
+    """sport_info JSON correctly parsed via extract_sport_ctl helper."""
+
+async def test_no_sport_info_returns_null_ctl(client):
+    """Empty/None sport_info → ctl_bike: null per week."""
+
+async def test_ctl_bike_7d_backwalk(client):
+    """5-day-old CTL is picked up when week_end has NULL sport_info."""
+
+async def test_longest_ride_max_in_28d(client):
+    """current_components.longest_ride_hours = max moving_time in last 28d."""
+
+async def test_race_rides_excluded(client):
+    """is_race=True rides do NOT count toward longest_ride or durability."""
+
+async def test_decoupling_median_from_compute_efficiency_trend(client):
+    """decoupling_median_pct === compute_efficiency_trend(...)['decoupling_trend']['median']."""
+
+async def test_decoupling_status_thresholds(client):
+    """status: green ≤5, yellow ≤10, red >10 — consistent с decoupling_status() helper."""
+
+async def test_indoor_ride_counts_if_decoupling_present(client):
+    """VirtualRide with valid decoupling included; without — excluded (via strict_filter)."""
+
+async def test_no_valid_rides_returns_null_decoupling(client):
+    """No valid rides in 84d window → decoupling_median_pct: null, decoupling_n: 0."""
+
+async def test_per_user_scoping(client):
+    """Tenant isolation on activities + activity_details + wellness — regression."""
+
+async def test_ef_trend_pct_field_populated(client):
+    """ef_trend_pct — number (percentage), не enum."""
+```
+
+Pure-формул в этой спеке нет (всё распадается на DB-запросы + filter helpers), поэтому unit-тесты идут на API integration layer. Если в Phase 2 появится `data/bike_readiness.py` модуль — добавятся unit-тесты на pure helpers (target_ctl_for_distance, verdict logic).
+
+---
+
+## 9. Out of scope
+
+- **MCP tool `get_bike_readiness`** — viewer-only widget, AI не использует. Если в Phase 2 захочется отвечать «хватит ли мне ножек на 70.3» в чате — обёртка над тем же endpoint'ом, copy-paste из marathon_shape MCP wrapper.
+- **Интеграция в утренний отчёт / prompt enrichment** — после валидации виджета.
+- **Bike Shape % (single synthetic number)** — отвергнут, см. §12.
+- **5K bike / 100mi / Sprint** — picker сужен до Olympic/70.3/IM. Sprint bike-leg = 20 км, Olympic покрывает с запасом. 100mi gravel — out of scope для триатлета.
+- **FTP-derived target_ctl** — попытка параметризовать target_ctl от FTP не подкреплена литературой. Табличные значения проще и достаточны для три trifecta distances.
+- **Per-rider position adjustment (TT vs road vs MTB)** — too granular. Decoupling уже учитывает «как тело держит мощность», независимо от позиции.
+- **Calories / kJ as alternative volume metric** — CTL_bike сам по себе включает kJ-derived TSS через Intervals.icu pipeline, дублировать нет смысла.
+
+---
+
+## 10. Phases
+
+| Phase | Scope | Status |
+|---|---|---|
+| **1** | `GET /api/bike-readiness` endpoint + `BikeReadinessWidget` (verdict + chart + 3 signal cards + EF trend sub-line) + integration-тесты | ✅ done — BR-1…BR-4 landed 2026-05-15 |
+| **1.5** | ML Predicted Power block (`predict_splits_with_ci(sport='ride')` integration + Redis cache + uncertainty-aware UI) | 🔵 pending — depends on Phase 1 |
+
+**Ordering:** Phase 1 ships first (core 3-signal readiness widget). Phase 1.5 добавляет Predicted Power block поверх — mirror MS Phase 1 → 1.5 history. Если 1.5 запустить до 1.5 — predicted без verdict не имеет actionable context.
+
+Phase 2 — только если явный запрос:
+- MCP tool wrapper для chat-/morning-доступа.
+- FTP-parameterised target_ctl (если table drift'ит на elite/beginner brackets).
+- Synthetic Bike Shape % (если виджет провалидируется и появится явная потребность в одной цифре для chart-trend'а — see §12, currently rejected).
+- Sport-Specific Readiness combo на одной странице (`BikeReadiness` + `MarathonShape` + (потенциально) `SwimReadiness` рядом).
+
+---
+
+## 11. Acceptance criteria
+
+### Phase 1 — core readiness ✅
+
+- [x] `GET /api/bike-readiness?weeks=12` возвращает 12 weekly buckets с `ctl_bike` + `current_components` (longest_ride, decoupling_median, decoupling_status, decoupling_n, ef_trend_pct).
+- [x] `BikeReadinessWidget` рендерится на `/progress` при `sport='bike'` после `ProgressionWidget`.
+- [x] Distance picker (`Olympic`/`70.3`/`IM`) переключает target для chart annotation и пересчитывает verdict в header без re-fetch'а.
+- [x] Header verdict следует логике §3.4: ≥1 red → Building, all green (из доступных) → Ready, иначе Almost ready. Subtext «N of M signals on track» под verdict'ом.
+- [x] Three components carry traffic-light dots: Volume / Long ride / Durability. Durability card имеет sub-line «📈 EF trend ±X.X% (12w)» если `ef_trend_pct` non-null.
+- [x] Chart показывает 12 точек с gap'ами для weeks без `sport_info.ride`.
+- [x] При полном отсутствии bike-rides виджет рендерит «Not enough data» без crash'а.
+- [x] Race rides (`is_race=True`) НЕ входят в long_ride и avg_decoupling. Регрессионный `test_race_rides_excluded` (+ helper-level fix in `compute_efficiency_trend` — раньше races leaked through Durability, fixed 2026-05-15).
+- [x] Tenant isolation: `user_id` фильтр на activities + activity_details + wellness, регрессионный `test_per_user_scoping`.
+- [x] Durability сигнал считается через `compute_efficiency_trend(sport='bike', strict_filter=True)` — `is_valid_for_decoupling` НЕ дублируется в `dashboard.py`, переиспользуется existing pipeline.
+
+### Phase 1.5 — ML Predicted Power
+
+- [ ] `/api/bike-readiness` response расширен `predicted_power: {Olympic, "70.3", IM}` с `watts` + `watts_ci_low/high` для каждой дистанции.
+- [ ] Cold-start (`ModelNotTrained`) / below-acceptance / отсутствие ride-модели → соответствующая дистанция = `null`, остальные могут быть filled. Никаких 500-ок.
+- [ ] Widget показывает Predicted block (Power + CI), привязанный к выбранной distance из picker'а. При `predicted_power[distance] === null` — блок скрывается, остальной UI рендерится без crash'а.
+- [ ] Power формат — `XXX W` (240W). CI — `(CI XXX – XXX W)`.
+- [ ] **Uncertainty-aware UI**: при CI spread > 20% от center value — footnote «model uncertainty high, limited race history» под Predicted block.
+- [ ] Integration test: endpoint mock'ит `predict_splits_with_ci` (`ModelNotTrained` для одной distance, valid для другой) → response корректно отражает оба случая.
+- [ ] Redis cache `(user_id, today_iso)` с TTL до полуночи Belgrade (mirror MS pattern из `_compute_predicted_times` в `api/routers/dashboard.py`). Graceful fallback при Redis disabled / unreachable / errors.
+
+---
+
+## 12. Phasing & GitHub issues
+
+### Phase 1 punch-list ✅ (landed 2026-05-15)
+
+- [x] **BR-1 — `GET /api/bike-readiness` endpoint.** Single SQL query на `wellness` за 12 weeks (extract `sport_info.ride` per Sunday + 7d back-walk) + single query на `activities` за 28d (longest Ride, no race — `type == "Ride"` post-normalisation, see `data/intervals/dto.py:_normalize_type` for VirtualRide → Ride mapping) + single helper call `compute_efficiency_trend(sport='bike', days_back=84, strict_filter=True)`. Response shape per §5. `api/routers/dashboard.py:747-881`.
+- [x] **BR-2 — `BikeReadinessWidget` на Progress.tsx.** Distance picker + verdict badge + chart + 3 component cards + EF trend sub-line. Client-side computes traffic-light status + verdict + subtext «N of M signals on track» при переключении picker'а. Two-effect chart pattern (lifecycle + annotation patch) mirrors MarathonShapeWidget. `webapp/src/pages/Progress.tsx:886-1188`.
+- [x] **BR-3 — Integration tests.** 12 тестов в `tests/api/test_dashboard.py::TestBikeReadiness` + 3 helper-level regression tests в `tests/mcp/test_efficiency_trend.py` (race-exclusion in `compute_efficiency_trend`, since `strict_filter=True` alone wasn't dropping `is_race=True` activities — affects BR-1, `/api/progress`, and the AI MCP tool).
+- [x] **BR-4 — Empty/edge states.** «Not enough data» при insufficient signals, «No bike rides last 28 days» при пустом окне, «No valid rides» при NULL decoupling, chart hidden при полностью пустом `sport_info.ride`. Verified by `test_no_sport_info_returns_null_ctl` + `test_no_valid_rides_returns_null_decoupling`.
+
+### Phase 1.5 punch-list
+
+- [ ] **BR-5 — Endpoint extension.** `/api/bike-readiness` вызывает `predict_splits_with_ci(user_id, mode='today', race_date=today_iso, race_distance_ride_m=X)` для 40000 / 90000 / 180000 м sequentially (sync `_predict_one` inside — gather не даёт parallelism, см. MS §13 «Latency»). Try/except каждый — `ModelNotTrained` / `ModelBelowAcceptance` → null для дистанции. ~80 строк mirror'я MS pattern.
+- [ ] **BR-6 — Response types + widget Predicted block.** `BikeReadinessResponse.predicted_power` + types в `webapp/src/api/types.ts`. Widget рендерит Power + CI под header'ом badge'а. Wide-CI footnote при spread > 20%.
+- [ ] **BR-7 — ML Integration test.** Mock `predict_splits_with_ci` → endpoint собирает корректный `predicted_power` envelope, cold-start = null для одной дистанции, valid для другой.
+- [ ] **BR-8 — Redis cache layer.** `_compute_bike_predicted_power` обёртка над `_predict_power_fresh`, key `bike_readiness_pred:{user_id}:{today_iso}`, TTL через `_ttl_until_midnight_local()` (reuse from MS).
+
+---
+
+## 13. ML-based power prediction (Phase 1.5)
+
+### Зачем
+
+Mirror Marathon Shape §13 pattern. Для bike атлет получает actionable pacing band: «target 240W on race-leg, CI 230-250W». Это сильнее чем «у тебя FTP 250W», потому что:
+
+- **Personalised** через XGBoost на личной race-history (включает CTL/ATL/HRV/eFTP features).
+- **CI bands** — атлет видит uncertainty.
+- **Distance-aware** — predicted power для 70.3 bike-leg отличается от Olympic (более длинный → ниже target watts).
+
+У нас уже есть `predict_splits_with_ci(sport='ride', ...)` — same pipeline что и для run, units = watts (per `_DISCIPLINE_META["ride"]`).
+
+### Источник данных
+
+```python
+from data.ml.race_predict import predict_splits_with_ci, ModelNotTrained, ModelBelowAcceptance
+
+# Per-distance Ride prediction. Sequential — same as MS rationale.
+DISTANCE_M = {"Olympic": 40000, "70.3": 90000, "IM": 180000}
+predicted_power: dict[str, dict | None] = {}
+
+for label, dist_m in DISTANCE_M.items():
+    try:
+        env = await predict_splits_with_ci(
+            user_id=uid,
+            mode="today",
+            race_date=today.isoformat(),  # см. MS §13 note про bias correction
+            race_distance_ride_m=dist_m,
+        )
+        ride = env["splits"].get("ride")
+        if ride and "pred" in ride:
+            predicted_power[label] = {
+                "watts": round(ride["pred"]),
+                "watts_ci_low": round(ride["ci_low"]),
+                "watts_ci_high": round(ride["ci_high"]),
+            }
+        else:
+            predicted_power[label] = None
+    except (ModelNotTrained, ModelBelowAcceptance):
+        predicted_power[label] = None
+```
+
+**Note:** Ride возвращает `total_sec_unavailable: True` + `total_sec_reason: "power_only_phase1"` — у нас нет speed sub-model. Это OK для widget'а: показываем только watts.
+
+**Bias correction для Ride disabled** (per `race_predict.py:328-333`): `bias_fit_method='out_of_scope'` для Ride/Swim, корректировка не применяется. Это нормально — calibration Run-only Phase 2.0β2. Watts prediction идёт raw от XGBoost.
+
+### Response envelope
+
+```json
+{
+  "weeks": [...],
+  "current_components": {...},
+  "predicted_power": {
+    "Olympic": { "watts": 252, "watts_ci_low": 240, "watts_ci_high": 264 },
+    "70.3":    { "watts": 240, "watts_ci_low": 230, "watts_ci_high": 250 },
+    "IM":      { "watts": 218, "watts_ci_low": 205, "watts_ci_high": 232 }
+  }
+}
+```
+
+### UI rendering
+
+Под header'ом verdict'а + subtext, перед chart'ом:
+
+```
+Predicted (70.3 bike):
+  Power   240W   (CI 230 – 250W)
+```
+
+Привязано к **выбранной distance** из picker'а — переключение мгновенное, все три предсказания пришли одним response. При `predicted_power[selected] === null` — block скрывается.
+
+Wide-CI footnote (spread > 20% от center) — «model uncertainty high, limited race history». Для bike это особенно релевантно: атлет с малым race-history имеет CI типа «200-300W» что useless без контекста.
+
+### Edge cases (mirror MS §13)
+
+| Случай | Поведение |
+|---|---|
+| `ModelNotTrained` для всех дистанций | Predicted block не рендерится, остальной widget работает |
+| `ModelNotTrained` для одной distance, valid для других | Скрываем block только когда picker = эта distance |
+| `ModelBelowAcceptance` | Аналогично — скрываем |
+| CI bands пересекают physiological floor (`ride` floor = 50W в `_DISCIPLINE_META`) | Уже clamp'ится в `_predict_one` (`race_predict.py:357-364`) |
+| User свежий, нет race history → cold-start | Все 3 = null, block скрыт. Widget работает как Phase 1 only |
+
+### Performance / caching
+
+- 3 sequential inference calls × ~80ms = ~240ms latency overhead. Same constraint as MS (`_predict_one` sync).
+- Redis cache `(user_id, today_iso)` с TTL до полуночи Belgrade — mirror MS pattern.
+
+---
+
+## 14. Considered alternatives
+
+Три подхода были рассмотрены. Этот раздел — audit trail для будущих контрибьюторов, чтобы не было соблазна «давайте лучше Bike Shape %».
+
+### 12.1 ✅ Combo-widget (chosen)
+
+3 независимых сигнала (Volume / Long ride / Durability), verdict по traffic-light logic. Без synthetic %.
+
+**Trade-offs:**
+- ✅ Каждая цифра имеет физическую интерпретацию. Атлет видит, где именно недотягивает.
+- ✅ Никакой новой математики, переиспользуем существующие helpers (`extract_sport_ctl`, `is_valid_for_decoupling`, `compute_efficiency_trend`).
+- ✅ Низкий риск: не ввели новую формулу, которую нужно валидировать.
+- ❌ Нет single trend-line «насколько я в форме» как у Marathon Shape. Chart ограничен volume-метрикой (CTL_bike).
+
+### 12.2 ❌ Bike Shape % (single synthetic number) — rejected
+
+```
+shape_pct = 100 * (0.45 * ctl_ratio + 0.30 * long_ride_ratio + 0.25 * durability_score)
+```
+
+По образцу Marathon Shape: один процент, chart 12 недель trend, шкала «70.3 = 100%».
+
+**Trade-offs:**
+- ✅ Эстетическая симметрия с Marathon Shape.
+- ✅ Trend chart по одной метрике.
+- ❌ **В индустрии нет прецедентов этой формулы.** Runalyze явно отказывается, TrainingPeaks / Intervals / Xert тоже нет. Не на что калибровать.
+- ❌ Веса 0.45/0.30/0.25 — пальцем в небо. В Runalyze 0.67/0.33 валидированы годами на тысячах атлетов, у нас валидации нет.
+- ❌ Target CTL и long ride — табличные, не функция FTP. В Runalyze всё параметризовано VO2max, here — нет аналогичного параметра.
+- ❌ CTL-based shape пляшет с тренировочным циклом: в таперинге CTL падает → shape % падает, хотя атлет как раз готов. Известная проблема CTL-метрик, не решена.
+
+**Почему отвергнут:** низкая валидируемость + риск дать атлету misleading цифру, которая снижается на таперинге.
+
+### 12.3 ❌ Hybrid (combo + synthetic %) — rejected
+
+Combo-widget из 12.1 плюс одна цифра Bike Shape % из 12.2 наверху, chart по Shape %.
+
+**Trade-offs:**
+- ✅ Best of both: видно и общую цифру, и breakdown.
+- ❌ Все минусы 12.2 остаются (синтетика, веса с потолка).
+- ❌ UX-сложность: «у меня CTL ок и long ride ок, durability ок, а Bike Shape 78% — почему?» — расходящиеся подписи путают атлета.
+- ❌ Двойное обслуживание: и cards, и %. Любая доработка метрики — пересмотр обоих представлений.
+
+**Почему отвергнут:** добавляет cognitive load без новой информации.
+
+---
+
+## 15. Architectural decisions — standing audit trail
+
+> Standing decisions, зафиксированные при первой итерации спеки (2026-05-14). В отличие от §14 (rejected approaches) этот раздел документирует **принятые** internal choices с rationale, чтобы при будущих pull requests разработчики не переоткрывали уже закрытые вопросы.
+>
+> Аналог §14 в MS-спеке (где decisions были post-divergence). Здесь — proactive audit, для bike нет upstream-reference чтобы расходиться, но **внутренние** trade-off'ы есть.
+
+| ID | Decision | Date | Rationale |
+|---|---|---|---|
+| **B1** | **Traffic-light verdict, no synthetic %** | 2026-05-14 | No industry precedent (§1 stance). Weighted-combo формула требует калибровки которой не на что опираться. Three independent signals + multi-state verdict дают больше actionable info чем single %. |
+| **B2** | **Table targets, not FTP-parameterised** | 2026-05-14 | В литературе для bike-CTL точной формулы `f(FTP, age)` нет. Friel/Coggan приводят bands, не функции. Table 50/75/100 — calibrated empirical, см. §3.1 caveat. Phase 2 option: parameterise если обнаружим drift. |
+| **B3** | **Long ride: 28d window, single-best** | 2026-05-14 | Один валидный long ride демонстрирует physical capability. 28d покрывает monthly cycle + tolerance. Не требует N-sample median — long ride binary «сделал хотя бы раз». |
+| **B4** | **Durability: 84d window, median of 5** | 2026-05-14 | Decoupling — стабильность через trend, требует sample stability. `is_valid_for_decoupling` фильтр строгий (ride ≥60min + VI ≤1.10 + Z1+Z2 >70%), у атлета 1-2 valid rides per 28d window — noisy median. 84d даёт реалистичный 5-sample horizon. |
+| **B5** | **Olympic distance kept (informational only)** | 2026-05-14 | Threshold 1.5h не дискриминирует (любой consistent rider clearит). Оставляем в picker'е для completeness виджета — другие атлеты могут гоняться Olympic. Если feedback что misleading — drop в Phase 2 (см. §3.2 disclaimer). |
+| **B6** | **Verdict subtext «N of M signals on track»** | 2026-05-14 | 4-state verdict (Ready/Almost/Building/Insufficient) огрубляет YYY vs GGY (оба → almost). Subtext gradient information без extra verdict state — UX simplicity сохранена. |
+| **B7** | **EF trend surface as supplementary, not signal** | 2026-05-14 | EF trend (от `compute_efficiency_trend`) — долгосрочное aerobic improvement. **Не** включать в traffic-light decision (durability — durability сегодня, EF — несколько месяцев). Render как sub-line под Durability card, не дублирует pipeline. |
+| **B8** | **Race-effort excluded from all signals** | 2026-05-14 | Race ≠ training base (consistent c MS §7 до Phase 1.6). Bike-races редкие, инфлюенс на 28d/84d медиану марginal. **Note:** если в Phase 2 MS-style alignment придёт идея «mirror Runalyze includes races» — для bike нет upstream, decision stays. Можем пересмотреть если найдём industry argument. |
+| **B9** | **Phase 1.5 ML Predicted Power** | 2026-05-14 | Symmetric MS Phase 1.5. `predict_splits_with_ci(sport='ride')` уже в pipeline, copy pattern. Actionable: race-day pacing band «target watts CI». Single value-add над industry baseline. |
+
+**Когда возвращаться к этому разделу:**
+- New PR хочет изменить thresholds (5%/10% decoupling, 0.80 ratio) → проверить B-row, документировать new decision если меняется.
+- New PR хочет добавить 4th signal (HRV bike-specific? Power curve?) → добавить B-row, не пересматривать существующие.
+- New Phase wants synthetic % → revisit §14 (Considered alternatives) **и** B1.
+
+---
+
+## 16. Related
+
+- [`MARATHON_SHAPE_SPEC.md`](MARATHON_SHAPE_SPEC.md) — run-side parallel, similar layout pattern, тот же подход «pure helpers + REST + widget».
+- [Runalyze docs — нет аналога для bike](https://runalyze.com/help/article/marathon-shape) — Runalyze явно ограничен бегом.
+- `webapp/src/pages/Progress.tsx:77` — placement target (после `ProgressionWidget`).
+- `data/utils.py:81` — `extract_sport_ctl(sport_info)` per-sport CTL extractor.
+- `data/metrics.py:594` — `is_valid_for_decoupling(...)` filter contract.
+- `mcp_server/tools/progress.py:99` — `compute_efficiency_trend(user_id, sport, ...)` reusable helper для `ef_trend`.
+- `api/routers/dashboard.py:468` — `/api/marathon-shape` endpoint как референс для week-bucket pattern.
+- `data/db/activity.py:542-545` — `ActivityDetail.variability_index`, `efficiency_factor`, `decoupling`, `hr_zone_times`.

--- a/mcp_server/tools/progress.py
+++ b/mcp_server/tools/progress.py
@@ -118,6 +118,11 @@ async def compute_efficiency_trend(
         sg = _sport_group(act.type)
         if not sg or sg not in target_sports:
             continue
+        # Race-effort excluded: peak race load is not a training-base signal.
+        # All three callers (BR-1, /api/progress, AI MCP tool) analyse
+        # training efficiency, not race performance.
+        if act.is_race:
+            continue
         min_dur = _MIN_DURATION.get(sg, 0)
         if strict_filter:
             pass  # strict duration handled by is_valid_for_decoupling below

--- a/tests/api/test_dashboard.py
+++ b/tests/api/test_dashboard.py
@@ -17,7 +17,7 @@ from httpx import ASGITransport, AsyncClient
 
 from api.deps import require_viewer
 from api.routers.dashboard import router as dashboard_router
-from data.db import Activity, ActivityDetail, AthleteGoal, Race, User, Wellness, get_session
+from data.db import Activity, ActivityDetail, AthleteGoal, AthleteSettings, Race, User, Wellness, get_session
 from data.intervals.dto import ActivityDTO
 
 _FIXED_TODAY = date(2026, 4, 30)
@@ -1379,3 +1379,387 @@ class TestMarathonShapePredictedTimes:
 
         pt = resp.json()["predicted_times"]
         assert pt == {"10K": None, "HM": None, "Marathon": None}
+
+
+# ---------------------------------------------------------------------------
+# /api/bike-readiness   (BIKE_READINESS_SPEC §3, §5, §11)
+# ---------------------------------------------------------------------------
+
+
+# Sunday-anchored 12-week window, mirror /api/marathon-shape:
+#   _FIXED_TODAY = 2026-04-30 (Thu) → newest Sunday = 2026-04-26 → newest week
+#   Mon 2026-04-20 → Sun 2026-04-26; oldest Mon = 2026-02-02.
+_BR_WINDOW_END = _MS_WINDOW_END  # = date(2026, 4, 26)
+_BR_NEWEST_WEEK_START = _MS_NEWEST_WEEK_START  # = date(2026, 4, 20)
+
+
+async def _seed_wellness_sport_info(
+    user_id: int,
+    dt: date,
+    *,
+    ctl_bike: float | None = None,
+    ctl_run: float | None = None,
+) -> None:
+    """Insert a wellness row with `sport_info` populated. The endpoint reads
+    CTL_bike via `extract_sport_ctl(sport_info)["ride"]`, which expects a list
+    of `{"type": <sport>, "ctl": <float>}` dicts (the format Intervals.icu
+    returns enriched with our pipeline's `ctl` field, see `data/utils.py:81`).
+    """
+    sport_info: list[dict] = []
+    if ctl_bike is not None:
+        sport_info.append({"type": "Ride", "ctl": ctl_bike})
+    if ctl_run is not None:
+        sport_info.append({"type": "Run", "ctl": ctl_run})
+    async with get_session() as session:
+        session.add(
+            Wellness(
+                user_id=user_id,
+                date=dt.isoformat(),
+                sport_info=sport_info or None,
+                updated=datetime.now(timezone.utc),
+            )
+        )
+        await session.commit()
+
+
+async def _seed_valid_bike_ride(
+    aid: str,
+    *,
+    dt: date,
+    is_race: bool = False,
+    decoupling: float | None = 4.0,
+    moving_time: int = 4200,
+    efficiency_factor: float = 2.10,
+    user_id: int = 1,
+) -> None:
+    """Seed one bike Activity + an ActivityDetail row that clears every
+    `is_valid_for_decoupling` gate (≥60min, VI ≤1.10, >70% Z1+Z2, decoupling
+    not NULL) and `_is_z2` (avg_hr inside 68–83% LTHR, with LTHR=153 from
+    `_seed_bike_thresholds`). Pass `decoupling=None` to seed an indoor-ride
+    style row that the strict filter should drop. `efficiency_factor` is
+    overridable so `test_ef_trend_pct_field_populated` can seed a positive
+    trend (rides with different EF values across two weekly buckets)."""
+    dto = ActivityDTO(
+        id=aid,
+        start_date_local=dt,
+        type="Ride",
+        moving_time=moving_time,
+        average_hr=115.0,  # inside Z2 for LTHR=153
+    )
+    dto.is_race = is_race
+    await Activity.save_bulk(user_id, activities=[dto])
+    async with get_session() as session:
+        session.add(
+            ActivityDetail(
+                activity_id=aid,
+                variability_index=1.02,
+                efficiency_factor=efficiency_factor,
+                decoupling=decoupling,
+                hr_zone_times=[1200, 2400, 400, 150, 50],  # 86% Z1+Z2
+                pace=2.5,
+            )
+        )
+        await session.commit()
+
+
+async def _seed_bike_thresholds(user_id: int = 1) -> None:
+    """LTHR=153 → Z2 (68–83% LTHR) = 104–127 bpm. `_seed_valid_bike_ride`
+    sets avg_hr=115 so rides clear the Z2 gate under `strict_filter=True`."""
+    await AthleteSettings.upsert(user_id=user_id, sport="Ride", lthr=153)
+
+
+class TestBikeReadiness:
+    """Spec BIKE_READINESS_SPEC §8 — 12 integration tests for /api/bike-readiness."""
+
+    @pytest.fixture(autouse=True)
+    def _freeze_progress_today(self):
+        """`compute_efficiency_trend` (mcp_server/tools/progress.py:107) calls
+        bare `date.today()` to compute its 84-day window. The module-level
+        `_freeze_today` only pins the dashboard endpoint's notion of today —
+        without this extra patch, the helper's window drifts with wall-clock
+        time and the decoupling / EF-trend assertions become date-fragile."""
+
+        class _FrozenDate(date):
+            @classmethod
+            def today(cls):
+                return _FIXED_TODAY
+
+        with patch("mcp_server.tools.progress.date", _FrozenDate):
+            yield
+
+    async def test_returns_12_weeks_newest_first(self, client):
+        await _seed_wellness_sport_info(1, _BR_WINDOW_END, ctl_bike=70.0)
+
+        async with client as c:
+            resp = await c.get("/api/bike-readiness?weeks=12")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["weeks"]) == 12
+        assert data["weeks"][0]["week_start"] == _BR_NEWEST_WEEK_START.isoformat()
+        assert data["weeks"][0]["week_end"] == _BR_WINDOW_END.isoformat()
+        # Newest-first ordering — second bucket must be one week earlier
+        assert data["weeks"][1]["week_end"] == (_BR_WINDOW_END - timedelta(days=7)).isoformat()
+
+    async def test_ctl_bike_extracted_from_sport_info_json(self, client):
+        await _seed_wellness_sport_info(1, _BR_WINDOW_END, ctl_bike=68.4, ctl_run=42.0)
+
+        async with client as c:
+            resp = await c.get("/api/bike-readiness?weeks=12")
+
+        data = resp.json()
+        # Only the Ride entry's CTL is surfaced — not run.
+        assert data["weeks"][0]["ctl_bike"] == 68.4
+        assert data["current_components"]["ctl_bike"] == 68.4
+
+    async def test_no_sport_info_returns_null_ctl(self, client):
+        # Wellness row exists but without sport_info — typical for a fresh user
+        # whose Intervals.icu pipeline hasn't enriched per-sport CTL yet.
+        async with get_session() as session:
+            session.add(
+                Wellness(
+                    user_id=1,
+                    date=_BR_WINDOW_END.isoformat(),
+                    sport_info=None,
+                    updated=datetime.now(timezone.utc),
+                )
+            )
+            await session.commit()
+
+        async with client as c:
+            resp = await c.get("/api/bike-readiness?weeks=12")
+
+        data = resp.json()
+        for w in data["weeks"]:
+            assert w["ctl_bike"] is None
+        assert data["current_components"]["ctl_bike"] is None
+
+    async def test_ctl_bike_7d_backwalk(self, client):
+        """A Sunday with NULL sport_info should fall back to the most recent
+        earlier day with a value (spec §7 — 7-day walk-back, safe because
+        CTL decays with τ=42d)."""
+        # Seed CTL 5 days BEFORE window_end (= Tuesday 2026-04-21). The
+        # window_end Sunday itself has no row → endpoint walks back to find 65.0.
+        await _seed_wellness_sport_info(1, _BR_WINDOW_END - timedelta(days=5), ctl_bike=65.0)
+
+        async with client as c:
+            resp = await c.get("/api/bike-readiness?weeks=12")
+
+        assert resp.json()["weeks"][0]["ctl_bike"] == 65.0
+
+    async def test_longest_ride_max_in_28d(self, client):
+        # Three rides: 70min (4200s), 120min (7200s), 90min (5400s). The
+        # 120-min ride wins → 2.0h.
+        await _seed_valid_bike_ride("short", dt=_BR_WINDOW_END - timedelta(days=2), moving_time=4200)
+        await _seed_valid_bike_ride("long", dt=_BR_WINDOW_END - timedelta(days=10), moving_time=7200)
+        await _seed_valid_bike_ride("mid", dt=_BR_WINDOW_END - timedelta(days=20), moving_time=5400)
+
+        async with client as c:
+            resp = await c.get("/api/bike-readiness?weeks=12")
+
+        cc = resp.json()["current_components"]
+        assert cc["longest_ride_hours"] == 2.0
+        assert cc["longest_ride_date"] == (_BR_WINDOW_END - timedelta(days=10)).isoformat()
+
+    async def test_race_rides_excluded(self, client):
+        """Spec §3.2, §7: is_race=True rides must not surface as longest_ride
+        and must not contribute to the decoupling median."""
+        await _seed_bike_thresholds()
+        # 3-hour A-race + 1-hour training ride. Without the filter the race
+        # would win the longest-ride slot and pollute decoupling with 12%.
+        await _seed_valid_bike_ride(
+            "race",
+            dt=_BR_WINDOW_END - timedelta(days=3),
+            is_race=True,
+            moving_time=10800,  # 3h
+            decoupling=12.0,
+        )
+        await _seed_valid_bike_ride(
+            "train",
+            dt=_BR_WINDOW_END - timedelta(days=2),
+            moving_time=3600,
+            decoupling=4.0,
+        )
+
+        async with client as c:
+            resp = await c.get("/api/bike-readiness?weeks=12")
+
+        cc = resp.json()["current_components"]
+        assert cc["longest_ride_hours"] == 1.0  # the 1h training ride, not the 3h race
+        assert cc["longest_ride_date"] == (_BR_WINDOW_END - timedelta(days=2)).isoformat()
+        # Race decoupling 12% would have made the median yellow/red; training-only
+        # median is 4.0% → green.
+        assert cc["decoupling_median_pct"] == 4.0
+        assert cc["decoupling_status"] == "green"
+        assert cc["decoupling_n"] == 1
+
+    async def test_decoupling_median_from_compute_efficiency_trend(self, client):
+        """`decoupling_median_pct` must match exactly the value the helper
+        produces — spec §3.3 «не пишем свой SQL/Python pipeline»."""
+        await _seed_bike_thresholds()
+        # 5 rides with decoupling 3.0, 3.5, 4.0, 4.5, 5.0 → median = 4.0
+        for i, drift in enumerate([3.0, 3.5, 4.0, 4.5, 5.0]):
+            await _seed_valid_bike_ride(
+                f"r{i}",
+                dt=_BR_WINDOW_END - timedelta(days=10 + i),
+                decoupling=drift,
+            )
+
+        async with client as c:
+            resp = await c.get("/api/bike-readiness?weeks=12")
+
+        cc = resp.json()["current_components"]
+        assert cc["decoupling_median_pct"] == 4.0
+        assert cc["decoupling_n"] == 5
+
+    async def test_decoupling_status_yellow_threshold(self, client):
+        """Status binding follows `decoupling_status()` helper: green ≤5,
+        yellow ≤10, red >10. This exercises the *yellow* band; the green
+        path is covered by `test_race_rides_excluded`, the red band by
+        `test_decoupling_status_red_threshold`."""
+        await _seed_bike_thresholds()
+        # 5 rides all at 7% → median = 7.0 → yellow
+        for i in range(5):
+            await _seed_valid_bike_ride(
+                f"y{i}",
+                dt=_BR_WINDOW_END - timedelta(days=2 + i),
+                decoupling=7.0,
+            )
+
+        async with client as c:
+            resp = await c.get("/api/bike-readiness?weeks=12")
+
+        cc = resp.json()["current_components"]
+        assert cc["decoupling_median_pct"] == 7.0
+        assert cc["decoupling_status"] == "yellow"
+
+    async def test_decoupling_status_red_threshold(self, client):
+        """Median strictly > 10 → red. Locks the upper threshold so a future
+        widening of the yellow band (e.g. yellow ≤ 12) would fail loud."""
+        await _seed_bike_thresholds()
+        # 5 rides all at 12% → median = 12.0 → red
+        for i in range(5):
+            await _seed_valid_bike_ride(
+                f"r{i}",
+                dt=_BR_WINDOW_END - timedelta(days=2 + i),
+                decoupling=12.0,
+            )
+
+        async with client as c:
+            resp = await c.get("/api/bike-readiness?weeks=12")
+
+        cc = resp.json()["current_components"]
+        assert cc["decoupling_median_pct"] == 12.0
+        assert cc["decoupling_status"] == "red"
+
+    async def test_indoor_ride_counts_if_decoupling_present(self, client):
+        """Spec §7: indoor ride (VirtualRide normalises → "Ride" at DTO
+        ingest, `data/intervals/dto.py:_normalize_type`) is counted iff
+        ActivityDetail.decoupling is not NULL. A ride without decoupling —
+        common for older indoor rides without HR drift computed — must be
+        filtered out by `is_valid_for_decoupling`."""
+        await _seed_bike_thresholds()
+        await _seed_valid_bike_ride("indoor_ok", dt=_BR_WINDOW_END - timedelta(days=2), decoupling=4.0)
+        await _seed_valid_bike_ride(
+            "indoor_no_decoup",
+            dt=_BR_WINDOW_END - timedelta(days=3),
+            decoupling=None,  # is_valid_for_decoupling → False
+        )
+
+        async with client as c:
+            resp = await c.get("/api/bike-readiness?weeks=12")
+
+        cc = resp.json()["current_components"]
+        # Only the ride with non-NULL decoupling lands in last_5.
+        assert cc["decoupling_n"] == 1
+        assert cc["decoupling_median_pct"] == 4.0
+
+    async def test_no_valid_rides_returns_null_decoupling(self, client):
+        """Empty 84-day window → decoupling_median_pct is null, n=0. The
+        widget reads decoupling_n=0 OR status=null as "insufficient" — both
+        signals are emitted distinctly here so we don't lose the distinction
+        through accidental coercion."""
+        # No activities seeded → helper returns {"data_points": 0, ...}
+        # without a decoupling_trend key.
+        async with client as c:
+            resp = await c.get("/api/bike-readiness?weeks=12")
+
+        cc = resp.json()["current_components"]
+        assert cc["decoupling_median_pct"] is None
+        assert cc["decoupling_status"] is None
+        assert cc["decoupling_n"] == 0
+
+    async def test_per_user_scoping(self, client):
+        """Tenant isolation: rows for user 2 must not leak into user 1's
+        response — regression for `docs/MULTI_TENANT_SECURITY_SPEC.md` T1."""
+        async with get_session() as session:
+            session.add(User(id=2, chat_id="other", role="athlete"))
+            await session.commit()
+        # Seed under user 2 only
+        await _seed_bike_thresholds(user_id=2)
+        await _seed_wellness_sport_info(2, _BR_WINDOW_END, ctl_bike=99.0)
+        await _seed_valid_bike_ride(
+            "u2_ride",
+            dt=_BR_WINDOW_END - timedelta(days=1),
+            decoupling=4.0,
+            user_id=2,
+        )
+
+        # Call as user 1 (the test fixture's mock_user)
+        async with client as c:
+            resp = await c.get("/api/bike-readiness?weeks=12")
+
+        cc = resp.json()["current_components"]
+        assert cc["ctl_bike"] is None
+        assert cc["longest_ride_hours"] is None
+        assert cc["decoupling_n"] == 0
+
+    async def test_ef_trend_pct_field_populated(self, client):
+        """ef_trend_pct is a signed percentage, not an enum or status string.
+        Spec §6 — EF trend is a *supplementary* sub-line, not a traffic-light
+        signal, so the widget needs the raw % to prefix '+' / '-' on the sign.
+
+        Seed two weekly buckets with differentiated EF (older 2.00 → newer
+        2.20, +10%) so the assertion catches a degenerate regression where
+        the endpoint hardcodes zero or strips direction."""
+        await _seed_bike_thresholds()
+        # Older bucket (ISO W16): EF=2.00. Newer bucket (W17): EF=2.20.
+        # `_trend_pct` is (last - first) / |first| * 100 = (2.20-2.00)/2.00*100 = +10.0.
+        await _seed_valid_bike_ride(
+            "w16_old",
+            dt=_BR_WINDOW_END - timedelta(days=9),
+            decoupling=4.0,
+            efficiency_factor=2.00,
+        )
+        await _seed_valid_bike_ride(
+            "w17_new",
+            dt=_BR_WINDOW_END - timedelta(days=2),
+            decoupling=4.0,
+            efficiency_factor=2.20,
+        )
+
+        async with client as c:
+            resp = await c.get("/api/bike-readiness?weeks=12")
+
+        cc = resp.json()["current_components"]
+        assert isinstance(cc["ef_trend_pct"], (int, float))
+        # +10% improvement — exact value pinned by `_trend_pct`'s rounding.
+        assert cc["ef_trend_pct"] == 10.0
+
+    async def test_ef_trend_pct_null_when_insufficient(self, client):
+        """Single weekly EF sample → `_trend_pct` returns
+        `direction=insufficient_data`, and the endpoint maps that to
+        `ef_trend_pct: None`. The widget hides the sub-line on null
+        (Progress.tsx EF-trend conditional render). Spec §3.3."""
+        await _seed_bike_thresholds()
+        # Single ride → only one ISO week populated → trend insufficient.
+        await _seed_valid_bike_ride("lone", dt=_BR_WINDOW_END - timedelta(days=2), decoupling=4.0)
+
+        async with client as c:
+            resp = await c.get("/api/bike-readiness?weeks=12")
+
+        cc = resp.json()["current_components"]
+        assert cc["ef_trend_pct"] is None
+        # Sanity: the ride DID land in the decoupling pipeline — null here
+        # is about EF trend specifically, not a blanket "no data" miss.
+        assert cc["decoupling_n"] == 1

--- a/tests/mcp/test_efficiency_trend.py
+++ b/tests/mcp/test_efficiency_trend.py
@@ -1,0 +1,116 @@
+"""Regression tests for ``compute_efficiency_trend``.
+
+Covers the race-exclusion contract relied on by:
+  - ``/api/bike-readiness`` (BIKE_READINESS_SPEC §3.3, §7)
+  - ``/api/progress``
+  - the ``get_efficiency_trend`` MCP tool
+
+The function pre-filters activities before the bulk-detail fetch; race-effort
+(`is_race=True`) is peak load, not a training-base signal, so all three
+callers want it dropped before the decoupling median / weekly EF are computed.
+"""
+
+from datetime import date, timedelta
+
+from data.db import Activity, ActivityDetail, AthleteSettings, get_session
+from data.intervals.dto import ActivityDTO
+from mcp_server.tools.progress import compute_efficiency_trend
+
+
+async def _seed_bike_thresholds(user_id: int = 1) -> None:
+    """LTHR = 153 → Z2 (68–83% LTHR) = 104–127 bpm. Test rides set avg_hr=115
+    so they clear the Z2 gate under ``strict_filter=True``."""
+    await AthleteSettings.upsert(user_id=user_id, sport="Ride", lthr=153)
+
+
+async def _seed_bike_ride(
+    aid: str,
+    *,
+    dt: date,
+    is_race: bool = False,
+    decoupling: float = 4.0,
+    user_id: int = 1,
+) -> None:
+    """Seed one bike activity + a matching ActivityDetail that clears every
+    `is_valid_for_decoupling` gate (VI ≤ 1.10, ≥60min ride, >70% Z1+Z2,
+    decoupling not NULL) and `_is_z2` (avg_hr inside 68–83% LTHR)."""
+    dto = ActivityDTO(
+        id=aid,
+        start_date_local=dt,
+        type="Ride",
+        moving_time=4200,  # 70 min, > 60-min bike floor
+        average_hr=115.0,  # inside Z2 (104–127) for LTHR=153
+    )
+    dto.is_race = is_race
+    await Activity.save_bulk(user_id, activities=[dto])
+
+    async with get_session() as session:
+        session.add(
+            ActivityDetail(
+                activity_id=aid,
+                variability_index=1.02,
+                efficiency_factor=2.10,
+                decoupling=decoupling,
+                hr_zone_times=[1200, 2400, 400, 150, 50],  # 86% in Z1+Z2
+                pace=2.5,
+            )
+        )
+        await session.commit()
+
+
+class TestRaceExclusion:
+    """Spec BIKE_READINESS_SPEC §3.3 + §7 — races out of decoupling + EF trend."""
+
+    async def test_race_dropped_from_decoupling_trend(self):
+        """A bike race with elevated decoupling must not poison the median.
+
+        Without the fix the 12% race-day decoupling would flip the
+        last-5 median above 5% and force the Durability traffic-light yellow.
+        """
+        await _seed_bike_thresholds()
+        # Three healthy rides (decoupling ≈ 4%), then a race with 12% drift.
+        today = date.today()
+        for i, aid in enumerate(["r1", "r2", "r3"]):
+            await _seed_bike_ride(aid, dt=today - timedelta(days=i + 2), decoupling=4.0)
+        await _seed_bike_ride("race", dt=today - timedelta(days=1), is_race=True, decoupling=12.0)
+
+        result = await compute_efficiency_trend(user_id=1, sport="bike", days_back=84, strict_filter=True)
+
+        # Single-sport request → flat dict (not nested under "bike").
+        trend = result["decoupling_trend"]
+        assert trend["last_n"] == 3, "race must be dropped before the last-5 median"
+        assert 12.0 not in trend["values"]
+        assert trend["median"] == 4.0
+        assert trend["status"] == "green"
+
+    async def test_race_dropped_from_weekly_ef(self):
+        """A bike race's EF must not land in any weekly bucket — `weekly`
+        feeds the EFChart and the supplementary EF-trend signal."""
+        await _seed_bike_thresholds()
+        today = date.today()
+        await _seed_bike_ride("nrm", dt=today - timedelta(days=3), decoupling=4.0)
+        await _seed_bike_ride("rac", dt=today - timedelta(days=2), is_race=True, decoupling=4.0)
+
+        result = await compute_efficiency_trend(user_id=1, sport="bike", days_back=84, strict_filter=True)
+
+        # Race id must not appear among the per-activity entries either.
+        ids = [a["id"] for a in result["activities"]]
+        assert "rac" not in ids
+        assert "nrm" in ids
+        # Weekly aggregate exists (single non-race ride) but is built only
+        # from the non-race; sessions count == 1 confirms isolation.
+        assert sum(w["sessions"] for w in result["weekly"]) == 1
+
+    async def test_baseline_non_race_included(self):
+        """Sanity: the same fixture without `is_race=True` IS counted —
+        ensures the assertions above flunk the test if race exclusion
+        accidentally turns into blanket exclusion."""
+        await _seed_bike_thresholds()
+        today = date.today()
+        await _seed_bike_ride("plain", dt=today - timedelta(days=1), decoupling=4.0)
+
+        result = await compute_efficiency_trend(user_id=1, sport="bike", days_back=84, strict_filter=True)
+
+        assert result["data_points"] == 1
+        assert result["decoupling_trend"]["last_n"] == 1
+        assert result["decoupling_trend"]["values"] == [4.0]

--- a/webapp/src/api/types.ts
+++ b/webapp/src/api/types.ts
@@ -767,3 +767,33 @@ export interface MarathonShapeResponse {
   // races > 30 km.
   max_run_race_distance_m: number | null
 }
+
+// Bike Readiness — 3-signal (Volume / Long ride / Durability) bike-leg
+// readiness, no synthetic Bike Shape %. Endpoint returns 12 weekly CTL_bike
+// snapshots + current 3-signal envelope; the widget computes
+// distance-specific targets (Olympic / 70.3 / IM) and the traffic-light
+// verdict client-side from the empirical target table (spec §3.1).
+export interface BikeReadinessWeek {
+  week_start: string
+  week_end: string
+  // null when `wellness.sport_info` is missing for week_end and the 7-day
+  // back-walk also yields nothing (e.g. fresh user, backfill gap).
+  ctl_bike: number | null
+}
+
+export interface BikeReadinessComponents {
+  ctl_bike: number | null               // newest week's CTL_bike — Volume signal
+  longest_ride_hours: number | null     // max moving_time over last 28d, hours
+  longest_ride_date: string | null      // "YYYY-MM-DD" of the longest ride
+  decoupling_median_pct: number | null  // median of last 5 valid bike rides over 84d
+  decoupling_status: 'green' | 'yellow' | 'red' | null
+  decoupling_n: number                  // count of valid rides used (0 = insufficient)
+  // Signed % EF change over the 84-day window. >0 = improving aerobic fitness.
+  // null when fewer than 2 weekly samples landed (insufficient_data).
+  ef_trend_pct: number | null
+}
+
+export interface BikeReadinessResponse {
+  weeks: BikeReadinessWeek[]
+  current_components: BikeReadinessComponents
+}

--- a/webapp/src/pages/Progress.tsx
+++ b/webapp/src/pages/Progress.tsx
@@ -11,7 +11,7 @@ import { useApi } from '../hooks/useApi'
 import { apiFetch } from '../api/client'
 import { CHART_COLORS } from '../lib/constants'
 import { num } from '../lib/formatters'
-import type { ProgressResponse, DecouplingTrend, MarathonShapeResponse } from '../api/types'
+import type { ProgressResponse, DecouplingTrend, MarathonShapeResponse, BikeReadinessResponse } from '../api/types'
 
 interface FitnessProjectionData {
   count: number
@@ -86,6 +86,7 @@ export default function Progress() {
       {sport !== 'swim' && <PolarizationWidget sport={sport} />}
       {sport === 'run' && <MarathonShapeWidget />}
       {sport === 'bike' && <ProgressionWidget />}
+      {sport === 'bike' && <BikeReadinessWidget />}
 
       <TabSwitcher tabs={DAYS_TABS} active={days} onChange={setDays} />
 
@@ -877,6 +878,306 @@ function MarathonShapeWidget() {
             <span className="font-mono">{num(current.vo2max, 1)}</span>
           </div>
         </div>
+      )}
+    </div>
+  )
+}
+
+
+// Bike Readiness — 3-signal (Volume / Long ride / Durability) bike-leg
+// readiness, no synthetic Bike Shape %. Distance picker renormalises the
+// per-distance targets but doesn't refetch — endpoint returns absolute
+// values, widget computes ratios + verdict client-side (spec §3, §6).
+type BRDistance = 'Olympic' | '70.3' | 'IM'
+
+const BR_DISTANCE_TABS = [
+  { key: 'Olympic', label: 'Olympic' },
+  { key: '70.3', label: '70.3' },
+  { key: 'IM', label: 'IM' },
+]
+
+// Spec §3.1 (target_ctl_bike) + §3.2 (target_long_ride_hours). Table values,
+// not FTP-parameterised — there is no published `f(FTP, age)` formula for
+// bike CTL bands. Calibrated on mid-pack AG-triathlete reference (Friel /
+// Coggan band midpoints); see spec §3.1 Provenance + Calibration caveat.
+// Phase 2 may revisit if drift shows up at elite / beginner brackets.
+const BR_DISTANCE_TARGETS: Record<BRDistance, { ctl: number; longRideH: number }> = {
+  Olympic: { ctl: 50, longRideH: 1.5 },
+  '70.3': { ctl: 75, longRideH: 3.0 },
+  IM: { ctl: 100, longRideH: 5.0 },
+}
+
+// Spec §3.1 / §3.2 traffic-light bounds. Same ratio thresholds for Volume
+// and Long ride; Durability uses backend-computed status (decoupling has
+// fixed %-thresholds 5 / 10 wired into `decoupling_status` helper).
+const BR_RATIO_GREEN = 1.0
+const BR_RATIO_YELLOW = 0.8
+
+type BRSignal = 'green' | 'yellow' | 'red' | 'insufficient'
+
+function ratioToSignal(ratio: number | null): BRSignal {
+  if (ratio === null) return 'insufficient'
+  if (ratio >= BR_RATIO_GREEN) return 'green'
+  if (ratio >= BR_RATIO_YELLOW) return 'yellow'
+  return 'red'
+}
+
+// Decimal hours → "H:MM". 2.25 → "2:15", 0.75 → "0:45". Used for the long-ride
+// row («2:15 / 3:00»). Sub-hour rides keep the leading zero so the column
+// stays visually aligned with the target.
+function formatHoursHM(hours: number): string {
+  if (!Number.isFinite(hours) || hours < 0) return '—'
+  const total = Math.round(hours * 60)
+  const h = Math.floor(total / 60)
+  const m = total % 60
+  return `${h}:${String(m).padStart(2, '0')}`
+}
+
+function BikeReadinessWidget() {
+  const [data, setData] = useState<BikeReadinessResponse | null>(null)
+  const [distance, setDistance] = useState<BRDistance>('70.3')
+  const chartRef = useRef<HTMLCanvasElement>(null)
+  const chartInstRef = useRef<Chart | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    apiFetch<BikeReadinessResponse>('/api/bike-readiness?weeks=12')
+      .then(d => { if (!cancelled) setData(d) })
+      .catch(e => console.warn('bike-readiness fetch failed:', e))
+    return () => { cancelled = true }
+  }, [])
+
+  // Chronological for the chart (oldest → newest). API returns newest-first
+  // so `current_components` reads weeks[0]; reverse here for plotting. Stable
+  // ref via useMemo — load-bearing because this array feeds the chart-effect
+  // deps, see the same pattern in MarathonShapeWidget.
+  const chronological = useMemo(() => data ? [...data.weeks].reverse() : [], [data])
+  const targets = BR_DISTANCE_TARGETS[distance]
+  const current = data?.current_components ?? null
+
+  // Three signals per spec §3. Each is computed client-side from the absolute
+  // values returned by the endpoint — the only distance-dependent inputs are
+  // `targets.ctl` and `targets.longRideH`. Durability comes pre-classified
+  // from the backend (it has no distance dependence — decoupling thresholds
+  // are fixed 5%/10%).
+  const volumeRatio = current?.ctl_bike != null ? current.ctl_bike / targets.ctl : null
+  const longRideRatio = current?.longest_ride_hours != null ? current.longest_ride_hours / targets.longRideH : null
+  const volumeSignal = ratioToSignal(volumeRatio)
+  const longRideSignal = ratioToSignal(longRideRatio)
+  const durabilitySignal: BRSignal =
+    !current || current.decoupling_status === null || current.decoupling_n === 0
+      ? 'insufficient'
+      : current.decoupling_status
+
+  // Spec §3.4 verdict. `available` = signals we actually have data for; a
+  // mostly-empty user shouldn't be flagged "Building" off a single red.
+  const signals: BRSignal[] = [volumeSignal, longRideSignal, durabilitySignal]
+  const greens = signals.filter(s => s === 'green').length
+  const reds = signals.filter(s => s === 'red').length
+  const insufficient = signals.filter(s => s === 'insufficient').length
+  const available = 3 - insufficient
+
+  let verdictLabel: string
+  let verdictColor: string
+  let subtext: string | null
+  if (insufficient >= 2) {
+    verdictLabel = `Not enough data for ${distance}`
+    verdictColor = 'var(--text-dim)'
+    subtext = null
+  } else if (reds >= 1) {
+    verdictLabel = `Building for ${distance}`
+    verdictColor = STATUS_COLORS.red
+    // Building subtext counts non-reds (greens + yellows) — gradient
+    // information that distinguishes "1 red, 2 green" from "1 red, 0 green".
+    subtext = `${available - reds} of ${available} signals on track`
+  } else if (greens === available) {
+    verdictLabel = `Ready for ${distance}`
+    verdictColor = STATUS_COLORS.green
+    subtext = 'All signals on track ✓'
+  } else {
+    // YYY vs GGY both land here — subtext distinguishes them by counting
+    // only fully-green signals (spec §3.4 — "Subtext gradient information
+    // without extra verdict state").
+    verdictLabel = `Almost ready for ${distance}`
+    verdictColor = STATUS_COLORS.yellow
+    subtext = `${greens} of ${available} signals on track`
+  }
+
+  // Effect 1 — chart lifecycle, depends only on the dataset. Distance
+  // switches patch the annotation in place (Effect 2) instead of rebuilding
+  // the chart, mirroring the MarathonShapeWidget pattern.
+  useEffect(() => {
+    if (!chartRef.current || chronological.length === 0) return
+
+    chartInstRef.current?.destroy()
+
+    const labels = chronological.map(w => w.week_end.replace(/^\d{4}-/, ''))
+    const values = chronological.map(w => w.ctl_bike)
+    const color = CHART_COLORS.ride
+    const baseOpts = chartOptions('CTL Bike — 12 weeks')
+
+    chartInstRef.current = new Chart(chartRef.current, {
+      type: 'line',
+      data: {
+        labels,
+        datasets: [{
+          label: 'CTL bike',
+          data: values,
+          borderColor: color,
+          backgroundColor: color + '20',
+          fill: true,
+          tension: 0.3,
+          pointRadius: 3,
+          pointBackgroundColor: color,
+          borderWidth: 2,
+          spanGaps: true,
+        }],
+      },
+      options: {
+        ...baseOpts,
+        plugins: {
+          ...(baseOpts.plugins as Record<string, unknown>),
+          annotation: {
+            annotations: {
+              target: {
+                type: 'line',
+                yMin: targets.ctl,
+                yMax: targets.ctl,
+                borderColor: STATUS_COLORS.green,
+                borderWidth: 2,
+                borderDash: [5, 5],
+                label: {
+                  display: true,
+                  content: `${distance} target ${targets.ctl}`,
+                  position: 'end',
+                  backgroundColor: STATUS_COLORS.green,
+                  color: '#fff',
+                  font: { size: 10, weight: 'bold' },
+                },
+              },
+            },
+          },
+        },
+      },
+    })
+
+    return () => { chartInstRef.current?.destroy() }
+    // Distance/targets intentionally excluded — see Effect 2.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [chronological])
+
+  // Effect 2 — annotation patch on distance switch (no chart rebuild).
+  useEffect(() => {
+    const chart = chartInstRef.current
+    const annotation = (chart?.options?.plugins as { annotation?: { annotations?: { target?: Record<string, unknown> } } })
+      ?.annotation?.annotations?.target
+    if (!chart || !annotation) return
+
+    annotation.yMin = targets.ctl
+    annotation.yMax = targets.ctl
+    const label = annotation.label as { content?: string } | undefined
+    if (label) label.content = `${distance} target ${targets.ctl}`
+    chart.update('none')
+  }, [distance, targets.ctl])
+
+  if (!data) return null
+
+  const hasAnyChartData = chronological.some(w => w.ctl_bike !== null)
+
+  return (
+    <div className="bg-surface border border-border rounded-[14px] p-4 mb-3">
+      <div className="flex items-center justify-between mb-3">
+        <span className="text-[13px] text-text-dim">Bike Readiness</span>
+      </div>
+
+      <TabSwitcher tabs={BR_DISTANCE_TABS} active={distance} onChange={k => setDistance(k as BRDistance)} />
+
+      <div className="mb-3 mt-2">
+        <div className="text-base font-bold" style={{ color: verdictColor }}>{verdictLabel}</div>
+        {subtext && <div className="text-[11px] text-text-dim mt-0.5">{subtext}</div>}
+      </div>
+
+      {hasAnyChartData && (
+        <ChartCard>
+          <canvas ref={chartRef} />
+        </ChartCard>
+      )}
+
+      <div className="mt-3 pt-3 border-t border-border space-y-2 text-[12px]">
+        <SignalRow
+          signal={volumeSignal}
+          label="Volume"
+          value={
+            current?.ctl_bike != null
+              ? `CTL ${num(current.ctl_bike, 0)} / ${targets.ctl}`
+              : 'CTL unavailable'
+          }
+          pct={volumeRatio !== null ? Math.round(volumeRatio * 100) : null}
+        />
+        <SignalRow
+          signal={longRideSignal}
+          label="Long ride"
+          value={
+            current?.longest_ride_hours != null
+              ? `${formatHoursHM(current.longest_ride_hours)} / ${formatHoursHM(targets.longRideH)}`
+              : 'No bike rides last 28 days'
+          }
+          pct={longRideRatio !== null ? Math.round(longRideRatio * 100) : null}
+        />
+        <SignalRow
+          signal={durabilitySignal}
+          label="Durability"
+          value={
+            current && current.decoupling_median_pct != null
+              ? `Pa:Hr ${num(current.decoupling_median_pct, 1)}% (${current.decoupling_n} rides)`
+              : 'No valid rides'
+          }
+          pct={null}
+          subLine={
+            current?.ef_trend_pct != null
+              ? `\u{1F4C8} EF trend ${current.ef_trend_pct >= 0 ? '+' : ''}${num(current.ef_trend_pct, 1)}% (12w)`
+              : null
+          }
+        />
+      </div>
+    </div>
+  )
+}
+
+// One row in the 3-signal block: colored dot + label + actual/target +
+// optional percentage. Durability passes `subLine` for the supplementary EF
+// trend (spec §3.3 / §6 — EF is a complement, not a fourth signal).
+function SignalRow({
+  signal,
+  label,
+  value,
+  pct,
+  subLine,
+}: {
+  signal: BRSignal
+  label: string
+  value: string
+  pct: number | null
+  subLine?: string | null
+}) {
+  const dotColor = signal === 'insufficient' ? 'var(--text-dim)' : STATUS_COLORS[signal]
+  return (
+    <div>
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <span
+            className="inline-block w-2 h-2 rounded-full"
+            style={{ backgroundColor: dotColor }}
+          />
+          <span className="text-text-dim">{label}</span>
+        </div>
+        <span className="font-mono">
+          {value}
+          {pct !== null && <span className="text-text-dim ml-2">({pct}%)</span>}
+        </span>
+      </div>
+      {subLine && (
+        <div className="ml-4 mt-0.5 text-[11px] text-text-dim">{subLine}</div>
       )}
     </div>
   )


### PR DESCRIPTION
### Summary
Introduces a new bike readiness endpoint and widget to the dashboard, allowing users to assess their bike-training readiness level.

### Key Changes
- Adds an endpoint for fetching bike readiness data, including 12-week CTL trends and current training signals
- Implements a bike readiness widget on the dashboard featuring a traffic-light evaluation of training volume, longest ride, and durability
- Enhances the compute efficiency trend function to exclude race efforts from training analysis

### Benefits
- Provides triathletes with a tool to objectively evaluate their bike-leg preparedness
- Uses industry-validated metrics without introducing synthetic percentages, ensuring reliable insights into training status

### Test Coverage
- Included comprehensive tests for the new endpoint and underlying functionality
- Ensures reliability by testing edge cases and tenant isolation compliance

### Additional Context
- Specified logic for distance-targeted goals with adaptable indicators based on the user’s chosen race distance (Olympic, 70.3, or IM)
- Designed widget to be self-assessing with no need for back-end recalculations upon user input changes