### PR TITLE
Adds per-sport CTL/ATL backfill with CLI support

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -135,6 +135,18 @@ def main() -> None:
     )
     p_trm.add_argument("user_id", type=int)
 
+    p_rsl = sub.add_parser(
+        "recalc-sport-load",
+        help="Backfill per-sport CTL+ATL across all active athletes for the last N days. "
+        "Dispatches actor_user_wellness(force=True) per (user, day), which re-pulls wellness "
+        "from Intervals (creates row if missing for inactive users) and re-runs the pipeline — "
+        "including _actor_enrich_wellness_sport_info that recomputes sport_info[].ctl/atl. "
+        "See docs/PER_SPORT_LOAD_SPEC.md §Step 1.5.",
+    )
+    p_rsl.add_argument("--user-id", type=int, default=None, help="Specific user; default: all active athletes")
+    p_rsl.add_argument("--days", type=int, default=200, help="Window in days (default: 200, matches CTL EMA 5τ)")
+    p_rsl.add_argument("--dry-run", action="store_true", help="List users + dates without dispatching")
+
     p_cn = sub.add_parser(
         "classify-noise",
         help="Backfill activities.noise_reason for Run activities — Phase 1.6 "
@@ -181,6 +193,8 @@ def main() -> None:
         _train_race_models(args.user_id)
     elif args.command == "classify-noise":
         _classify_noise(user_id=args.user_id, since_days=args.since_days, dry_run=args.dry_run)
+    elif args.command == "recalc-sport-load":
+        _recalc_sport_load(user_id=args.user_id, days=args.days, dry_run=args.dry_run)
 
 
 def _resolve_user(user_id: int) -> UserDTO:
@@ -817,6 +831,73 @@ def _train_race_models(user_id: int) -> None:
             print(f"  {discipline:5s}: skip — {e}")
         except Exception as e:
             print(f"  {discipline:5s}: FAILED — {type(e).__name__}: {e}")
+
+
+def _recalc_sport_load(*, user_id: int | None, days: int, dry_run: bool) -> None:
+    """Backfill per-sport CTL+ATL for the last `days` days across active athletes.
+
+    For each (user, day) → `actor_user_wellness(force=True)`. The actor re-pulls
+    wellness from Intervals (creates row if missing), then dispatches
+    `actor_after_activity_update` which re-runs `_actor_enrich_wellness_sport_info`
+    on the 200-day window — recomputing per-sport CTL/ATL with the new algorithm.
+
+    Sequential per user: user `i` starts at `i * days * 20s`. The 20s/day pacing
+    mirrors `_sync_wellness` and stays under Intervals.icu's rate limit.
+    """
+    today = date.today()
+    start = today - timedelta(days=days - 1)
+
+    with get_sync_session() as session:
+        if user_id is not None:
+            user = session.get(User, user_id)
+            if not user or not user.is_active or not user.athlete_id:
+                raise SystemExit(f"User {user_id} not active or has no athlete_id")
+            users = [user]
+        else:
+            users = list(
+                session.execute(
+                    select(User).where(User.is_active.is_(True), User.athlete_id.isnot(None)).order_by(User.id)
+                )
+                .scalars()
+                .all()
+            )
+
+    if not users:
+        print("No active athletes found")
+        return
+
+    # 60s/day vs sync-wellness's 20s: actor_user_wellness fans out HRV/RHR/Banister/
+    # recovery analyses that walk rolling 7/60d baselines. 20s can be tight under
+    # API retries and risks the cross-day race OAUTH_BOOTSTRAP_SYNC_SPEC §17 warns
+    # about. 60s is a 3× margin — one-shot backfill, wall-time cost is acceptable.
+    delay_per_day_ms = 60_000
+    days_per_user = days
+    per_user_window_ms = days_per_user * delay_per_day_ms
+
+    total_msgs = len(users) * days_per_user
+    wall_minutes = (len(users) * per_user_window_ms) / 60_000
+    print(
+        f"recalc-sport-load: {len(users)} user(s), {days_per_user} day(s) each "
+        f"({start} → {today}) → {total_msgs} dispatches, "
+        f"~{wall_minutes:.0f} min wall time"
+    )
+
+    if dry_run:
+        for u in users:
+            print(f"  user_id={u.id} chat_id={u.chat_id} @{u.username or '-'}")
+        print("Dry run — no messages queued.")
+        return
+
+    for i, u in enumerate(users):
+        user_dto = UserDTO.model_validate(u)
+        user_offset_ms = i * per_user_window_ms
+        for j in range(days_per_user):
+            day = (start + timedelta(days=j)).isoformat()
+            actor_user_wellness.send_with_options(
+                kwargs={"user": user_dto, "dt": day, "force": True},
+                delay=user_offset_ms + j * delay_per_day_ms,
+            )
+        print(f"  user_id={u.id} queued {days_per_user} days, " f"starts at +{user_offset_ms // 60_000} min")
 
 
 def _classify_noise(*, user_id: int | None, since_days: int, dry_run: bool) -> None:

--- a/data/db/activity.py
+++ b/data/db/activity.py
@@ -159,11 +159,16 @@ class Activity(Base):
         *,
         filters: tuple[ColumnElement, ...] = (),
         as_of: DateDTO | None = None,
+        days: int = 90,
         session: Session,
     ) -> list[Activity]:
-        """Return activities within a date window with extra SA filters."""
+        """Return activities within a date window with extra SA filters.
+
+        Default 90d window covers Banister ESS (τ=7, hears only the last ~14d) with
+        a wide safety margin. Callers needing reliable CTL/ATL EMAs (τ=42 / τ=7)
+        should pass `days=200` — see `data/metrics.py:calculate_sport_ctl`.
+        """
         ref = as_of or date.today()
-        days = 90
 
         cutoff = (ref - timedelta(days=days)).isoformat()
         newest = ref.isoformat()

--- a/data/db/wellness.py
+++ b/data/db/wellness.py
@@ -329,14 +329,20 @@ class Wellness(Base):
 
     @classmethod
     @with_sync_session
-    def update_sport_ctl(
+    def update_sport_load(
         cls,
         user_id: int,
         dt: DateDTO,
         sport_ctl: dict[str, float],
+        sport_atl: dict[str, float],
         *,
         session: Session,
     ) -> None:
+        """Merge per-sport CTL+ATL into wellness.sport_info JSON.
+
+        Preserves existing per-sport fields (eftp, wPrime, pMax from Intervals.icu);
+        only the ctl/atl keys are overwritten.
+        """
         date_str = dt.isoformat()
         result = session.execute(
             select(cls).where(
@@ -351,16 +357,27 @@ class Wellness(Base):
         existing_info = list(row.sport_info or [])  # copy to trigger SQLAlchemy change detection
         existing_types = {e["type"].lower(): i for i, e in enumerate(existing_info) if e.get("type")}
 
-        for canonical_sport, ctl_val in sport_ctl.items():
-            if ctl_val < 0:
+        for canonical_sport in ("swim", "ride", "run"):
+            ctl_val = sport_ctl.get(canonical_sport)
+            atl_val = sport_atl.get(canonical_sport)
+            ctl_ok = ctl_val is not None and ctl_val >= 0
+            atl_ok = atl_val is not None and atl_val >= 0
+            if not ctl_ok and not atl_ok:
                 continue
-            iv_type = _CANONICAL_TO_TYPE[canonical_sport]
 
+            iv_type = _CANONICAL_TO_TYPE[canonical_sport]
             iv_type_lower = iv_type.lower()
             if iv_type_lower in existing_types:
-                existing_info[existing_types[iv_type_lower]]["ctl"] = ctl_val
+                entry = existing_info[existing_types[iv_type_lower]]
             else:
-                existing_info.append({"type": iv_type, "ctl": ctl_val})
+                entry = {"type": iv_type}
+                existing_info.append(entry)
+                existing_types[iv_type_lower] = len(existing_info) - 1
+
+            if ctl_ok:
+                entry["ctl"] = ctl_val
+            if atl_ok:
+                entry["atl"] = atl_val
 
         row.sport_info = existing_info
         session.commit()

--- a/data/metrics.py
+++ b/data/metrics.py
@@ -310,67 +310,84 @@ def calculate_banister_for_date(
 # ---------------------------------------------------------------------------
 
 
-def calculate_sport_ctl(
+def _calculate_sport_load_ema(
     activities: list[Activity],
-    tau: int = 42,
+    tau: int,
+    as_of: date_type | None = None,
 ) -> dict[str, float]:
-    """Calculate per-sport CTL (Chronic Training Load) from activity history.
+    """Per-sport exponential moving average of daily TSS with constant `tau`.
 
-    Uses exponential moving average (EMA) with tau=42 days, matching Intervals.icu's
-    impulse-response model. Activities must span at least 42+ days for reliable values.
+    Shared core for `calculate_sport_ctl` (τ=42) and `calculate_sport_atl` (τ=7).
+    Iterates one date at a time so days without activities contribute zero load —
+    necessary for the EMA to decay correctly during rest periods.
 
-    Args:
-        activities: Objects with attrs: type (str|None), icu_training_load (float|None),
-                    start_date_local (str|date). Accepts Activity model or Activity ORM.
-        tau: Time constant in days (default 42, matching Intervals.icu CTL).
-
-    Returns:
-        {"swim": float, "ride": float, "run": float} — CTL per sport.
-        Returns 0.0 for sports with no activities.
+    `as_of` is the target evaluation date. The EMA runs from the first activity
+    up to and including `as_of`, so a rest gap between the last activity and
+    `as_of` still decays. Default `None` uses the last activity date (legacy
+    behavior — only safe when caller guarantees recent activity).
     """
     if not activities:
         return {"swim": 0.0, "ride": 0.0, "run": 0.0}
 
-    # Group daily load by sport (types are already canonical: Ride/Run/Swim/Other)
     daily_load: dict[str, dict[str, float]] = defaultdict(lambda: defaultdict(float))
     for act in activities:
         sport = (act.type or "").lower()
         if sport not in ("swim", "ride", "run"):
             continue
-
         if act.icu_training_load is None:
             continue
-
         daily_load[sport][str(act.start_date_local)] += act.icu_training_load
 
     if not daily_load:
         return {"swim": 0.0, "ride": 0.0, "run": 0.0}
 
-    # Find date range across all sports
-    all_dates = set()
+    all_dates: set[str] = set()
     for sport_dates in daily_load.values():
         all_dates.update(sport_dates.keys())
 
     min_date = date_type.fromisoformat(min(all_dates))
-    max_date = date_type.fromisoformat(max(all_dates))
+    last_activity_date = date_type.fromisoformat(max(all_dates))
+    end_date = as_of if as_of is not None else last_activity_date
+    if end_date < min_date:
+        end_date = min_date
 
-    # Calculate EMA for each sport day by day
-    k = 1.0 / tau  # rate constant
-    decay = math.exp(-k)
+    decay = math.exp(-1.0 / tau)
 
-    result = {}
+    result: dict[str, float] = {}
     for sport in ("swim", "ride", "run"):
-        ctl = 0.0
+        value = 0.0
         sport_loads = daily_load.get(sport, {})
         current = min_date
-        while current <= max_date:
-            ds = current.strftime("%Y-%m-%d")
-            tss = sport_loads.get(ds, 0.0)
-            ctl = ctl * decay + tss * (1 - decay)
+        while current <= end_date:
+            tss = sport_loads.get(current.strftime("%Y-%m-%d"), 0.0)
+            value = value * decay + tss * (1 - decay)
             current += timedelta(days=1)
-        result[sport] = round(ctl, 1)
+        result[sport] = round(value, 1)
 
     return result
+
+
+def calculate_sport_ctl(
+    activities: list[Activity],
+    tau: int = 42,
+    as_of: date_type | None = None,
+) -> dict[str, float]:
+    """Per-sport CTL (Chronic Training Load) — EMA with τ=42, matching Intervals.icu.
+
+    Caller must supply enough history for the EMA to warm up: at least ~3τ (126 days)
+    for <5% bias, ideally 5τ (210 days) for <1%. Pass `as_of` so the EMA decays
+    correctly through any rest gap between the last activity and the target date.
+    """
+    return _calculate_sport_load_ema(activities, tau, as_of=as_of)
+
+
+def calculate_sport_atl(
+    activities: list[Activity],
+    tau: int = 7,
+    as_of: date_type | None = None,
+) -> dict[str, float]:
+    """Per-sport ATL (Acute Training Load) — EMA with τ=7, matching Intervals.icu."""
+    return _calculate_sport_load_ema(activities, tau, as_of=as_of)
 
 
 # ---------------------------------------------------------------------------

--- a/data/utils.py
+++ b/data/utils.py
@@ -94,22 +94,34 @@ def extract_sport_ctl(sport_info: list[dict] | None) -> dict[str, float | None]:
     Works with both the original Intervals.icu format (type + eftp/wPrime/pMax)
     enriched with 'ctl' field by our pipeline, and any legacy formats.
     """
+    return _extract_sport_field(sport_info, "ctl", legacy_key="ctlLoad")
+
+
+def extract_sport_atl(sport_info: list[dict] | None) -> dict[str, float | None]:
+    """Extract per-sport ATL from sport_info JSON. Symmetric to extract_sport_ctl."""
+    return _extract_sport_field(sport_info, "atl", legacy_key="atlLoad")
+
+
+def _extract_sport_field(
+    sport_info: list[dict] | None,
+    key: str,
+    *,
+    legacy_key: str | None = None,
+) -> dict[str, float | None]:
     result: dict[str, float | None] = {"swim": None, "ride": None, "run": None}
-    if not sport_info:
-        return result
-    if not isinstance(sport_info, list):
+    if not sport_info or not isinstance(sport_info, list):
         return result
     for entry in sport_info:
         raw_type = (entry.get("type") or entry.get("sport") or "").lower()
         sport = SPORT_MAP.get(raw_type)
         if not sport:
             continue
-        ctl_val = entry.get("ctl")
-        if ctl_val is None:
-            ctl_val = entry.get("ctlLoad")
-        if ctl_val is None:
+        val = entry.get(key)
+        if val is None and legacy_key is not None:
+            val = entry.get(legacy_key)
+        if val is None:
             continue
-        result[sport] = round(float(ctl_val), 1)
+        result[sport] = round(float(val), 1)
     return result
 
 

--- a/data/workout_adapter.py
+++ b/data/workout_adapter.py
@@ -593,6 +593,14 @@ def humango_to_intervals_steps(
                     step_kind = sub.text.lower().replace("-", "")
                     if step_kind in ("cooldown", "cool down"):
                         break  # cooldown belongs to outer level
+                    # Two consecutive Rest blocks → the second one is the
+                    # rest between sets, not part of the repeat body. Leave
+                    # ``i`` pointing at it so the outer loop picks it up as
+                    # an outer-level step instead of multiplying it ``reps``
+                    # times inside the group. Case-insensitive — label
+                    # capitalization may drift in future variants.
+                    if step_kind == "rest" and sub_steps and (sub_steps[-1].text or "").lower() == "rest":
+                        break
                     sub_steps.append(sub)
                 i += 1
             if sub_steps:

--- a/docs/PER_SPORT_LOAD_SPEC.md
+++ b/docs/PER_SPORT_LOAD_SPEC.md
@@ -1,0 +1,153 @@
+# Per-Sport CTL/ATL + Plan-Aware Forecast — Spec
+
+> Status: **planned, not started**. Bookmark of the design discussion 2026-05-24.
+
+## Goal
+
+1. Per-sport CTL считать на расширенном окне (200 дней вместо 90) для устранения warm-up bias.
+2. Добавить per-sport **ATL** рядом с CTL (зеркально, τ=7).
+3. Нарисовать plan-aware forecast (CTL + ATL) на графике LoadDetail «By sport» — солидная линия в прошлом, dashed в будущем, тинт forecast-зоны.
+
+## Confirmed decisions (discussion 2026-05-24)
+
+| # | Choice | Rationale |
+|---|---|---|
+| 1 | Window 200 дней (5τ) | Bias <1% vs ~10-15% на текущих 90д |
+| 2 | Storage: `wellness.sport_info[].atl` JSON | Без миграции, симметрично существующему `.ctl` |
+| 3 | `Activity.get_windowed(days=90)` параметризовать с default 90 | Banister на 90 остаётся, only enrich-actor зовёт с 200 |
+| 4 | TSB per-sport НЕ рисуем | Шум на маленькой карточке |
+| 5 | Forecast — **plan-aware** (учитывает scheduled_workouts) | По дизайну `direction-b-halo.jsx::BLoadChart` |
+| 6 | Forecast горизонт — `max(scheduled_workouts.date)` (последний запланированный день) | Если плана нет на будущее — forecast не рисуем. Decay-tail после конца плана НЕ рисуем. |
+| 7 | Future TSS — `scheduled_workouts.icu_training_load` | Уже в DB |
+| 8 | Compute-on-read (НЕ persist) | Один consumer (LoadDetail chart). Persist потребовал бы хуки в 4+ триггера (CALENDAR_UPDATED, suggest_workout, save_workout, enrich-actor) — invalidation hell |
+| 9 | `fitness_projection` НЕ трогаем | Это зеркало Intervals (zero-load), наша per-sport проекция — plan-aware, другая семантика |
+| 10 | Горизонт **общий для всех спортов** = `max(scheduled_workouts.date)` глобально | Одна X-ось на 3 графика; спорт без планов после последнего своего workout'а decay'ит до общего горизонта |
+
+## Implementation plan
+
+### Step 1 — Backend: per-sport CTL + ATL расчёт
+
+- [data/db/activity.py:156](../data/db/activity.py:156) `get_windowed` — добавить параметр `days: int = 90`.
+- [data/metrics.py:313](../data/metrics.py:313):
+  - Extract `_calculate_sport_load_ema(activities, tau) -> dict[sport, float]`.
+  - Обёртки: `calculate_sport_ctl(activities, tau=42)`, `calculate_sport_atl(activities, tau=7)`.
+- [tasks/actors/common.py:30](../tasks/actors/common.py:30) `_actor_enrich_wellness_sport_info`:
+  - `Activity.get_windowed(..., days=200)`.
+  - Считаем `sport_ctl` и `sport_atl` параллельно из того же среза.
+  - Зовём новый `Wellness.update_sport_load(sport_ctl=, sport_atl=)`.
+- [data/db/wellness.py:298](../data/db/wellness.py:298) `update_sport_ctl` → переименовать в `update_sport_load(sport_ctl, sport_atl)`. JSON: `{"type": "Run", "ctl": X, "atl": Y, ...}`. Старое имя удалить (no shim).
+- [data/utils.py:88](../data/utils.py:88) — добавить параллельную `extract_sport_atl(sport_info)` (5 строк).
+
+### Step 1.5 — CLI backfill `recalc-sport-load`
+
+После того как Step 1 задеплоен, исторические `wellness.sport_info` всё ещё содержат старые CTL (90д окно) и не содержат ATL. Backfill применяет новый алгоритм на последние 200 дней для всех активных атлетов.
+
+**Имя:** `recalc-sport-load`
+**Файл:** [cli.py](../cli.py) — новый subparser + handler `_recalc_sport_load`.
+
+**Что делает:**
+1. `User.get_active_athletes()` — `is_active=True AND athlete_id IS NOT NULL`. С `--user-id` — один юзер.
+2. Для каждого атлета — итерация по последним `--days` (default 200) дням.
+3. Для каждого (user, day) → `actor_user_wellness.send_with_options(kwargs={user, dt, force=True})`.
+
+**Почему `actor_user_wellness(force=True)`, а не дёргать enrich напрямую:**
+- Inactive атлет может вообще не иметь wellness-row на день N. `actor_user_wellness` сначала зовёт Intervals API → создаёт row → потом дёргает pipeline (включая `_actor_enrich_wellness_sport_info`).
+- Если row есть, но не изменился — `force=True` всё равно прогоняет pipeline.
+- Один путь, один actor, никакой ветвистости.
+
+**CLI args:**
+- `--user-id` (int, optional, default: all active athletes).
+- `--days` (int, default: 200) — окно. Параметризовано, чтобы не править команду при будущих изменениях.
+- `--dry-run` — печатает план без диспатча.
+
+**Пейсинг:** sequential per user.
+- `delay_per_day_ms = 60_000` (3× больше чем у `_sync_wellness`'а 20s).
+- `user_i` начинается на `i * days * 60_000` ms (накопительный offset).
+- Wall time: `N × days × 60s` (для N=22, days=200 — ~73 часа ≈ 3 суток).
+- Почему 60s, а не 20s: actor_user_wellness каскадит HRV/RHR/Banister/recovery analyses с rolling 7/60d baselines — `OAUTH_BOOTSTRAP_SYNC_SPEC.md §17` предупреждает про cross-day race на этих окнах. 20s pacing мог не вмещать pipeline под API-ретраями. 60s — 3× запас. Code-review M2 от 2026-05-24.
+- Это one-shot миграция; гипероптимизация не нужна.
+
+**НЕ делаем в команде:**
+- Smart skip «не зовём API если row есть» — лишняя ветвь, экономия копеечная.
+- Параллельные юзеры — Sentry-шум при rate-limit, сложнее предсказать нагрузку.
+
+### Step 2 — API: добавить ATL (past) в `/api/training-load`
+
+- [api/routers/dashboard.py:72](../api/routers/dashboard.py:72) — `atl_swim/atl_ride/atl_run` параллельно `ctl_*`. Контракт аддитивный.
+
+### Step 3 — Frontend: CTL+ATL на per-sport графике
+
+- [webapp/src/api/types.ts:460](../webapp/src/api/types.ts:460) — добавить `atl_swim/atl_ride/atl_run`.
+- [webapp/src/pages/LoadDetail.tsx:287](../webapp/src/pages/LoadDetail.tsx:287) collapsible «By sport»:
+  - `LoadLineChart` принимает 2 линии (CTL+ATL).
+  - В правом счётчике: `{ctl} CTL · {atl} ATL`.
+  - `PerSportCtlCard` snapshot не трогаем (остаётся CTL-only).
+
+### Step 3.5 — Plan-aware forecast (compute-on-read)
+
+- [data/metrics.py](../data/metrics.py) — новая pure-функция:
+  ```python
+  def project_sport_load_forward(
+      today_ctl: float, today_atl: float,
+      daily_planned_load: dict[date, float],  # future TSS by date
+      horizon_dt: date,
+      today: date,
+  ) -> tuple[list[tuple[date, float]], list[tuple[date, float]]]:
+      """EMA forward с τ=42/7. Дни без workouts = zero load."""
+  ```
+- [api/routers/dashboard.py](../api/routers/dashboard.py) `/api/training-load`:
+  - SELECT `MAX(start_date_local) AS horizon FROM scheduled_workouts WHERE user_id=? AND start_date_local > today`.
+  - Если `horizon IS NULL` (нет будущих workouts) — return past-only (как сейчас).
+  - SELECT `scheduled_workouts` WHERE `start_date_local > today AND start_date_local <= horizon` для user, group by `(date, sport)`, sum `icu_training_load`.
+  - Для каждого спорта: `project_sport_load_forward(today_ctl[sport], today_atl[sport], planned[sport], horizon, today)`.
+  - Конкатенация past + future в `ctl_run/atl_run/...`. `dates` тоже расширены до horizon.
+  - В ответ добавить `today_date: str` (ISO). Фронт ищет индекс — клиент не зависит от порядка массива.
+  - Если `today_ctl[sport] is None` — future-часть для этого спорта остаётся `None` массивом.
+- [webapp/src/pages/LoadDetail.tsx](../webapp/src/pages/LoadDetail.tsx) `LoadLineChart`:
+  - Перенести из [design-package/endurai/direction-b-halo.jsx:4538](../design-package/endurai/direction-b-halo.jsx:4538) `BLoadChart`: split по `todayIdx`, dashed после today, forecast-band tint, today-rule.
+  - Тот же компонент используется и на overall (главная карточка), и на per-sport (By sport карточки).
+
+### Step 4 — Tests
+
+- `tests/metrics/test_project_sport_load_forward.py` — новый:
+  - Zero load → чистый decay.
+  - Constant load → steady-state.
+  - Граничные: today_ctl=None, пустой план, horizon=today.
+- `tests/api/test_dashboard.py` — расширенный кейс:
+  - С future scheduled_workouts массивы длиннее past.
+  - `today_date` корректно.
+  - Без активной цели forecast = пуст.
+  - `ctl_swim/ctl_ride/ctl_run` + новые `atl_*` keys присутствуют.
+- `tests/test_sport_normalization.py` — `extract_sport_atl` (legacy aliases, пустой sport_info).
+- `tests/tasks/test_actors.py` — actor зовёт `Wellness.update_sport_load(sport_ctl, sport_atl)`, `Activity.get_windowed(days=200)`.
+
+## What we explicitly DON'T do
+
+- `fitness_projection` не трогаем — это зеркало Intervals (zero-load), наша проекция другая (plan-aware).
+- TSB per-sport не рисуем.
+- Не кэшируем forecast в Redis (compute дешевле инвалидации).
+- Не вешаем хуки в CALENDAR_UPDATED / suggest_workout / save_workout — compute-on-read снимает необходимость.
+- Не выносим per-sport projection в отдельный MCP tool / morning report — нет потребителей, только UI chart.
+
+> Backfill для исторических wellness-rows **делаем** через Step 1.5 `recalc-sport-load` — естественная нормализация через activity-обновления медленная (≥200 дней до полной стабилизации для неактивных юзеров).
+
+## Open questions при возврате к работе
+
+- Стоит ли при отсутствии цели всё-таки рисовать zero-load decay-forecast на N дней вперёд? Сейчас договорились: «нет цели — нет forecast». Можно пересмотреть.
+- Если расход растёт за счёт плана с большим количеством будущих workouts — стоит ли пагинировать `scheduled_workouts` запрос? Сейчас не нужно (горизонт ≤ race_date обычно < 26 недель).
+
+## Key file references
+
+| File | Role |
+|---|---|
+| [tasks/actors/common.py:30](../tasks/actors/common.py:30) | `_actor_enrich_wellness_sport_info` — главный writer per-sport CTL |
+| [data/metrics.py:313](../data/metrics.py:313) | `calculate_sport_ctl` — текущая функция, рефакторится |
+| [data/db/wellness.py:298](../data/db/wellness.py:298) | `update_sport_ctl` — переименовывается в `update_sport_load` |
+| [data/db/activity.py:156](../data/db/activity.py:156) | `get_windowed` — добавляется параметр `days` |
+| [data/utils.py:88](../data/utils.py:88) | `extract_sport_ctl` — добавляется `extract_sport_atl` |
+| [api/routers/dashboard.py:72](../api/routers/dashboard.py:72) | `/api/training-load` — основной endpoint |
+| [webapp/src/pages/LoadDetail.tsx:287](../webapp/src/pages/LoadDetail.tsx:287) | «By sport» collapsible — UI consumer |
+| [design-package/endurai/direction-b-halo.jsx:4450](../design-package/endurai/direction-b-halo.jsx:4450) | `BLoadChart` — reference design для split actual/forecast |
+| [docs/INTERVALS_WEBHOOKS_RESEARCH.md:126](INTERVALS_WEBHOOKS_RESEARCH.md) | FITNESS_UPDATED payload — почему он не годится как trigger |
+| [cli.py](../cli.py) | новый `recalc-sport-load` subcommand (Step 1.5) |
+| [cli.py:233](../cli.py:233) | `_sync_wellness` — референс для пейсинга и пагинации `actor_user_wellness` |

--- a/tasks/actors/common.py
+++ b/tasks/actors/common.py
@@ -9,7 +9,7 @@ from pydantic import validate_call
 from sqlalchemy import select
 
 from data.db import Activity, AthleteSettings, AthleteThresholdsDTO, UserDTO, Wellness, get_sync_session
-from data.metrics import calculate_banister_for_date, calculate_sport_ctl
+from data.metrics import calculate_banister_for_date, calculate_sport_atl, calculate_sport_ctl
 from tasks.dto import DateDTO
 
 from .training_log import actor_fill_training_log, actor_fill_training_log_post
@@ -31,23 +31,40 @@ def _actor_enrich_wellness_sport_info(
     user: UserDTO,
     dt: DateDTO,
 ) -> None:
-    """Enrich wellness with per-sport CTL from DB (not API)."""
+    """Enrich wellness with per-sport CTL + ATL from DB (not API).
+
+    Uses a 200-day activity window so the CTL EMA (τ=42) and ATL EMA (τ=7) both
+    have ~5τ of warm-up — see `docs/PER_SPORT_LOAD_SPEC.md`.
+    """
 
     with get_sync_session() as session:
         activity_row: list[Activity] = Activity.get_windowed(
             user.id,
             filters=(Activity.icu_training_load.isnot(None),),
             as_of=dt,
+            days=200,
             session=session,
         )
 
-        sport_ctl: dict[str, float] = calculate_sport_ctl(activity_row)
-        logger.info("Sport CTL for user %d on %s: %s (%d activities)", user.id, dt, sport_ctl, len(activity_row))
+        # `as_of=dt` ensures the EMA decays through any rest gap between the
+        # last activity and `dt` — without it the value freezes at the last
+        # activity date and a 30-day rest leaves CTL at its pre-rest level.
+        sport_ctl: dict[str, float] = calculate_sport_ctl(activity_row, as_of=dt)
+        sport_atl: dict[str, float] = calculate_sport_atl(activity_row, as_of=dt)
+        logger.info(
+            "Sport load for user %d on %s: ctl=%s atl=%s (%d activities)",
+            user.id,
+            dt,
+            sport_ctl,
+            sport_atl,
+            len(activity_row),
+        )
 
-        Wellness.update_sport_ctl(
+        Wellness.update_sport_load(
             user_id=user.id,
             dt=dt,
             sport_ctl=sport_ctl,
+            sport_atl=sport_atl,
             session=session,
         )
 

--- a/tasks/actors/fitness.py
+++ b/tasks/actors/fitness.py
@@ -37,13 +37,14 @@ def actor_save_fitness_projection(user: UserDTO, records: list[dict]) -> None:
     sorted_records = sorted(valid_records, key=lambda r: r["id"])
     FitnessProjection.save_bulk(user_id=user.id, records=sorted_records)
 
-    today_iso = local_today().isoformat()
+    today = local_today()
+    today_iso = today.isoformat()
     today_record = next((r for r in sorted_records if r["id"] == today_iso), None)
     wellness_updated = False
     if today_record is not None:
         wellness_updated = Wellness.update_loads(
             user_id=user.id,
-            dt=today_iso,
+            dt=today,
             ctl=today_record.get("ctl"),
             atl=today_record.get("atl"),
             ramp_rate=today_record.get("rampRate"),

--- a/tests/bot/test_workout_adapter.py
+++ b/tests/bot/test_workout_adapter.py
@@ -661,3 +661,47 @@ class TestHumangoToIntervalsStepsRepeatGroup:
         ), f"expected no repeat groups (single-rep should flatten), got reps={[s.reps for s in steps]}"
         # Sequence: warmup, interval (flattened), recovery (flattened), cooldown
         assert [s.text for s in steps] == ["Warm-up", "Interval", "Recovery", "Cool-down"]
+
+    def test_inter_set_rest_not_swallowed_into_repeat(self):
+        """Regression: HumanGo swim sets often emit `interval + short rest +
+        long rest` inside a `repeat N times` block, where the long Rest is
+        actually the rest **between sets**, not part of the repeat body.
+        Pre-fix parser multiplied that long Rest by N, inflating duration.
+        Mirrors event 111913346 (user 1, 2026-05-24) which leaked ~9 min.
+        """
+        desc = (
+            "View on HumanGo: https://app.humango.ai/...\n\n"
+            "==============================\n\n"
+            "======= repeat 4 times =====\n\n"
+            "==============================\n\n"
+            "interval\n\ndistance: 200 meters\n\n"
+            "pace:\n\nlow: 2:00 per 100 meters\n\nhigh: 1:50 per 100 meters\n\n"
+            "==============================\n\n"
+            "rest\n\nduration: 0 min 15 sec\n\n"
+            "==============================\n\n"
+            "rest\n\nduration: 1 min 0 sec\n\n"
+            "==============================\n\n"
+            "======= repeat 4 times =====\n\n"
+            "==============================\n\n"
+            "interval\n\ndistance: 150 meters\n\n"
+            "pace:\n\nlow: 2:00 per 100 meters\n\nhigh: 1:50 per 100 meters\n\n"
+            "==============================\n\n"
+            "rest\n\nduration: 0 min 15 sec\n\n"
+            "==============================\n\n"
+            "rest\n\nduration: 1 min 0 sec\n\n"
+        )
+        steps = humango_to_intervals_steps(desc, "Swim", _thresholds(css=110.0))
+        assert steps
+
+        # Two repeat groups + two outer Rests between/after them.
+        repeats = [s for s in steps if s.reps == 4]
+        assert len(repeats) == 2, f"expected 2 repeat-4 groups, got {[s.reps for s in steps]}"
+        # Each repeat body holds Interval + short Rest only — the long Rest
+        # must NOT have been absorbed.
+        for rep in repeats:
+            assert [sub.text for sub in rep.steps] == ["Interval", "Rest"], rep.steps
+            assert rep.steps[1].duration == 15  # short rest stays inside
+
+        # The long Rest blocks live at the outer level (not multiplied by 4).
+        outer_long_rests = [s for s in steps if s.text == "Rest" and s.duration == 60]
+        assert len(outer_long_rests) == 2, [(s.text, s.duration) for s in steps]

--- a/tests/tasks/test_actors.py
+++ b/tests/tasks/test_actors.py
@@ -594,7 +594,7 @@ class TestActorUpdateHrvAnalysis:
 
 
 class TestActorEnrichWellnessSportInfo:
-    """_actor_enrich_wellness_sport_info calculates per-sport CTL and writes to wellness."""
+    """_actor_enrich_wellness_sport_info calculates per-sport CTL+ATL and writes to wellness."""
 
     def _make_activity(self, activity_type: str, load: float):
         act = MagicMock()
@@ -603,36 +603,41 @@ class TestActorEnrichWellnessSportInfo:
         act.start_date_local = _DT_STR
         return act
 
-    def test_no_activities_calls_update_with_empty_ctl(self):
-        """No activities → calculate_sport_ctl returns empty/zero dict → update_sport_ctl called."""
+    def test_no_activities_calls_update_with_zero_load(self):
+        """No activities → both CTL and ATL = zero dict → update_sport_load called."""
         from tasks.actors.common import _actor_enrich_wellness_sport_info
 
         mock_session = MagicMock()
         mock_session.__enter__ = MagicMock(return_value=mock_session)
         mock_session.__exit__ = MagicMock(return_value=False)
+        zeros = {"swim": 0.0, "ride": 0.0, "run": 0.0}
 
         with (
             patch("tasks.actors.common.get_sync_session", return_value=mock_session),
             patch("tasks.actors.common.Activity.get_windowed", return_value=[]) as mock_get,
-            patch("tasks.actors.common.calculate_sport_ctl", return_value={"swim": 0.0, "ride": 0.0, "run": 0.0}),
-            patch("tasks.actors.common.Wellness.update_sport_ctl") as mock_update,
+            patch("tasks.actors.common.calculate_sport_ctl", return_value=zeros),
+            patch("tasks.actors.common.calculate_sport_atl", return_value=zeros),
+            patch("tasks.actors.common.Wellness.update_sport_load") as mock_update,
         ):
             _actor_enrich_wellness_sport_info(_user().model_dump(), _DT)
 
         mock_get.assert_called_once()
         assert mock_get.call_args[0][0] == 1  # user_id positional
         assert mock_get.call_args[1]["as_of"] == _DT
+        assert mock_get.call_args[1]["days"] == 200  # CTL warm-up requires 200d
         mock_update.assert_called_once()
         assert mock_update.call_args[1]["user_id"] == 1
         assert mock_update.call_args[1]["dt"] == _DT
-        assert mock_update.call_args[1]["sport_ctl"] == {"swim": 0.0, "ride": 0.0, "run": 0.0}
+        assert mock_update.call_args[1]["sport_ctl"] == zeros
+        assert mock_update.call_args[1]["sport_atl"] == zeros
 
-    def test_activities_present_calculates_sport_ctl(self):
-        """Activities passed to calculate_sport_ctl and result forwarded to Wellness."""
+    def test_activities_present_calculates_both_loads(self):
+        """Activities forwarded to both calculate_sport_ctl and calculate_sport_atl."""
         from tasks.actors.common import _actor_enrich_wellness_sport_info
 
         activities = [self._make_activity("Run", 80.0), self._make_activity("Ride", 120.0)]
         expected_ctl = {"swim": 0.0, "ride": 10.5, "run": 6.3}
+        expected_atl = {"swim": 0.0, "ride": 18.2, "run": 11.7}
 
         mock_session = MagicMock()
         mock_session.__enter__ = MagicMock(return_value=mock_session)
@@ -642,19 +647,23 @@ class TestActorEnrichWellnessSportInfo:
             patch("tasks.actors.common.get_sync_session", return_value=mock_session),
             patch("tasks.actors.common.Activity.get_windowed", return_value=activities),
             patch("tasks.actors.common.calculate_sport_ctl", return_value=expected_ctl) as mock_ctl,
-            patch("tasks.actors.common.Wellness.update_sport_ctl") as mock_update,
+            patch("tasks.actors.common.calculate_sport_atl", return_value=expected_atl) as mock_atl,
+            patch("tasks.actors.common.Wellness.update_sport_load") as mock_update,
         ):
             _actor_enrich_wellness_sport_info(_user().model_dump(), _DT)
 
-        mock_ctl.assert_called_once_with(activities)
+        mock_ctl.assert_called_once_with(activities, as_of=_DT)
+        mock_atl.assert_called_once_with(activities, as_of=_DT)
         mock_update.assert_called_once()
         assert mock_update.call_args[1]["sport_ctl"] == expected_ctl
+        assert mock_update.call_args[1]["sport_atl"] == expected_atl
 
     def test_uses_user_id_from_dto(self):
-        """user_id passed to both Activity.get_windowed and Wellness.update_sport_ctl."""
+        """user_id passed to both Activity.get_windowed and Wellness.update_sport_load."""
         from tasks.actors.common import _actor_enrich_wellness_sport_info
 
         user = _user(id=7)
+        zeros = {"swim": 0.0, "ride": 0.0, "run": 0.0}
 
         mock_session = MagicMock()
         mock_session.__enter__ = MagicMock(return_value=mock_session)
@@ -663,8 +672,9 @@ class TestActorEnrichWellnessSportInfo:
         with (
             patch("tasks.actors.common.get_sync_session", return_value=mock_session),
             patch("tasks.actors.common.Activity.get_windowed", return_value=[]) as mock_get,
-            patch("tasks.actors.common.calculate_sport_ctl", return_value={}),
-            patch("tasks.actors.common.Wellness.update_sport_ctl") as mock_update,
+            patch("tasks.actors.common.calculate_sport_ctl", return_value=zeros),
+            patch("tasks.actors.common.calculate_sport_atl", return_value=zeros),
+            patch("tasks.actors.common.Wellness.update_sport_load") as mock_update,
         ):
             _actor_enrich_wellness_sport_info(user.model_dump(), _DT)
 

--- a/tests/tasks/test_fitness_actor.py
+++ b/tests/tasks/test_fitness_actor.py
@@ -67,7 +67,10 @@ class TestActorSaveFitnessProjection:
             assert [r["id"] for r in kwargs["records"]] == [_TODAY_ISO, "2026-05-21", "2026-09-15"]
 
     def test_updates_wellness_for_today_from_payload(self):
-        """Wellness.update_loads is called with today's record values — no API roundtrip."""
+        """Wellness.update_loads is called with today's record values — no API roundtrip.
+        ``dt`` must be a ``date`` (not a string) — the method calls ``dt.isoformat()``
+        and would AttributeError on a str (regression: caught in prod 2026-05-24).
+        """
         with (
             _patch_today(),
             patch("tasks.actors.fitness.FitnessProjection.save_bulk"),
@@ -76,13 +79,17 @@ class TestActorSaveFitnessProjection:
             actor_save_fitness_projection(user=_user(), records=_RECORDS)
             upd.assert_called_once_with(
                 user_id=42,
-                dt=_TODAY_ISO,
+                dt=_TODAY,
                 ctl=18.94,
                 atl=38.27,
                 ramp_rate=4.23,
                 ctl_load=41.0,
                 atl_load=44.0,
             )
+            # Type-contract guard: ``Wellness.update_loads`` invokes
+            # ``dt.isoformat()``; pass-through of a raw str would explode at
+            # runtime under @with_sync_session (no Pydantic coercion there).
+            assert hasattr(upd.call_args.kwargs["dt"], "isoformat")
 
     def test_no_wellness_update_when_today_absent(self):
         """If today isn't in records (edge case), skip the wellness update."""

--- a/tests/test_sport_load.py
+++ b/tests/test_sport_load.py
@@ -1,0 +1,151 @@
+"""Per-sport CTL/ATL EMA tests — data/metrics.py."""
+
+from datetime import date, timedelta
+from unittest.mock import MagicMock
+
+import pytest
+
+from data.metrics import calculate_sport_atl, calculate_sport_ctl
+
+
+def _act(sport: str, dt: date, load: float):
+    a = MagicMock()
+    a.type = sport
+    a.icu_training_load = load
+    a.start_date_local = dt.isoformat()
+    return a
+
+
+class TestCalculateSportCtl:
+    def test_empty_returns_zeros(self):
+        assert calculate_sport_ctl([]) == {"swim": 0.0, "ride": 0.0, "run": 0.0}
+
+    def test_unknown_sport_ignored(self):
+        result = calculate_sport_ctl([_act("Yoga", date(2026, 1, 1), 50.0)])
+        assert result == {"swim": 0.0, "ride": 0.0, "run": 0.0}
+
+    def test_none_load_skipped(self):
+        result = calculate_sport_ctl([_act("Run", date(2026, 1, 1), None)])
+        assert result == {"swim": 0.0, "ride": 0.0, "run": 0.0}
+
+    def test_constant_daily_load_approaches_load(self):
+        """EMA with constant input X converges to X. 5τ ≈ 99.3% of steady state."""
+        start = date(2026, 1, 1)
+        acts = [_act("Run", start + timedelta(days=i), 50.0) for i in range(210)]
+        result = calculate_sport_ctl(acts)
+        # 5τ → steady-state error <1%. CTL should be very close to daily load.
+        assert 49.0 <= result["run"] <= 50.0
+        assert result["ride"] == 0.0
+        assert result["swim"] == 0.0
+
+    def test_lowercase_sport_normalized(self):
+        """Activity.type stored as canonical Title case; matcher lowers it."""
+        acts = [_act("Run", date(2026, 1, 1), 50.0)]
+        result = calculate_sport_ctl(acts)
+        assert result["run"] > 0
+
+
+class TestCalculateSportAtl:
+    def test_empty_returns_zeros(self):
+        assert calculate_sport_atl([]) == {"swim": 0.0, "ride": 0.0, "run": 0.0}
+
+    def test_atl_reacts_faster_than_ctl(self):
+        """τ_ATL=7 vs τ_CTL=42: after a short load burst ATL should be ≫ CTL."""
+        # 7 consecutive days of TSS=100, evaluated on day 7.
+        start = date(2026, 1, 1)
+        acts = [_act("Run", start + timedelta(days=i), 100.0) for i in range(7)]
+
+        ctl = calculate_sport_ctl(acts)["run"]
+        atl = calculate_sport_atl(acts)["run"]
+
+        # After 7 days at constant 100 TSS: ATL ≈ 1τ → ~63 of steady-state (100).
+        # CTL ≈ 7/42 τ → far from steady-state.
+        assert atl > ctl * 3, f"expected atl ≫ ctl (atl={atl}, ctl={ctl})"
+
+    def test_constant_load_approaches_value(self):
+        """5τ_ATL = 35 days. After 35 days at constant load, ATL ≈ steady-state."""
+        start = date(2026, 1, 1)
+        acts = [_act("Ride", start + timedelta(days=i), 80.0) for i in range(35)]
+        atl = calculate_sport_atl(acts)["ride"]
+        assert 78.0 <= atl <= 80.0
+
+    def test_per_sport_independent(self):
+        """ATL for one sport doesn't bleed into another's value."""
+        start = date(2026, 1, 1)
+        acts = [_act("Run", start + timedelta(days=i), 60.0) for i in range(30)]
+        result = calculate_sport_atl(acts)
+        assert result["run"] > 0
+        assert result["ride"] == 0.0
+        assert result["swim"] == 0.0
+
+
+class TestAsOfDecay:
+    """Regression: without `as_of`, EMA stops at last activity date — rest gaps
+    leave the value frozen instead of decaying. See code-review M1 (2026-05-24)."""
+
+    def test_rest_gap_after_training_decays_ctl(self):
+        """100 days at TSS=50, then 30 days rest → CTL should halve under τ=42."""
+        start = date(2026, 1, 1)
+        acts = [_act("Run", start + timedelta(days=i), 50.0) for i in range(100)]
+        last_train_day = start + timedelta(days=99)
+
+        ctl_at_last_train = calculate_sport_ctl(acts, as_of=last_train_day)["run"]
+        ctl_30d_later = calculate_sport_ctl(acts, as_of=last_train_day + timedelta(days=30))["run"]
+
+        # e^(-30/42) ≈ 0.490 → CTL should drop ~51%
+        import math
+
+        expected = ctl_at_last_train * math.exp(-30 / 42)
+        assert ctl_30d_later == pytest.approx(expected, abs=0.5)
+
+    def test_as_of_before_first_activity_clamps_to_zero(self):
+        """Defensive: as_of before any activity → loop should still run min..min."""
+        start = date(2026, 1, 1)
+        acts = [_act("Run", start, 50.0)]
+        # as_of way before first activity — clamps to min_date (one EMA step).
+        result = calculate_sport_ctl(acts, as_of=date(2025, 1, 1))["run"]
+        assert result > 0
+
+    def test_as_of_none_preserves_legacy_behavior(self):
+        """No as_of → iterate to last activity date (legacy)."""
+        start = date(2026, 1, 1)
+        acts = [_act("Run", start + timedelta(days=i), 50.0) for i in range(50)]
+        with_explicit = calculate_sport_ctl(acts, as_of=start + timedelta(days=49))["run"]
+        legacy = calculate_sport_ctl(acts)["run"]
+        assert with_explicit == legacy
+
+    def test_atl_decays_faster_than_ctl_through_gap(self):
+        """ATL (τ=7) collapses much faster than CTL (τ=42) over a rest gap."""
+        start = date(2026, 1, 1)
+        acts = [_act("Run", start + timedelta(days=i), 80.0) for i in range(60)]
+        target = start + timedelta(days=89)  # 30-day rest after day 59
+
+        ctl = calculate_sport_ctl(acts, as_of=target)["run"]
+        atl = calculate_sport_atl(acts, as_of=target)["run"]
+        assert atl < ctl, f"ATL ({atl}) should decay below CTL ({ctl}) after long rest"
+        assert atl < 5.0, f"ATL after 30d rest should be near zero, got {atl}"
+
+
+class TestSharedCore:
+    """Both wrappers share `_calculate_sport_load_ema` — these tests verify the
+    contract holds identically for both."""
+
+    @pytest.mark.parametrize("fn", [calculate_sport_ctl, calculate_sport_atl])
+    def test_multi_sport_independent_accumulation(self, fn):
+        start = date(2026, 1, 1)
+        acts = (
+            [_act("Run", start + timedelta(days=i), 40.0) for i in range(60)]
+            + [_act("Ride", start + timedelta(days=i), 80.0) for i in range(60)]
+            + [_act("Swim", start + timedelta(days=i), 20.0) for i in range(60)]
+        )
+        result = fn(acts)
+        # Ride should be highest, Swim lowest — order preserved.
+        assert result["ride"] > result["run"] > result["swim"] > 0
+
+    @pytest.mark.parametrize("fn", [calculate_sport_ctl, calculate_sport_atl])
+    def test_multiple_activities_same_day_summed(self, fn):
+        """Two activities on the same day → loads summed before EMA step."""
+        dt = date(2026, 1, 1)
+        single = fn([_act("Run", dt, 100.0)])
+        double = fn([_act("Run", dt, 50.0), _act("Run", dt, 50.0)])
+        assert single["run"] == double["run"]

--- a/tests/test_sport_normalization.py
+++ b/tests/test_sport_normalization.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from data.utils import HRV_ELIGIBLE_TYPES, extract_sport_ctl, is_bike, is_run, normalize_sport
+from data.utils import HRV_ELIGIBLE_TYPES, extract_sport_atl, extract_sport_ctl, is_bike, is_run, normalize_sport
 
 
 class TestNormalizeSport:
@@ -78,6 +78,35 @@ class TestExtractSportCtl:
     def test_empty(self):
         assert extract_sport_ctl(None) == {"swim": None, "ride": None, "run": None}
         assert extract_sport_ctl([]) == {"swim": None, "ride": None, "run": None}
+
+    def test_legacy_ctl_load_key(self):
+        """Older Intervals.icu payloads used 'ctlLoad' — extractor falls back."""
+        result = extract_sport_ctl([{"type": "Run", "ctlLoad": 18.7}])
+        assert result["run"] == 18.7
+
+
+class TestExtractSportAtl:
+    def test_all_sports(self):
+        sport_info = [
+            {"type": "Swim", "atl": 5.0, "ctl": 10.0},
+            {"type": "Ride", "atl": 28.0, "ctl": 30.0},
+            {"type": "Run", "atl": 22.0, "ctl": 20.0},
+        ]
+        result = extract_sport_atl(sport_info)
+        assert result == {"swim": 5.0, "ride": 28.0, "run": 22.0}
+
+    def test_empty(self):
+        assert extract_sport_atl(None) == {"swim": None, "ride": None, "run": None}
+        assert extract_sport_atl([]) == {"swim": None, "ride": None, "run": None}
+
+    def test_legacy_atl_load_key(self):
+        result = extract_sport_atl([{"type": "Ride", "atlLoad": 33.1}])
+        assert result["ride"] == 33.1
+
+    def test_atl_independent_from_ctl(self):
+        """Entry with only ctl set → atl extraction returns None for that sport."""
+        sport_info = [{"type": "Run", "ctl": 20.0}]
+        assert extract_sport_atl(sport_info) == {"swim": None, "ride": None, "run": None}
 
 
 class TestDTONormalization:


### PR DESCRIPTION
This update introduces a backfill for per-sport Chronic Training Load (CTL) and Acute Training Load (ATL) across user data spanning the last 200 days. It provides a new CLI command `recalc-sport-load` to process this asynchronously, optimizing data accuracy by recalculating using extended windows. This is instrumental for improving decay accuracy in load analytics during inactive periods.

Key changes:
- CLI extension to execute `recalc-sport-load`, supporting optional user ID and days parameterization, with a dry-run capability for previewing operations.
- Refined computation of CTL and ATL using a 200-day window to minimize warm-up bias, leveraging an enhanced exponential moving average method.
- Updates to JSON schema for wellness data to accommodate both CTL and ATL values, preserving existing fields and enhancing accuracy.

These modifications aim to provide a comprehensive and retrospective recalculation mechanism, ensuring historical data reflects recent algorithm enhancements, crucial for more accurate forecasting and data-driven decision making.