### PR TITLE
Add measured thresholds API for athlete profiles

### DIFF
--- a/api/routers/athlete.py
+++ b/api/routers/athlete.py
@@ -17,7 +17,8 @@ from fastapi import APIRouter, Depends, HTTPException
 
 from api.deps import get_data_user_id, require_athlete, require_viewer
 from api.dto import AthleteGoalPatchRequest, AthleteProfilePatchRequest
-from data.db import AthleteGoal, User
+from data.db import ActivityHrv, AthleteGoal, User
+from data.db.dto import MeasuredThresholdsDTO
 from tasks.dto import local_today
 
 logger = logging.getLogger(__name__)
@@ -53,6 +54,26 @@ async def list_athlete_goals(
             for g in goals
         ],
     }
+
+
+@router.get("/api/athlete/measured-thresholds")
+async def get_measured_thresholds(
+    user: User = Depends(require_viewer),
+) -> MeasuredThresholdsDTO:
+    """Our DFA-α1 ramp-test thresholds (HRVT2 per sport).
+
+    Distinct from the Intervals.icu-synced values in ``/auth/me``'s ``profile``
+    block — this is what *we* measured (latest ramp-test HRVT2 with confidence +
+    measurement date). Powers the Settings "measured vs auto-synced" threshold
+    card. VO2max is not here: the card keeps the Intervals VO2max as sync-only,
+    and our composite VO2max lives on the Endurance Score surface.
+
+    Read-only — ``require_viewer`` so demo/viewer sessions see the owner's
+    measured thresholds on the read-only tour.
+    """
+    data_uid = get_data_user_id(user)
+    measured = await ActivityHrv.get_latest_measured(data_uid)
+    return MeasuredThresholdsDTO(thresholds=measured)
 
 
 @router.patch("/api/athlete/goal/{goal_id}")

--- a/data/db/activity.py
+++ b/data/db/activity.py
@@ -5,6 +5,7 @@ from datetime import date, datetime, timedelta, timezone
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from .dto import MeasuredThresholdDTO
     from .user import UserDTO
 
 from sqlalchemy import (
@@ -528,6 +529,56 @@ class ActivityHrv(Base):
             .order_by(cls.activity_id)
         )
         return list(result.scalars().all())
+
+    @classmethod
+    @dual
+    def get_latest_measured(cls, user_id: int, *, session: Session) -> list["MeasuredThresholdDTO"]:
+        """Latest *measured* ramp-test thresholds per sport (Run, Ride).
+
+        One row per sport — the most recent ``processed`` activity of
+        good/moderate HRV quality that produced a detected HRVT2. Mirrors the
+        drift-detector filter in ``User.detect_threshold_drift`` so the Settings
+        card and the drift alert agree on which test is "current". Powers the
+        "measured vs auto-synced" threshold card.
+        """
+        from .dto import MeasuredThresholdDTO
+
+        out: list[MeasuredThresholdDTO] = []
+        for sport in ("Ride", "Run"):
+            # Lead with ActivityHrv columns so the FROM anchors to activity_hrv,
+            # then JOIN activities — same column ordering as detect_threshold_drift.
+            row = session.execute(
+                select(
+                    cls.hrvt2_hr,
+                    cls.hrvt2_power,
+                    cls.hrvt2_confidence,
+                    Activity.id,
+                    Activity.start_date_local,
+                )
+                .join(Activity, Activity.id == cls.activity_id)
+                .where(
+                    Activity.user_id == user_id,
+                    Activity.type == sport,
+                    cls.processing_status == "processed",
+                    cls.hrvt2_hr.isnot(None),
+                    cls.hrv_quality.in_(["good", "moderate"]),
+                )
+                .order_by(Activity.start_date_local.desc())
+                .limit(1)
+            ).first()
+            if not row:
+                continue
+            out.append(
+                MeasuredThresholdDTO(
+                    sport=sport,
+                    activity_id=row[3],
+                    measured_at=str(row[4]),
+                    hrvt2_hr=row[0],
+                    hrvt2_power=row[1],
+                    hrvt2_confidence=row[2],
+                )
+            )
+        return out
 
 
 class ActivityDetail(Base):

--- a/data/db/dto.py
+++ b/data/db/dto.py
@@ -104,6 +104,36 @@ class AthleteThresholdsDTO(BaseModel):
     threshold_pace_run: float | None = None  # sec/km
 
 
+class MeasuredThresholdDTO(BaseModel):
+    """Latest *our-measured* ramp-test threshold (DFA α1) for one sport.
+
+    Distinct from `AthleteThresholdsDTO`, which mirrors Intervals.icu's
+    auto-synced sport-settings. HRVT2 (α1=0.50) ≈ LTHR / FTP, carried with its
+    confidence tier (high | medium | low — R² × local point density) so the UI
+    can label "тест 168 · high · 12 May" against the auto-synced value. Scoped
+    to the fields the Settings card actually renders — HRVT1 / threshold-pace
+    live in `activity_hrv` for the activity-detail view, not here.
+    """
+
+    sport: str  # "Run" | "Ride"
+    measured_at: str  # activity date (ISO) the threshold was detected on
+    activity_id: str
+    hrvt2_hr: float | None = None
+    hrvt2_power: float | None = None  # W (Ride)
+    hrvt2_confidence: str | None = None  # high | medium | low
+
+
+class MeasuredThresholdsDTO(BaseModel):
+    """Aggregate of all *our-computed* thresholds for the Settings card.
+
+    VO2max is intentionally absent: the card shows the Intervals-synced VO2max
+    (sync-only tile), and our composite VO2max lives on the Endurance Score
+    surface, not here — see the threshold-card design decision.
+    """
+
+    thresholds: list[MeasuredThresholdDTO] = []
+
+
 class AthleteGoalDTO(BaseModel):
     """Active goal summary."""
 

--- a/tests/api/test_measured_thresholds.py
+++ b/tests/api/test_measured_thresholds.py
@@ -1,0 +1,71 @@
+"""Endpoint contract test for GET /api/athlete/measured-thresholds.
+
+Complements the ORM-level tests in tests/db/test_measured_thresholds.py: here
+we exercise the router wiring the unit tests can't see —
+
+  • ``require_viewer`` gate (the endpoint is the read-only demo/viewer tour
+    target; a regression to ``require_athlete`` would silently break it),
+  • ``get_data_user_id`` resolution (viewer/demo tokens are minted as the
+    owner, so the owner's measured data must come back).
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from api.deps import require_viewer
+from api.routers.athlete import router as athlete_router
+from data.db import Activity, ActivityHrv, get_session
+
+
+@pytest.fixture
+def client():
+    test_app = FastAPI()
+    test_app.include_router(athlete_router)
+    # Viewer role resolves to the owner (id=1, seeded by conftest) — mirrors how
+    # demo/viewer tokens are minted with the owner's chat_id.
+    mock_user = MagicMock()
+    mock_user.id = 1
+    mock_user.role = "viewer"
+    mock_user.is_active = True
+    test_app.dependency_overrides[require_viewer] = lambda: mock_user
+    return AsyncClient(transport=ASGITransport(app=test_app), base_url="http://test")
+
+
+async def _seed_measured(user_id: int) -> None:
+    async with get_session() as session:
+        session.add(Activity(id="b1", user_id=user_id, start_date_local="2026-05-12", type="Ride", moving_time=3000))
+        session.add(
+            ActivityHrv(
+                activity_id="b1",
+                activity_type="Ride",
+                processing_status="processed",
+                hrv_quality="good",
+                hrvt2_hr=166.0,
+                hrvt2_power=240.0,
+                hrvt2_confidence="high",
+            )
+        )
+        await session.commit()
+
+
+class TestMeasuredThresholdsEndpoint:
+    async def test_viewer_sees_owner_measured(self, _test_db, client):
+        await _seed_measured(1)
+        async with client as c:
+            r = await c.get("/api/athlete/measured-thresholds")
+        assert r.status_code == 200
+        body = r.json()
+        assert len(body["thresholds"]) == 1
+        tile = body["thresholds"][0]
+        assert tile["sport"] == "Ride"
+        assert tile["hrvt2_power"] == 240.0
+        assert tile["hrvt2_confidence"] == "high"
+
+    async def test_empty_when_no_measured(self, _test_db, client):
+        async with client as c:
+            r = await c.get("/api/athlete/measured-thresholds")
+        assert r.status_code == 200
+        assert r.json() == {"thresholds": []}

--- a/tests/db/test_measured_thresholds.py
+++ b/tests/db/test_measured_thresholds.py
@@ -1,0 +1,125 @@
+"""Tests for ActivityHrv.get_latest_measured — the "our measured thresholds" feed.
+
+Powers the Settings "measured vs auto-synced" card. Returns the latest
+``processed`` good/moderate-quality ramp test per sport (Run, Ride) with a
+detected HRVT2, carrying HRVT1/HRVT2 HR/pace/power + per-threshold confidence.
+Filter mirrors ``User.detect_threshold_drift`` so card and drift alert agree.
+"""
+
+from datetime import date
+
+from data.db import ActivityHrv
+
+
+async def _add_hrv_sample(
+    *,
+    user_id: int,
+    sport: str,
+    activity_id: str,
+    dt: str,
+    hrvt2_hr: float = 165.0,
+    quality: str = "good",
+    hrvt2_pace: str | None = None,
+    hrvt2_power: float | None = None,
+    hrvt1_confidence: str | None = "high",
+    hrvt2_confidence: str | None = "high",
+    r_squared: float | None = 0.90,
+    processing_status: str = "processed",
+) -> None:
+    from data.db import Activity
+    from data.db.common import _AsyncSessionLocal
+
+    async with _AsyncSessionLocal() as session:
+        session.add(
+            Activity(
+                id=activity_id,
+                user_id=user_id,
+                start_date_local=dt,
+                type=sport,
+                moving_time=3000,
+            )
+        )
+        session.add(
+            ActivityHrv(
+                activity_id=activity_id,
+                activity_type=sport,
+                processing_status=processing_status,
+                hrv_quality=quality,
+                hrvt1_hr=hrvt2_hr - 15,
+                hrvt2_hr=hrvt2_hr,
+                hrvt1_pace=None,
+                hrvt2_pace=hrvt2_pace,
+                hrvt1_power=(hrvt2_power - 30) if hrvt2_power is not None else None,
+                hrvt2_power=hrvt2_power,
+                hrvt1_confidence=hrvt1_confidence,
+                hrvt2_confidence=hrvt2_confidence,
+                threshold_r_squared=r_squared,
+            )
+        )
+        await session.commit()
+
+
+class TestGetLatestMeasured:
+    async def test_no_data_returns_empty(self, _test_db):
+        assert await ActivityHrv.get_latest_measured(1) == []
+
+    async def test_returns_one_per_sport(self, _test_db):
+        await _add_hrv_sample(user_id=1, sport="Run", activity_id="r1", dt=str(date.today()), hrvt2_hr=172.0)
+        await _add_hrv_sample(
+            user_id=1, sport="Ride", activity_id="b1", dt=str(date.today()), hrvt2_hr=160.0, hrvt2_power=240.0
+        )
+        out = await ActivityHrv.get_latest_measured(1)
+        by_sport = {m.sport: m for m in out}
+        assert set(by_sport) == {"Run", "Ride"}
+        assert by_sport["Run"].hrvt2_hr == 172.0
+        assert by_sport["Ride"].hrvt2_power == 240.0
+
+    async def test_picks_latest_when_multiple(self, _test_db):
+        await _add_hrv_sample(user_id=1, sport="Run", activity_id="r_old", dt="2026-04-01", hrvt2_hr=160.0)
+        await _add_hrv_sample(user_id=1, sport="Run", activity_id="r_new", dt=str(date.today()), hrvt2_hr=174.0)
+        out = await ActivityHrv.get_latest_measured(1)
+        assert len(out) == 1
+        assert out[0].hrvt2_hr == 174.0
+        assert out[0].activity_id == "r_new"
+
+    async def test_excludes_poor_quality(self, _test_db):
+        await _add_hrv_sample(
+            user_id=1, sport="Run", activity_id="r1", dt=str(date.today()), hrvt2_hr=172.0, quality="poor"
+        )
+        assert await ActivityHrv.get_latest_measured(1) == []
+
+    async def test_excludes_unprocessed(self, _test_db):
+        await _add_hrv_sample(
+            user_id=1,
+            sport="Run",
+            activity_id="r1",
+            dt=str(date.today()),
+            hrvt2_hr=172.0,
+            processing_status="error",
+        )
+        assert await ActivityHrv.get_latest_measured(1) == []
+
+    async def test_carries_confidence_and_date(self, _test_db):
+        await _add_hrv_sample(
+            user_id=1,
+            sport="Run",
+            activity_id="r1",
+            dt=str(date.today()),
+            hrvt2_hr=172.0,
+            hrvt2_confidence="medium",
+        )
+        out = await ActivityHrv.get_latest_measured(1)
+        assert out[0].hrvt2_hr == 172.0
+        assert out[0].hrvt2_confidence == "medium"
+        assert out[0].measured_at == str(date.today())
+
+    async def test_scoped_by_user(self, _test_db):
+        from data.db import User
+        from data.db.common import _AsyncSessionLocal
+
+        async with _AsyncSessionLocal() as session:
+            session.add(User(id=2, chat_id="other_user", role="viewer"))
+            await session.commit()
+        await _add_hrv_sample(user_id=2, sport="Run", activity_id="r1", dt=str(date.today()), hrvt2_hr=172.0)
+        # user 1 has no samples → empty, even though user 2 does
+        assert await ActivityHrv.get_latest_measured(1) == []

--- a/webapp/src/api/types.ts
+++ b/webapp/src/api/types.ts
@@ -46,6 +46,22 @@ export interface AthleteGoalsResponse {
   goals: AthleteGoal[]
 }
 
+// Our-measured ramp-test threshold (DFA α1) for one sport — distinct from the
+// Intervals.icu-synced values in AuthMeResponse.profile. Served by
+// GET /api/athlete/measured-thresholds. HRVT2 ≈ LTHR/FTP, confidence = R² tier.
+export interface MeasuredThreshold {
+  sport: 'Run' | 'Ride'
+  measured_at: string // ISO date the threshold was detected on
+  activity_id: string
+  hrvt2_hr: number | null
+  hrvt2_power: number | null // W (Ride)
+  hrvt2_confidence: 'high' | 'medium' | 'low' | null
+}
+
+export interface MeasuredThresholdsResponse {
+  thresholds: MeasuredThreshold[]
+}
+
 export type SportTag = 'swim' | 'ride' | 'run'
 
 export interface AuthMeResponse {

--- a/webapp/src/i18n/en.json
+++ b/webapp/src/i18n/en.json
@@ -354,6 +354,14 @@
       "age": "Age",
       "thresholds_title": "Thresholds",
       "auto_synced": "auto-synced",
+      "measured_legend": "Measured · DFA α1",
+      "sync_only": "Auto-sync only",
+      "measured_test": "test",
+      "confidence": {
+        "high": "high",
+        "medium": "medium",
+        "low": "low"
+      },
       "lthr_run": "LTHR · run",
       "lthr_bike": "LTHR · bike",
       "ftp": "FTP",

--- a/webapp/src/i18n/ru.json
+++ b/webapp/src/i18n/ru.json
@@ -358,6 +358,14 @@
       "age": "Возраст",
       "thresholds_title": "Пороги",
       "auto_synced": "авто-синк",
+      "measured_legend": "Измерено · DFA α1",
+      "sync_only": "Только авто-синк",
+      "measured_test": "тест",
+      "confidence": {
+        "high": "высокое",
+        "medium": "среднее",
+        "low": "низкое"
+      },
       "lthr_run": "ПАНО · бег",
       "lthr_bike": "ПАНО · вело",
       "ftp": "FTP",

--- a/webapp/src/pages/Settings.tsx
+++ b/webapp/src/pages/Settings.tsx
@@ -12,6 +12,8 @@ import type {
   AthleteGoalsResponse,
   AuthMeResponse,
   IntervalsStatus,
+  MeasuredThreshold,
+  MeasuredThresholdsResponse,
   SportTag,
   SportType,
 } from '../api/types'
@@ -120,6 +122,10 @@ export default function Settings() {
   // goals so the athlete can edit each one independently.
   const [goals, setGoals] = useState<AthleteGoal[]>([])
   const [goalSaveError, setGoalSaveError] = useState<string | null>(null)
+  // Our-measured ramp-test thresholds (DFA α1) — separate fetch so the card
+  // gracefully degrades to auto-synced-only when this request fails or returns
+  // nothing (no ramp test yet). Never blocks the rest of Settings.
+  const [measured, setMeasured] = useState<MeasuredThresholdsResponse | null>(null)
   const [sports, setSports] = useState<SportTag[] | null>(null)
   const [sportsSaveError, setSportsSaveError] = useState<string | null>(null)
 
@@ -179,6 +185,16 @@ export default function Settings() {
         // (page reload) will retry.
         setGoals([])
       })
+  }, [isAuthenticated])
+
+  // Our-measured thresholds — separate fetch. On failure / no tests, leave
+  // `measured=null` so the Пороги card silently falls back to auto-synced-only
+  // tiles (the DFA-α1 secondary line just doesn't appear).
+  useEffect(() => {
+    if (!isAuthenticated) return
+    apiFetch<MeasuredThresholdsResponse>('/api/athlete/measured-thresholds')
+      .then(setMeasured)
+      .catch(() => setMeasured(null))
   }, [isAuthenticated])
 
   // Resolve `avatar_url` → object URL so the <img> can render. The endpoint
@@ -548,38 +564,78 @@ export default function Settings() {
         </Panel>
       )}
 
-      {/* Thresholds — read-only, auto-synced from Intervals.icu sport settings.
-          Prototype renders these as a 2-col stat grid (small label / big
-          value / unit) rather than the legacy stacked label↔value rows. */}
-      {profile && (profile.lthr_run || profile.lthr_bike || profile.ftp || profile.css || profile.vo2max) && (
-        <Panel
-          label={t('settings.profile.thresholds_title')}
-          hint={t('settings.profile.auto_synced')}
-        >
-          <div className="grid grid-cols-2 gap-x-4 gap-y-3.5">
-            {profile.ftp != null && (
-              <StatTile label={t('settings.profile.ftp')} value={String(profile.ftp)} unit="W" />
+      {/* Пороги — dual-source thresholds (Halo · direction-b-extras). The
+          Intervals value stays the headline number for every metric; for the
+          three we can measure ourselves (FTP, LTHR·run, LTHR·bike — via DFA-α1
+          ramp tests) a small secondary line surfaces OUR test value +
+          confidence (R²) + date beneath it. CSS (no swim method) and VO₂max
+          (composite — lives in Endurance Score) stay sync-only and render the
+          muted fallback shape — also what a measured tile collapses to when no
+          test exists or its confidence couldn't be graded. */}
+      {profile && (profile.lthr_run || profile.lthr_bike || profile.ftp || profile.css || profile.vo2max) && (() => {
+        const runRow = measured?.thresholds.find(m => m.sport === 'Run')
+        const bikeRow = measured?.thresholds.find(m => m.sport === 'Ride')
+        const lang = i18n.language
+        const cssVal =
+          profile.css != null
+            ? `${Math.floor(Number(profile.css) / 60)}:${String(Math.round(Number(profile.css) % 60)).padStart(2, '0')}`
+            : null
+        // Each metric carries its Intervals headline + (where we measure it) our
+        // DFA-α1 test line. Drop metrics whose Intervals value is missing.
+        const metrics: { key: string; label: string; unit: string; sync: string; our: OurThreshold | null }[] = [
+          profile.ftp != null && { key: 'ftp', label: t('settings.profile.ftp'), unit: 'W', sync: String(profile.ftp), our: ourLine(bikeRow, 'power', lang) },
+          profile.lthr_run != null && { key: 'lthr_run', label: t('settings.profile.lthr_run'), unit: 'bpm', sync: String(profile.lthr_run), our: ourLine(runRow, 'hr', lang) },
+          profile.lthr_bike != null && { key: 'lthr_bike', label: t('settings.profile.lthr_bike'), unit: 'bpm', sync: String(profile.lthr_bike), our: ourLine(bikeRow, 'hr', lang) },
+          cssVal != null && { key: 'css', label: t('settings.profile.css'), unit: '/100m', sync: cssVal, our: null },
+          profile.vo2max != null && { key: 'vo2max', label: 'VO₂max', unit: '', sync: String(profile.vo2max), our: null },
+        ].filter(Boolean) as { key: string; label: string; unit: string; sync: string; our: OurThreshold | null }[]
+        // Partition by whether OUR test exists: accent full-width tiles for
+        // measured metrics, the recessed 2-col grid for everything else
+        // (sync-only metrics + measurable ones with no trusted test yet).
+        const measuredTiles = metrics
+          .filter(m => m.our)
+          .map(m => <ThreshTile key={m.key} label={m.label} unit={m.unit} sync={m.sync} our={m.our} t={t} />)
+        const syncTiles = metrics
+          .filter(m => !m.our)
+          .map(m => <ThreshTile key={m.key} label={m.label} unit={m.unit} sync={m.sync} our={null} t={t} />)
+        return (
+          <Panel label={t('settings.profile.thresholds_title')}>
+            {/* Legend — only when we actually have a measured tile to explain.
+                With no ramp tests the card degrades to a plain sync-only grid. */}
+            {measuredTiles.length > 0 && (
+              <div className="mb-3 flex items-center gap-4">
+                <span className="inline-flex items-center gap-1.5">
+                  <span className="h-2 w-2 rounded-full bg-halo-brand" />
+                  <span className="text-[11px] text-halo-ink-dim">{t('settings.profile.measured_legend')}</span>
+                </span>
+                <span className="inline-flex items-center gap-1.5">
+                  <span className="box-border h-2 w-2 rounded-full border-[1.5px] border-halo-ink-dimmer" />
+                  <span className="text-[11px] text-halo-ink-dim">{t('settings.profile.auto_synced')}</span>
+                </span>
+              </div>
             )}
-            {profile.lthr_run != null && (
-              <StatTile label={t('settings.profile.lthr_run')} value={String(profile.lthr_run)} unit="bpm" />
+            {/* Mobile: measured tiles stack full-width (the dual-source line
+                needs the room). Desktop (md+, widened to 1180px beside the
+                sidebar): 3-across grid, matching the desktop BdSettings card. */}
+            {measuredTiles.length > 0 && (
+              <div className="flex flex-col gap-2.5 md:grid md:grid-cols-3 md:gap-3.5">{measuredTiles}</div>
             )}
-            {profile.lthr_bike != null && (
-              <StatTile label={t('settings.profile.lthr_bike')} value={String(profile.lthr_bike)} unit="bpm" />
+            {syncTiles.length > 0 && (
+              <>
+                {measuredTiles.length > 0 && (
+                  <div className="my-3 flex items-center gap-2.5 md:my-4">
+                    <span className="text-[10px] font-bold uppercase tracking-wide text-halo-ink-dimmer">
+                      {t('settings.profile.sync_only')}
+                    </span>
+                    <span className="h-px flex-1 bg-halo-border" />
+                  </div>
+                )}
+                <div className="grid grid-cols-2 gap-2.5 md:grid-cols-3 md:gap-3.5">{syncTiles}</div>
+              </>
             )}
-            {profile.css != null && (
-              <StatTile
-                label={t('settings.profile.css')}
-                value={`${Math.floor(Number(profile.css) / 60)}:${String(Math.round(Number(profile.css) % 60)).padStart(2, '0')}`}
-                unit="/100m"
-              />
-            )}
-            {/* VO₂max — technical term, literal (prototype Thresholds tile). */}
-            {profile.vo2max != null && (
-              <StatTile label="VO₂max" value={String(profile.vo2max)} unit="" />
-            )}
-          </div>
-        </Panel>
-      )}
+          </Panel>
+        )
+      })()}
 
       {/* Intervals.icu Connection — the prototype collapses this to a tiny
           "Live + Disconnect" card, but the real app needs the full
@@ -1050,15 +1106,98 @@ function SportTypeSelect({
   )
 }
 
-// Threshold stat tile — prototype's 2-col grid cell: small dim label on top,
-// big value + small unit below. Purely presentational.
-function StatTile({ label, value, unit }: { label: string; value: string; unit: string }) {
+// ── Dual-source thresholds (Halo redesign · direction-b-extras BxThreshTile) ──
+// Confidence = R² tier of the DFA-α1 ramp-test regression, the cross-card
+// signal grading how much we trust OUR measurement. high → brand cobalt,
+// medium → amber, low → coral. Keyed by the backend's hrvt2_confidence buckets.
+type ConfTier = 'high' | 'medium' | 'low'
+const CONF_CLASS: Record<ConfTier, { dot: string; text: string }> = {
+  high: { dot: 'bg-halo-brand', text: 'text-halo-brand' },
+  medium: { dot: 'bg-halo-amber', text: 'text-halo-amber' },
+  low: { dot: 'bg-halo-coral', text: 'text-halo-coral' },
+}
+
+// ISO date → localized short form ("2026-05-12" → "12 мая" / "May 12").
+function formatMeasuredDate(iso: string, lang: string): string {
+  const d = new Date(`${iso}T00:00:00`)
+  if (Number.isNaN(d.getTime())) return iso
+  return d.toLocaleDateString(lang === 'ru' ? 'ru-RU' : 'en-US', { day: 'numeric', month: 'short' })
+}
+
+type OurThreshold = { value: string; conf: ConfTier; date: string }
+
+// Build the "our test" secondary line from a measured row. Returns null (→
+// tile renders the sync-only fallback) when no row, no value, or the
+// confidence bucket is missing / untrusted.
+function ourLine(row: MeasuredThreshold | undefined, kind: 'hr' | 'power', lang: string): OurThreshold | null {
+  if (!row) return null
+  const conf = row.hrvt2_confidence
+  if (conf !== 'high' && conf !== 'medium' && conf !== 'low') return null
+  const raw = kind === 'power' ? row.hrvt2_power : row.hrvt2_hr
+  if (raw == null) return null
+  return { value: String(Math.round(raw)), conf, date: formatMeasuredDate(row.measured_at, lang) }
+}
+
+// One threshold tile, two shapes sharing the component:
+//  • measured (our != null) → faint cobalt wash + left accent bar. The
+//    Intervals value stays the headline; OUR test value rides beneath it as a
+//    small secondary line with a confidence dot (R² tier) + date.
+//  • sync-only (our == null) → muted fallback on the recessed surface: just
+//    the auto-synced number + an "авто-синк" tag. Also the graceful fallback
+//    when no ramp test exists or its confidence couldn't be graded.
+function ThreshTile({
+  label,
+  unit,
+  sync,
+  our,
+  t,
+}: {
+  label: string
+  unit: string
+  sync: string
+  our: OurThreshold | null
+  t: (k: string) => string
+}) {
+  if (!our) {
+    return (
+      <div className="rounded-chip border border-halo-border bg-halo-surface-2 px-3 py-3 md:px-4 md:py-3.5">
+        <div className="text-[11px] text-halo-ink-dim">{label}</div>
+        <div className="mt-1 flex items-baseline gap-1">
+          <span className="text-[20px] font-semibold tracking-tight text-halo-ink">{sync}</span>
+          {unit && <span className="text-[11px] text-halo-ink-dimmer">{unit}</span>}
+        </div>
+        <div className="mt-1.5 flex items-center gap-1.5">
+          <span className="box-border h-[7px] w-[7px] rounded-full border-[1.5px] border-halo-ink-dimmer" />
+          <span className="text-[10px] font-semibold tracking-wide text-halo-ink-dimmer">
+            {t('settings.profile.auto_synced')}
+          </span>
+        </div>
+      </div>
+    )
+  }
+  const c = CONF_CLASS[our.conf]
   return (
-    <div>
+    <div
+      className="rounded-chip border border-l-[3px] border-halo-border border-l-halo-brand px-3.5 py-3 md:px-4 md:py-3.5"
+      style={{ background: 'color-mix(in srgb, var(--color-brand) 4.5%, transparent)' }}
+    >
       <div className="text-[11px] text-halo-ink-dim">{label}</div>
-      <div className="mt-0.5 flex items-baseline gap-1">
-        <span className="text-[20px] font-semibold tracking-tight text-halo-ink">{value}</span>
-        <span className="text-[11px] text-halo-ink-dimmer">{unit}</span>
+      {/* Intervals value — the headline number. */}
+      <div className="mt-1 flex items-baseline gap-1">
+        <span className="text-[24px] font-bold tracking-tight text-halo-ink">{sync}</span>
+        <span className="text-[12px] text-halo-ink-dim">{unit}</span>
+        <span className="ml-0.5 text-[10px] font-semibold tracking-wide text-halo-ink-dimmer">
+          {t('settings.profile.auto_synced')}
+        </span>
+      </div>
+      {/* Our DFA-α1 test value — small secondary line, confidence by dot. */}
+      <div className="mt-2 flex items-center gap-1.5 border-t border-dashed border-halo-border pt-2">
+        <span className={`h-[7px] w-[7px] shrink-0 rounded-full ${c.dot}`} />
+        <span className="text-[11px] text-halo-ink-dim">
+          {t('settings.profile.measured_test')} <b className="font-bold text-halo-ink">{our.value}</b>
+          <span className={`font-semibold ${c.text}`}> · {t(`settings.profile.confidence.${our.conf}`)}</span>
+          <span className="text-halo-ink-dimmer"> · {our.date}</span>
+        </span>
       </div>
     </div>
   )


### PR DESCRIPTION
Introduces a new API endpoint to retrieve measured athletic thresholds, separate from auto-synced values, supporting more accurate athlete performance tracking.

- Implements GET /api/athlete/measured-thresholds to provide athlete-specific threshold values and composite VO₂ max.
- Adds database methods and DTOs to support new measured threshold data retrieval.
- Updates the front-end to display both auto-synced and measured threshold values in athlete settings.
- Includes comprehensive testing for the new endpoint and database methods.

Enhances the athlete profile settings by integrating both computed thresholds and auto-sync values, improving data accuracy and user experience.