### PR TITLE
Adds adjustable history length to fitness projection

### DIFF
--- a/api/routers/activities.py
+++ b/api/routers/activities.py
@@ -221,18 +221,22 @@ async def progression(
 
 
 @router.get("/api/fitness-projection")
-async def fitness_projection(user: User = Depends(require_viewer)) -> dict:
-    """Get fitness projection (CTL/ATL decay curve from Intervals.icu).
+async def fitness_projection(
+    days: int = Query(default=90, ge=1, le=365),
+    user: User = Depends(require_viewer),
+) -> dict:
+    """Get fitness projection (CTL/ATL curve from Intervals.icu).
 
-    Windowed to ``[today - 90d, last planned workout]``: ~3 months of history
-    give the trend, and the upper bound is the last scheduled workout because
-    beyond it the Intervals curve is pure zero-load decay (nothing to show).
-    Falls back to ``today`` when no future workout is planned.
+    Windowed to ``[today - days, last planned workout]``. ``days`` is the
+    history length the UI toggles (1m/3m/6m → 30/90/180). The upper bound is
+    the last scheduled workout: Intervals' forward curve *does* fold in
+    planned-workout load, but past the last workout it's only decay (nothing
+    more to show). Falls back to ``today`` when no future workout is planned.
     """
     uid = get_data_user_id(user)
     today = local_today()
 
-    oldest = (today - timedelta(days=90)).isoformat()
+    oldest = (today - timedelta(days=days)).isoformat()
     last_planned = await ScheduledWorkout.get_last_scheduled_date(uid)
     # ISO "YYYY-MM-DD" sorts lexicographically == chronologically, so max() picks
     # the later of {last planned workout, today} — the chart always reaches at

--- a/tests/db/test_fitness_projection.py
+++ b/tests/db/test_fitness_projection.py
@@ -134,10 +134,12 @@ class TestFitnessProjectionEndpoint:
     # recomputing the same wrong value). 2026-05-16 − 90d == 2026-02-15.
     FIXED_TODAY = date(2026, 5, 16)
 
-    async def _call(self, *, projection_rows, last_planned):
+    async def _call(self, *, projection_rows, last_planned, days=90):
         """Invoke the endpoint with both DB calls + local_today mocked.
 
-        Returns ``(result, get_projection mock)``.
+        ``days`` is passed explicitly because calling the endpoint function
+        directly (not via the app) would otherwise leave the ``Query`` default
+        as a FieldInfo object. Returns ``(result, get_projection mock)``.
         """
         with (
             patch("api.routers.activities.FitnessProjection") as mock_fp,
@@ -153,7 +155,7 @@ class TestFitnessProjectionEndpoint:
             mock_user = MagicMock()
             mock_user.id = 1
             mock_user.role = "athlete"
-            result = await fitness_projection(user=mock_user)
+            result = await fitness_projection(days=days, user=mock_user)
 
         return result, mock_fp.get_projection
 
@@ -185,11 +187,24 @@ class TestFitnessProjectionEndpoint:
         assert result["ramp_rate"] == [4.7, 4.5]
 
     @pytest.mark.asyncio
-    async def test_window_lower_bound_is_today_minus_90d(self):
-        """oldest is always today − 90 days regardless of planned workouts."""
+    async def test_window_lower_bound_defaults_to_today_minus_90d(self):
+        """Default days=90 → oldest = today − 90 days (== 2026-02-15)."""
         _, get_proj = await self._call(projection_rows=[], last_planned=None)
 
         assert get_proj.await_args.kwargs["oldest"] == "2026-02-15"
+
+    @pytest.mark.asyncio
+    # Literal expecteds (FIXED_TODAY=2026-05-16 minus N days) so the test can't
+    # pass by recomputing the production formula. 1m/3m/6m == the UI toggle.
+    @pytest.mark.parametrize(
+        ("days", "expected_oldest"),
+        [(30, "2026-04-16"), (90, "2026-02-15"), (180, "2025-11-17")],
+    )
+    async def test_days_param_sets_lower_bound(self, days, expected_oldest):
+        """The UI's 1m/3m/6m toggle (30/90/180) drives the oldest bound."""
+        _, get_proj = await self._call(projection_rows=[], last_planned=None, days=days)
+
+        assert get_proj.await_args.kwargs["oldest"] == expected_oldest
 
     @pytest.mark.asyncio
     async def test_upper_bound_is_future_planned_workout(self):

--- a/webapp/src/pages/Progress.tsx
+++ b/webapp/src/pages/Progress.tsx
@@ -37,6 +37,19 @@ const DAYS_TABS = [
   { key: '365', label: '1y' },
 ]
 
+// Fitness-projection history length (lower bound). Upper bound is always the
+// last planned workout, set server-side. days = 30/90/180.
+const FITNESS_RANGE_TABS = [
+  { key: '30', label: '1m' },
+  { key: '90', label: '3m' },
+  { key: '180', label: '6m' },
+]
+
+// CTL/ATL are each split into a solid (past) + dashed projection dataset.
+// The label suffix pairs them — keep label construction, legend filter and
+// the paired-toggle onClick all sourced from this single constant.
+const PROJECTION_SUFFIX = ' (projection)'
+
 const STATUS_COLORS = {
   green: '#22c55e',
   yellow: '#eab308',
@@ -1308,12 +1321,15 @@ function FitnessProjectionChart() {
   const chartRef = useRef<HTMLCanvasElement>(null)
   const chartInstRef = useRef<Chart | null>(null)
   const [projection, setProjection] = useState<FitnessProjectionData | null>(null)
+  const [range, setRange] = useState('90')  // 3m default
 
   useEffect(() => {
-    apiFetch<FitnessProjectionData>('/api/fitness-projection')
-      .then(setProjection)
+    let cancelled = false
+    apiFetch<FitnessProjectionData>(`/api/fitness-projection?days=${range}`)
+      .then(d => { if (!cancelled) setProjection(d) })
       .catch(e => console.warn('fitness-projection fetch failed:', e))
-  }, [])
+    return () => { cancelled = true }
+  }, [range])
 
   useEffect(() => {
     if (!chartRef.current || !projection || projection.count === 0) return
@@ -1350,7 +1366,7 @@ function FitnessProjectionChart() {
             spanGaps: true,
           },
           {
-            label: 'CTL (projection)',
+            label: `CTL${PROJECTION_SUFFIX}`,
             data: ctlFuture,
             borderColor: CHART_COLORS.ctl,
             borderDash: [6, 4],
@@ -1370,7 +1386,7 @@ function FitnessProjectionChart() {
             spanGaps: true,
           },
           {
-            label: 'ATL (projection)',
+            label: `ATL${PROJECTION_SUFFIX}`,
             data: atlFuture,
             borderColor: CHART_COLORS.atl,
             borderDash: [6, 4],
@@ -1385,7 +1401,25 @@ function FitnessProjectionChart() {
         responsive: true,
         maintainAspectRatio: false,
         plugins: {
-          legend: { position: 'top', labels: { boxWidth: 12, padding: 10, font: { size: 13 }, filter: (item) => !item.text.includes('projection') } },
+          legend: {
+            position: 'top',
+            labels: { boxWidth: 12, padding: 10, font: { size: 13 }, filter: (item) => !item.text.endsWith(PROJECTION_SUFFIX) },
+            // The projection twin is filtered out of the legend. Default
+            // onClick toggles only the clicked dataset, leaving the future
+            // half visible. Toggle the base and its projection twin together.
+            onClick: (_e, legendItem, legend) => {
+              const ch = legend.chart
+              const idx = legendItem.datasetIndex
+              if (idx == null) return
+              const visible = !ch.isDatasetVisible(idx)
+              ch.data.datasets.forEach((ds, i) => {
+                if (ds.label === legendItem.text || ds.label === `${legendItem.text}${PROJECTION_SUFFIX}`) {
+                  ch.setDatasetVisibility(i, visible)
+                }
+              })
+              ch.update()
+            },
+          },
           title: { display: true, text: 'Fitness Projection (CTL / ATL)', font: { size: 14, weight: 'bold' } },
           annotation: todayIdx >= 0 ? {
             annotations: {
@@ -1411,12 +1445,18 @@ function FitnessProjectionChart() {
     return () => { chartInstRef.current?.destroy() }
   }, [projection])
 
+  // No fitness-projection rows at all → render nothing (incl. the range
+  // selector). `days` only moves the lower bound, so count===0 for the
+  // default range means the user has no projection data for any range.
   if (!projection || projection.count === 0) return null
 
   return (
-    <ChartCard>
-      <canvas ref={chartRef} />
-    </ChartCard>
+    <div className="mb-3">
+      <TabSwitcher tabs={FITNESS_RANGE_TABS} active={range} onChange={setRange} />
+      <ChartCard>
+        <canvas ref={chartRef} />
+      </ChartCard>
+    </div>
   )
 }
 


### PR DESCRIPTION
Enhances the fitness projection feature by allowing users to specify the number of days for their fitness history projection, with options for 1, 3, or 6 months (30/90/180 days). This update improves user experience by providing more flexible control over the displayed data range in the fitness projection chart.

- Refactors the endpoint to accept a `days` parameter
- Updates tests to account for the new parameter
- Modifies UI to include a range selector for fitness history length