### PR TITLE
Adds weekly ramp projection for training load

### DIFF
--- a/api/routers/wellness.py
+++ b/api/routers/wellness.py
@@ -9,7 +9,7 @@ from api.deps import get_data_user_id, require_viewer
 from bot.formatter import STATUS_EMOJI
 from config import settings
 from data.db import HrvAnalysis, RhrAnalysis, User, Wellness, get_session
-from data.metrics import recompute_today_loads
+from data.metrics import recompute_today_loads, recompute_today_ramp
 from data.utils import extract_sport_ctl
 
 router = APIRouter()
@@ -428,9 +428,9 @@ async def wellness_day(
         }
 
     result = await _build_wellness_response(row, target, uid, language=user.language or "ru")
-    # Intervals.icu bakes today's planned workouts into ctl/atl, so the
+    # Intervals.icu bakes today's planned workouts into ctl/atl/rampRate, so the
     # morning view looks as if the day's session is already done. Recompute
-    # from yesterday's loads + actually-completed activities.
+    # from yesterday's loads + actually-completed activities; de-plan ramp to match.
     if target == today:
         recomputed = await recompute_today_loads(uid)
         if recomputed is not None:
@@ -438,6 +438,9 @@ async def wellness_day(
             result["training_load"]["ctl"] = ctl
             result["training_load"]["atl"] = atl
             result["training_load"]["tsb"] = tsb
+            projected_ramp = await recompute_today_ramp(uid, ctl)
+            if projected_ramp is not None:
+                result["training_load"]["ramp_rate"] = projected_ramp
     result["is_today"] = target == today
     result["has_prev"] = has_prev
     result["has_next"] = has_next

--- a/data/metrics.py
+++ b/data/metrics.py
@@ -558,6 +558,28 @@ async def recompute_today_loads(user_id: int) -> tuple[float, float, float] | No
     return _project_loads_one_day(prev.ctl, prev.atl, tss_today)
 
 
+async def recompute_today_ramp(user_id: int, ctl_today: float) -> float | None:
+    """Projected weekly ramp consistent with the de-planned today CTL.
+
+    Intervals.icu's ``rampRate`` is the 7-day CTL change (``CTL_today − CTL_7d_ago``,
+    verified empirically), so the value it ships for today carries the same
+    planned-workout inflation that `recompute_today_loads` strips out of CTL/ATL.
+    Recompute it against the projected CTL so ramp stays consistent with the
+    de-planned CTL/ATL/TSB shown next to it.
+
+    `ctl_today` is the projected (de-planned) CTL from `recompute_today_loads`.
+    Returns None if the 7-day-ago wellness row is missing — caller should fall
+    back to the raw `ramp_rate` Intervals.icu reported.
+    """
+    week_ago = local_today() - timedelta(days=7)
+    prev = await Wellness.get(user_id, week_ago)
+    if prev is None or prev.ctl is None:
+        return None
+    # 1 dp to match the de-planned CTL/ATL/TSB it sits beside — ramp is derived
+    # from the 1-dp projected CTL, so extra precision would be spurious.
+    return round(ctl_today - prev.ctl, 1)
+
+
 def project_sport_load_forward(
     today_ctl: float,
     today_atl: float,

--- a/mcp_server/tools/goal.py
+++ b/mcp_server/tools/goal.py
@@ -12,9 +12,11 @@ from mcp_server.context import get_current_user_id
 
 
 def _pct(current: float | None, target: float | None) -> float | None:
+    # Integer rounding matches the webapp gauge (api/routers/dashboard.py) so
+    # the number Claude quotes in chat lines up with what the athlete sees.
     if current is None or not target or target <= 0:
         return None
-    return round(current / target * 100, 1)
+    return round(current / target * 100)
 
 
 @mcp.tool()

--- a/mcp_server/tools/progress.py
+++ b/mcp_server/tools/progress.py
@@ -248,6 +248,164 @@ async def compute_efficiency_trend(
     return response
 
 
+# Loosened "similar session" match for the per-activity comparison block.
+# Coverage over precision: the strict same-bucket + dominant-zone + TSB match
+# left long/notable sessions at pool 0-1 (validated on real data 2026-06-03).
+# ±30% duration + ±12 IF, no zone/TSB filter, 120d lifts routine sessions to
+# pool 5-14 while keeping "similar" honest. Genuinely unique long efforts stay
+# below _CMP_MIN_POOL and render an empty state rather than a 1-sample "norm".
+_CMP_WINDOW_DAYS = 120
+_CMP_DUR_TOL = 0.30
+_CMP_IF_TOL = 12.0
+_CMP_MIN_POOL = 3
+
+
+def _cmp_marker(
+    key: str,
+    value: float,
+    norm: float,
+    pool_n: int,
+    *,
+    lower_is_better: bool | None,
+    status: str | None = None,
+) -> dict:
+    """One "this vs norm" row. `band` colours the delta; `lower_is_better=None`
+    means the marker is neutral (avg HR, VI) — show the delta without a verdict."""
+    delta = value - norm
+    band = "neutral"
+    if lower_is_better is not None and norm:
+        if abs(delta) / abs(norm) < 0.05:
+            band = "neutral"
+        else:
+            worse = (delta > 0) if lower_is_better else (delta < 0)
+            band = "worse" if worse else "better"
+    marker = {
+        "key": key,
+        "value": round(value, 3),
+        "norm_median": round(norm, 3),
+        "pool_n": pool_n,
+        "delta": round(delta, 3),
+        "band": band,
+    }
+    if status is not None:
+        marker["status"] = status
+    return marker
+
+
+async def compute_activity_comparison(user_id: int, activity, detail) -> dict:
+    """Deterministic "this session vs your norm" markers for the activity page.
+
+    No Claude, no migration — pure aggregation over existing `activity_details`.
+    Pool = same sport, non-race, duration ±30%, IF ±12, last 120d (see
+    `_CMP_*`). Decoupling median is taken over valid-for-decoupling pool members
+    only (short/high-VI sessions would poison it). Returns
+    `{available, pool_n, markers}`; `available=False` with a `reason` when the
+    sport is unsupported or the pool is too thin to be a meaningful norm.
+    """
+    sport = _sport_group(activity.type)
+    ref_if = detail.intensity_factor if detail else None
+    ref_dur = activity.moving_time
+    if sport not in ("bike", "run") or detail is None or ref_if is None or not ref_dur:
+        return {"available": False, "pool_n": 0, "reason": "unsupported"}
+
+    since = date.today() - timedelta(days=_CMP_WINDOW_DAYS)
+    activities, _ = await Activity.get_range(user_id, since, date.today())
+
+    dur_lo, dur_hi = ref_dur * (1 - _CMP_DUR_TOL), ref_dur * (1 + _CMP_DUR_TOL)
+    candidates = [
+        a
+        for a in activities
+        if a.id != activity.id
+        and not a.is_race
+        and _sport_group(a.type) == sport
+        and a.moving_time
+        and dur_lo <= a.moving_time <= dur_hi
+    ]
+    if not candidates:
+        return {"available": False, "pool_n": 0, "reason": "no_similar"}
+
+    detail_map = await ActivityDetail.get_bulk([a.id for a in candidates])
+    pool: list[tuple] = []
+    for a in candidates:
+        d = detail_map.get(a.id)
+        if d is None or d.intensity_factor is None:
+            continue
+        if abs(d.intensity_factor - ref_if) <= _CMP_IF_TOL:
+            pool.append((a, d))
+
+    if len(pool) < _CMP_MIN_POOL:
+        return {"available": False, "pool_n": len(pool), "reason": "thin_pool"}
+
+    markers: list[dict] = []
+
+    # Decoupling — lower is better, median over valid-for-decoupling pool only.
+    ref_dec_valid = is_valid_for_decoupling(
+        activity_type=activity.type,
+        moving_time=ref_dur,
+        variability_index=detail.variability_index,
+        hr_zone_times=detail.hr_zone_times,
+        decoupling=detail.decoupling,
+    )
+    valid_dec = [
+        d.decoupling
+        for a, d in pool
+        if d.decoupling is not None
+        and is_valid_for_decoupling(
+            activity_type=a.type,
+            moving_time=a.moving_time,
+            variability_index=d.variability_index,
+            hr_zone_times=d.hr_zone_times,
+            decoupling=d.decoupling,
+        )
+    ]
+    if ref_dec_valid and detail.decoupling is not None and len(valid_dec) >= _CMP_MIN_POOL:
+        markers.append(
+            _cmp_marker(
+                "decoupling",
+                detail.decoupling,
+                median(valid_dec),
+                len(valid_dec),
+                lower_is_better=True,
+                status=decoupling_status(detail.decoupling),
+            )
+        )
+
+    # Efficiency factor — higher is better.
+    ef_vals = [d.efficiency_factor for _, d in pool if d.efficiency_factor and d.efficiency_factor > 0]
+    if detail.efficiency_factor and detail.efficiency_factor > 0 and len(ef_vals) >= _CMP_MIN_POOL:
+        markers.append(
+            _cmp_marker("ef", detail.efficiency_factor, median(ef_vals), len(ef_vals), lower_is_better=False)
+        )
+
+    # Pace (run, m/s — higher=faster) / Normalized power (bike) — higher is better.
+    if sport == "run":
+        pace_vals = [d.pace for _, d in pool if d.pace and d.pace > 0]
+        if detail.pace and detail.pace > 0 and len(pace_vals) >= _CMP_MIN_POOL:
+            markers.append(_cmp_marker("pace", detail.pace, median(pace_vals), len(pace_vals), lower_is_better=False))
+    else:
+        np_vals = [d.normalized_power for _, d in pool if d.normalized_power]
+        if detail.normalized_power and len(np_vals) >= _CMP_MIN_POOL:
+            markers.append(
+                _cmp_marker("np", detail.normalized_power, median(np_vals), len(np_vals), lower_is_better=False)
+            )
+
+    # Average HR — neutral context (lower at same pace is good, but only paired
+    # with EF; on its own it's just "where today sat").
+    hr_vals = [a.average_hr for a, _ in pool if a.average_hr]
+    if activity.average_hr and len(hr_vals) >= _CMP_MIN_POOL:
+        markers.append(_cmp_marker("avg_hr", activity.average_hr, median(hr_vals), len(hr_vals), lower_is_better=None))
+
+    # Variability index — neutral (closer to 1.0 = steadier, but not "better").
+    vi_vals = [d.variability_index for _, d in pool if d.variability_index]
+    if detail.variability_index and len(vi_vals) >= _CMP_MIN_POOL:
+        markers.append(_cmp_marker("vi", detail.variability_index, median(vi_vals), len(vi_vals), lower_is_better=None))
+
+    if not markers:
+        return {"available": False, "pool_n": len(pool), "reason": "no_markers"}
+
+    return {"available": True, "pool_n": len(pool), "markers": markers}
+
+
 def _group_weekly(entries: list[dict], sport: str) -> list[dict]:
     """Group activity entries by ISO week."""
     weeks: dict[str, list[dict]] = defaultdict(list)

--- a/mcp_server/tools/training_load.py
+++ b/mcp_server/tools/training_load.py
@@ -3,7 +3,7 @@
 from sqlalchemy import select
 
 from data.db import Wellness, get_session
-from data.metrics import recompute_today_loads
+from data.metrics import recompute_today_loads, recompute_today_ramp
 from data.utils import extract_sport_ctl
 from data.utils import tsb_zone as _tsb_zone
 from mcp_server.app import mcp
@@ -23,13 +23,18 @@ async def get_training_load(date: str) -> dict:
         return {"error": f"No data for {date}"}
 
     ctl, atl = row.ctl, row.atl
-    # Intervals.icu bakes today's planned workouts into ctl/atl, so morning
-    # reads look as if today's session is already done. Recompute from
-    # yesterday + actually-completed activities. sport_ctl/ramp_rate untouched.
+    ramp_rate = row.ramp_rate
+    # Intervals.icu bakes today's planned workouts into ctl/atl/rampRate, so
+    # morning reads look as if today's session is already done. Recompute from
+    # yesterday + actually-completed activities; de-plan ramp to match. sport_ctl
+    # untouched.
     if date == local_today().isoformat():
         recomputed = await recompute_today_loads(user_id)
         if recomputed is not None:
             ctl, atl, _ = recomputed
+            projected_ramp = await recompute_today_ramp(user_id, ctl)
+            if projected_ramp is not None:
+                ramp_rate = projected_ramp
 
     tsb = round(ctl - atl, 1) if ctl is not None and atl is not None else None
     sport_ctl = extract_sport_ctl(row.sport_info)
@@ -39,10 +44,10 @@ async def get_training_load(date: str) -> dict:
         "ctl": ctl,
         "atl": atl,
         "tsb": tsb,
-        "ramp_rate": row.ramp_rate,
+        "ramp_rate": ramp_rate,
         "sport_ctl": sport_ctl,
         "interpretation": {
             "tsb_zone": _tsb_zone(tsb),
-            "ramp_safe": row.ramp_rate <= 7 if row.ramp_rate else None,
+            "ramp_safe": ramp_rate <= 7 if ramp_rate is not None else None,
         },
     }

--- a/mcp_server/tools/wellness.py
+++ b/mcp_server/tools/wellness.py
@@ -3,7 +3,7 @@
 from sqlalchemy import select
 
 from data.db import Wellness, get_session
-from data.metrics import recompute_today_loads
+from data.metrics import recompute_today_loads, recompute_today_ramp
 from mcp_server.app import mcp
 from mcp_server.context import get_current_user_id
 from tasks.dto import local_today
@@ -38,11 +38,12 @@ def _row_to_dict(row: Wellness) -> dict:
 
 
 async def _apply_today_loads_override(user_id: int, record: dict) -> None:
-    """Replace `ctl`/`atl` in a wellness dict with the actual-only recompute.
+    """Replace `ctl`/`atl`/`ramp_rate` in a wellness dict with the actual-only recompute.
 
-    Intervals.icu bakes today's planned workouts into ctl/atl, so morning-time
-    reads look as if today's session is already done. Mutates `record` in
-    place. No-op if yesterday's wellness row is missing.
+    Intervals.icu bakes today's planned workouts into ctl/atl/rampRate, so
+    morning-time reads look as if today's session is already done. Mutates
+    `record` in place; de-plans ramp to stay consistent with ctl/atl. No-op if
+    yesterday's wellness row is missing.
     """
     recomputed = await recompute_today_loads(user_id)
     if recomputed is None:
@@ -50,6 +51,9 @@ async def _apply_today_loads_override(user_id: int, record: dict) -> None:
     ctl, atl, _ = recomputed
     record["ctl"] = ctl
     record["atl"] = atl
+    projected_ramp = await recompute_today_ramp(user_id, ctl)
+    if projected_ramp is not None:
+        record["ramp_rate"] = projected_ramp
 
 
 @mcp.tool()

--- a/tests/test_sport_load.py
+++ b/tests/test_sport_load.py
@@ -417,3 +417,71 @@ class TestRecomputeTodayLoads:
 
         result = await metrics.recompute_today_loads(1)
         assert result == metrics._project_loads_one_day(50.0, 50.0, 0.0)
+
+
+# ---------------------------------------------------------------------------
+# DB-integration: recompute_today_ramp
+# ---------------------------------------------------------------------------
+
+
+_WEEK_AGO = _TODAY - timedelta(days=7)
+
+
+async def _seed_wellness_at(user_id: int, dt: date, *, ctl: float | None) -> None:
+    """Plant a wellness row at an arbitrary date with just CTL — the 7-day-ago
+    baseline `recompute_today_ramp` reads."""
+    from datetime import datetime, timezone
+
+    from data.db import Wellness, get_session
+
+    async with get_session() as s:
+        s.add(Wellness(user_id=user_id, date=dt.isoformat(), ctl=ctl, updated=datetime.now(timezone.utc)))
+        await s.commit()
+
+
+class TestRecomputeTodayRamp:
+    """DB-integration: `recompute_today_ramp` returns projected weekly ramp as
+    de-planned-today-CTL minus the (settled) CTL from 7 days ago, matching how
+    Intervals.icu defines rampRate. Keeps ramp consistent with the de-planned
+    CTL/ATL/TSB shown beside it on the today screen."""
+
+    async def test_returns_none_when_no_week_ago_row(self, monkeypatch):
+        from data import metrics
+
+        monkeypatch.setattr(metrics, "local_today", lambda: _TODAY)
+        assert await metrics.recompute_today_ramp(1, ctl_today=55.0) is None
+
+    async def test_returns_none_when_week_ago_has_no_ctl(self, monkeypatch):
+        from data import metrics
+
+        await _seed_wellness_at(1, _WEEK_AGO, ctl=None)
+        monkeypatch.setattr(metrics, "local_today", lambda: _TODAY)
+        assert await metrics.recompute_today_ramp(1, ctl_today=55.0) is None
+
+    async def test_positive_ramp(self, monkeypatch):
+        """Fitness climbing across the week → positive ramp."""
+        from data import metrics
+
+        await _seed_wellness_at(1, _WEEK_AGO, ctl=50.0)
+        monkeypatch.setattr(metrics, "local_today", lambda: _TODAY)
+        assert await metrics.recompute_today_ramp(1, ctl_today=55.5) == pytest.approx(5.5)
+
+    async def test_negative_ramp_on_detraining(self, monkeypatch):
+        """Detraining week → negative ramp, must not clamp to zero."""
+        from data import metrics
+
+        await _seed_wellness_at(1, _WEEK_AGO, ctl=60.0)
+        monkeypatch.setattr(metrics, "local_today", lambda: _TODAY)
+        assert await metrics.recompute_today_ramp(1, ctl_today=56.2) == pytest.approx(-3.8)
+
+    async def test_week_ago_scoped_per_user(self, monkeypatch):
+        """Another user's week-ago row must not leak into this user's ramp."""
+        from data import metrics
+        from data.db import User, get_session
+
+        async with get_session() as s:
+            s.add(User(id=2, chat_id="other_user", role="user"))
+            await s.commit()
+        await _seed_wellness_at(2, _WEEK_AGO, ctl=10.0)
+        monkeypatch.setattr(metrics, "local_today", lambda: _TODAY)
+        assert await metrics.recompute_today_ramp(1, ctl_today=55.0) is None

--- a/webapp/src/i18n/en.json
+++ b/webapp/src/i18n/en.json
@@ -63,7 +63,7 @@
     "optimal": "Optimal",
     "race_a": "Race A",
     "weeks_out": "{{count}} weeks out",
-    "to_target": "to target",
+    "to_target": "of CTL target",
     "fitness_ctl": "Fitness (CTL)",
     "ctl_needed": "+{{delta}} needed · {{weeks}} weeks",
     "taper": "taper",

--- a/webapp/src/i18n/ru.json
+++ b/webapp/src/i18n/ru.json
@@ -63,7 +63,7 @@
     "optimal": "Оптимум",
     "race_a": "Гонка A",
     "weeks_out": "через {{count}} нед.",
-    "to_target": "до цели",
+    "to_target": "от цели CTL",
     "fitness_ctl": "Форма (CTL)",
     "ctl_needed": "+{{delta}} нужно · {{weeks}} нед.",
     "taper": "тейпер",


### PR DESCRIPTION
This update introduces a calculation for weekly ramp projection, adjusting the estimation for CTL and ATL to exclude planned workouts inflation. It ensures consistency in training load metrics displayed to users today by reconciling projected changes. This enhancement notably improves feedback accuracy by dynamically calculating ramp rate adjustments for fitness analysis, taking into account completed activities rather than planned ones.

Enhancements include:
- Modification of the existing training load calculation to incorporate weekly ramp rates.
- Introduction of a new function to compute projected ramp rates aligning with de-planned CTL/ATL.
- Adjustments in wellness views and metrics module, and sync with current user data.
- Test coverage is expanded to verify ramp rate calculations, ensuring the integrity of the feature behavior under various scenarios.