### PR TITLE
Enhances fitness projection with scheduled workout integration

### DIFF
--- a/api/routers/activities.py
+++ b/api/routers/activities.py
@@ -6,11 +6,22 @@ from sqlalchemy import exists, select
 
 from api.deps import get_data_user_id, require_viewer
 from config import settings
-from data.db import Activity, ActivityDetail, ActivityHrv, ActivityWeather, FitnessProjection, Race, User, get_session
+from data.db import (
+    Activity,
+    ActivityDetail,
+    ActivityHrv,
+    ActivityWeather,
+    FitnessProjection,
+    Race,
+    ScheduledWorkout,
+    User,
+    get_session,
+)
 from data.ml.progression import get_latest_analysis
 from data.utils import format_duration, serialize_activity_details, serialize_activity_hrv
 from mcp_server.tools.polarization import get_polarization_multi_window
 from mcp_server.tools.progress import compute_efficiency_trend
+from tasks.dto import local_today
 
 router = APIRouter()
 
@@ -211,8 +222,24 @@ async def progression(
 
 @router.get("/api/fitness-projection")
 async def fitness_projection(user: User = Depends(require_viewer)) -> dict:
-    """Get fitness projection (CTL/ATL decay curve from Intervals.icu)."""
-    rows = await FitnessProjection.get_projection(user_id=get_data_user_id(user))
+    """Get fitness projection (CTL/ATL decay curve from Intervals.icu).
+
+    Windowed to ``[today - 90d, last planned workout]``: ~3 months of history
+    give the trend, and the upper bound is the last scheduled workout because
+    beyond it the Intervals curve is pure zero-load decay (nothing to show).
+    Falls back to ``today`` when no future workout is planned.
+    """
+    uid = get_data_user_id(user)
+    today = local_today()
+
+    oldest = (today - timedelta(days=90)).isoformat()
+    last_planned = await ScheduledWorkout.get_last_scheduled_date(uid)
+    # ISO "YYYY-MM-DD" sorts lexicographically == chronologically, so max() picks
+    # the later of {last planned workout, today} — the chart always reaches at
+    # least today even if every planned workout is already in the past.
+    newest = max(last_planned, today.isoformat()) if last_planned else today.isoformat()
+
+    rows = await FitnessProjection.get_projection(user_id=uid, oldest=oldest, newest=newest)
     return {
         "count": len(rows),
         "dates": [str(r.date) for r in rows],

--- a/data/db/fitness_projection.py
+++ b/data/db/fitness_projection.py
@@ -79,9 +79,25 @@ class FitnessProjection(Base):
 
     @classmethod
     @dual
-    def get_projection(cls, user_id: int, *, session: Session) -> list[FitnessProjection]:
-        """Get all projection records for a user, ordered by date."""
-        result = session.execute(select(cls).where(cls.user_id == user_id).order_by(cls.date))
+    def get_projection(
+        cls,
+        user_id: int,
+        *,
+        oldest: str | None = None,
+        newest: str | None = None,
+        session: Session,
+    ) -> list[FitnessProjection]:
+        """Projection records for a user, ordered by date.
+
+        ``oldest`` / ``newest`` (inclusive, "YYYY-MM-DD") window the result.
+        Both default to None → full series (race-plan service relies on this).
+        """
+        conditions = [cls.user_id == user_id]
+        if oldest is not None:
+            conditions.append(cls.date >= oldest)
+        if newest is not None:
+            conditions.append(cls.date <= newest)
+        result = session.execute(select(cls).where(*conditions).order_by(cls.date))
         return list(result.scalars().all())
 
     @classmethod

--- a/data/db/workout.py
+++ b/data/db/workout.py
@@ -179,6 +179,18 @@ class ScheduledWorkout(Base):
 
         return workouts, last_synced_at
 
+    @classmethod
+    @with_session
+    async def get_last_scheduled_date(cls, user_id: int, *, session: AsyncSession) -> str | None:
+        """Latest planned-workout date (``start_date_local``) for the user, or None.
+
+        Used as the fitness-projection chart's upper bound: past the last
+        planned workout the Intervals curve is pure zero-load decay, so there
+        is nothing meaningful to show beyond it.
+        """
+        result = await session.execute(select(func.max(cls.start_date_local)).where(cls.user_id == user_id))
+        return result.scalar_one_or_none()
+
 
 class AiWorkout(Base):
     """AI-generated workout pushed to Intervals.icu (Phase 1: Adaptive Training Plan)."""

--- a/tests/db/test_fitness_projection.py
+++ b/tests/db/test_fitness_projection.py
@@ -1,6 +1,7 @@
 """Tests for FitnessProjection model — save_bulk upsert and get_projection."""
 
-from unittest.mock import MagicMock, patch
+from datetime import date
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -80,57 +81,133 @@ class TestGetProjection:
         result = FitnessProjection.get_projection(user_id=999, session=mock_session)
         assert result == []
 
+    @staticmethod
+    def _executed_sql(mock_session) -> str:
+        return str(mock_session.execute.call_args[0][0].compile(compile_kwargs={"literal_binds": True}))
+
+    def test_no_bounds_emits_no_date_predicate(self):
+        """Default call (oldest=newest=None) → only the user_id filter, full series.
+
+        Backward-compat guard: data/race_plan_service.py relies on the unbounded
+        behaviour to read future race-day rows.
+        """
+        mock_session = MagicMock()
+        mock_session.execute.return_value.scalars.return_value.all.return_value = []
+
+        FitnessProjection.get_projection(user_id=7, session=mock_session)
+
+        sql = self._executed_sql(mock_session)
+        assert "fitness_projection.date >=" not in sql
+        assert "fitness_projection.date <=" not in sql
+
+    def test_oldest_and_newest_window_the_query(self):
+        """oldest/newest add inclusive >= / <= predicates on date."""
+        mock_session = MagicMock()
+        mock_session.execute.return_value.scalars.return_value.all.return_value = []
+
+        FitnessProjection.get_projection(user_id=7, oldest="2026-02-15", newest="2026-05-29", session=mock_session)
+
+        sql = self._executed_sql(mock_session)
+        assert "2026-02-15" in sql
+        assert "2026-05-29" in sql
+        assert "fitness_projection.date >=" in sql
+        assert "fitness_projection.date <=" in sql
+
+    def test_only_oldest_applies_lower_bound_only(self):
+        """A lone oldest bound emits >= but not <=."""
+        mock_session = MagicMock()
+        mock_session.execute.return_value.scalars.return_value.all.return_value = []
+
+        FitnessProjection.get_projection(user_id=7, oldest="2026-02-15", session=mock_session)
+
+        sql = self._executed_sql(mock_session)
+        assert "fitness_projection.date >=" in sql
+        assert "fitness_projection.date <=" not in sql
+
 
 class TestFitnessProjectionEndpoint:
     """Tests for the /api/fitness-projection API response shape."""
 
-    @pytest.mark.asyncio
-    async def test_empty_projection_response(self):
-        """Empty projection returns count=0 with empty arrays."""
-        from unittest.mock import AsyncMock
+    # Endpoint's "today" is pinned so window assertions check literal dates —
+    # this makes the tz/offset/max() logic genuinely testable (a UTC-vs-Belgrade
+    # regression would change FIXED_TODAY's effect and fail, instead of the test
+    # recomputing the same wrong value). 2026-05-16 − 90d == 2026-02-15.
+    FIXED_TODAY = date(2026, 5, 16)
 
-        with patch("api.routers.activities.FitnessProjection") as mock_cls:
-            mock_cls.get_projection = AsyncMock(return_value=[])
+    async def _call(self, *, projection_rows, last_planned):
+        """Invoke the endpoint with both DB calls + local_today mocked.
+
+        Returns ``(result, get_projection mock)``.
+        """
+        with (
+            patch("api.routers.activities.FitnessProjection") as mock_fp,
+            patch("api.routers.activities.ScheduledWorkout") as mock_sw,
+            patch("api.routers.activities.local_today", return_value=self.FIXED_TODAY),
+            patch("api.routers.activities.get_data_user_id", return_value=1),
+        ):
+            mock_fp.get_projection = AsyncMock(return_value=projection_rows)
+            mock_sw.get_last_scheduled_date = AsyncMock(return_value=last_planned)
 
             from api.routers.activities import fitness_projection
 
             mock_user = MagicMock()
             mock_user.id = 1
             mock_user.role = "athlete"
+            result = await fitness_projection(user=mock_user)
 
-            with patch("api.routers.activities.get_data_user_id", return_value=1):
-                result = await fitness_projection(user=mock_user)
+        return result, mock_fp.get_projection
 
-            assert result["count"] == 0
-            assert result["dates"] == []
-            assert result["ctl"] == []
-            assert result["atl"] == []
-            assert result["ramp_rate"] == []
+    @pytest.mark.asyncio
+    async def test_empty_projection_response(self):
+        """Empty projection returns count=0 with empty arrays."""
+        result, _ = await self._call(projection_rows=[], last_planned=None)
+
+        assert result["count"] == 0
+        assert result["dates"] == []
+        assert result["ctl"] == []
+        assert result["atl"] == []
+        assert result["ramp_rate"] == []
 
     @pytest.mark.asyncio
     async def test_projection_response_shape(self):
         """Projection with data returns parallel arrays."""
-        from unittest.mock import AsyncMock
-
         mock_rows = [
             MagicMock(date="2026-04-16", ctl=19.5, atl=38.0, ramp_rate=4.7),
             MagicMock(date="2026-04-17", ctl=18.8, atl=35.2, ramp_rate=4.5),
         ]
 
-        with patch("api.routers.activities.FitnessProjection") as mock_cls:
-            mock_cls.get_projection = AsyncMock(return_value=mock_rows)
+        result, _ = await self._call(projection_rows=mock_rows, last_planned="2099-01-01")
 
-            from api.routers.activities import fitness_projection
+        assert result["count"] == 2
+        assert result["dates"] == ["2026-04-16", "2026-04-17"]
+        assert result["ctl"] == [19.5, 18.8]
+        assert result["atl"] == [38.0, 35.2]
+        assert result["ramp_rate"] == [4.7, 4.5]
 
-            mock_user = MagicMock()
-            mock_user.id = 1
-            mock_user.role = "athlete"
+    @pytest.mark.asyncio
+    async def test_window_lower_bound_is_today_minus_90d(self):
+        """oldest is always today − 90 days regardless of planned workouts."""
+        _, get_proj = await self._call(projection_rows=[], last_planned=None)
 
-            with patch("api.routers.activities.get_data_user_id", return_value=1):
-                result = await fitness_projection(user=mock_user)
+        assert get_proj.await_args.kwargs["oldest"] == "2026-02-15"
 
-            assert result["count"] == 2
-            assert result["dates"] == ["2026-04-16", "2026-04-17"]
-            assert result["ctl"] == [19.5, 18.8]
-            assert result["atl"] == [38.0, 35.2]
-            assert result["ramp_rate"] == [4.7, 4.5]
+    @pytest.mark.asyncio
+    async def test_upper_bound_is_future_planned_workout(self):
+        """A planned workout in the future becomes the upper bound."""
+        _, get_proj = await self._call(projection_rows=[], last_planned="2026-06-05")
+
+        assert get_proj.await_args.kwargs["newest"] == "2026-06-05"
+
+    @pytest.mark.asyncio
+    async def test_upper_bound_falls_back_to_today_when_no_plan(self):
+        """No planned workouts → upper bound clamps to today."""
+        _, get_proj = await self._call(projection_rows=[], last_planned=None)
+
+        assert get_proj.await_args.kwargs["newest"] == "2026-05-16"
+
+    @pytest.mark.asyncio
+    async def test_upper_bound_clamps_to_today_when_plan_in_past(self):
+        """Last planned workout already in the past → still reach at least today."""
+        _, get_proj = await self._call(projection_rows=[], last_planned="2026-05-01")
+
+        assert get_proj.await_args.kwargs["newest"] == "2026-05-16"

--- a/tests/db/test_scheduled_workouts.py
+++ b/tests/db/test_scheduled_workouts.py
@@ -50,6 +50,17 @@ def _make_workout(
     )
 
 
+async def _ensure_user(user_id: int) -> None:
+    """Create a users row so FK-constrained inserts for a 2nd tenant succeed."""
+    from data.db import User
+    from data.db.common import get_session
+
+    async with get_session() as session:
+        if not await session.get(User, user_id):
+            session.add(User(id=user_id, chat_id=f"test_user_{user_id}", role="athlete"))
+            await session.commit()
+
+
 # ---------------------------------------------------------------------------
 # save_scheduled_workouts — last_synced_at
 # ---------------------------------------------------------------------------
@@ -267,6 +278,37 @@ class TestGetScheduledWorkoutsRange:
         rows, _ = await ScheduledWorkout.get_range(1, date(2026, 3, 23), date(2026, 3, 29))
         dates = [r.start_date_local for r in rows]
         assert dates == sorted(dates)
+
+
+# ---------------------------------------------------------------------------
+# get_last_scheduled_date — fitness-projection chart upper bound
+# ---------------------------------------------------------------------------
+
+
+class TestGetLastScheduledDate:
+    async def test_returns_max_start_date(self):
+        base = _uid(50)
+        ScheduledWorkout.save_bulk(
+            1,
+            [
+                _make_workout(id=base, dt=date(2026, 5, 10)),
+                _make_workout(id=base + 1, dt=date(2026, 5, 29)),  # latest
+                _make_workout(id=base + 2, dt=date(2026, 5, 18)),
+            ],
+        )
+
+        assert await ScheduledWorkout.get_last_scheduled_date(1) == "2026-05-29"
+
+    async def test_returns_none_when_no_workouts(self):
+        assert await ScheduledWorkout.get_last_scheduled_date(_uid(55)) is None
+
+    async def test_scoped_per_user(self):
+        """A later workout owned by another user must not leak into the max."""
+        await _ensure_user(2)
+        ScheduledWorkout.save_bulk(2, [_make_workout(id=_uid(60), dt=date(2027, 1, 1))])
+        ScheduledWorkout.save_bulk(1, [_make_workout(id=_uid(61), dt=date(2026, 5, 5))])
+
+        assert await ScheduledWorkout.get_last_scheduled_date(1) == "2026-05-05"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Updates fitness projection logic to consider the last scheduled workout:
- Adds a window to the fitness projection query, using the last scheduled workout as the upper bound for more accurate results.
- Introduces a method to fetch the last planned workout date, influencing the projection's end date.
- Expands API response tests to ensure correct projection date bounding and validity.
- Ensures the system falls back to the current date if no future workouts are scheduled.

These changes provide better insight into users' fitness trends by preventing misleading zero-load decay beyond planned workouts.