### PR TITLE
Use date-specific eFTP for Endurance Score bike Base

### DIFF
--- a/data/endurance_score.py
+++ b/data/endurance_score.py
@@ -134,6 +134,10 @@ class WellnessSnapshot:
     ctl: float | None
     ramp_rate: float | None
     sport_ctl: dict[str, float] = field(default_factory=dict)  # keys: "Ride"/"Run"/"Swim"
+    # Intervals.icu eFTP from wellness.sport_info on this date — date-specific
+    # (unlike athlete_settings.ftp which only holds the current value), so
+    # backfill/trend get the real fitness arc. None for users without power.
+    ride_eftp: float | None = None
 
 
 @dataclass(frozen=True)
@@ -190,6 +194,7 @@ class EnduranceScoreResult:
 def vo2max_composite(
     athlete: AthleteProfile,
     sport_ctl: dict[str, float],
+    ride_eftp: float | None = None,
 ) -> float:
     """Compute composite VO2max weighted by sport-CTL share.
 
@@ -197,6 +202,10 @@ def vo2max_composite(
       · Bike — Storer (needs ftp + weight + age)
       · Run  — Daniels (needs threshold_pace)
       · Swim — proxy = run (no industry-standard formula from swim pace)
+
+    Bike FTP precedence: ``ride_eftp`` (date-specific, from wellness sport_info)
+    wins over ``athlete.ftp_w`` (current athlete_settings value, goes stale
+    between manual updates and is wrong for historical trend points).
 
     Fallbacks:
       · No FTP → bike = run (if available) else DEFAULT_VO2MAX
@@ -206,7 +215,8 @@ def vo2max_composite(
     age = athlete.age or 40
     weight_kg = athlete.weight_kg or 75.0
 
-    vo2_bike = vo2max_bike_storer(athlete.ftp_w, weight_kg, age) if athlete.ftp_w is not None else None
+    ftp_w = ride_eftp if ride_eftp is not None else athlete.ftp_w
+    vo2_bike = vo2max_bike_storer(ftp_w, weight_kg, age) if ftp_w is not None else None
     vo2_run = (
         vo2max_run_daniels(athlete.threshold_pace_sec_per_km) if athlete.threshold_pace_sec_per_km is not None else None
     )
@@ -478,7 +488,7 @@ def compute_endurance_score(
     components, per-sport decomposition, zone classification, and badge.
     """
     sport_ctl = dict(latest_wellness.sport_ctl)
-    vo2 = vo2max_composite(athlete, sport_ctl)
+    vo2 = vo2max_composite(athlete, sport_ctl, ride_eftp=latest_wellness.ride_eftp)
 
     base = round(100.0 * vo2)
     long_term = round(long_term_bonus(_weekly_ctl_avg(wellness_56d, ref_date, weeks=8)))
@@ -503,7 +513,9 @@ def compute_endurance_score(
         recent_badge_ids=recent_badge_ids,
     )
 
-    insufficient = athlete.ftp_w is None and athlete.threshold_pace_sec_per_km is None
+    insufficient = (
+        athlete.ftp_w is None and latest_wellness.ride_eftp is None and athlete.threshold_pace_sec_per_km is None
+    )
     return EnduranceScoreResult(
         score=score,
         zone_id=zone.id,

--- a/data/endurance_score_service.py
+++ b/data/endurance_score_service.py
@@ -43,7 +43,7 @@ from data.endurance_score import (
     classify_zone,
     compute_endurance_score,
 )
-from data.utils import extract_sport_ctl
+from data.utils import extract_sport_ctl, extract_sport_eftp
 
 logger = logging.getLogger(__name__)
 
@@ -122,6 +122,8 @@ def _build_wellness_snapshots(rows) -> list[WellnessSnapshot]:
         except (TypeError, ValueError):
             continue
         sc = extract_sport_ctl(sport_info) or {}
+        eftp = extract_sport_eftp(sport_info) or {}
+        ride_eftp = eftp.get("ride")
         out.append(
             WellnessSnapshot(
                 dt=dt,
@@ -132,6 +134,7 @@ def _build_wellness_snapshots(rows) -> list[WellnessSnapshot]:
                     "Run": float(sc.get("run") or 0.0),
                     "Swim": float(sc.get("swim") or 0.0),
                 },
+                ride_eftp=float(ride_eftp) if ride_eftp is not None else None,
             )
         )
     return out

--- a/data/utils.py
+++ b/data/utils.py
@@ -102,6 +102,15 @@ def extract_sport_atl(sport_info: list[dict] | None) -> dict[str, float | None]:
     return _extract_sport_field(sport_info, "atl", legacy_key="atlLoad")
 
 
+def extract_sport_eftp(sport_info: list[dict] | None) -> dict[str, float | None]:
+    """Extract per-sport eFTP from sport_info JSON.
+
+    Intervals.icu fills `eftp` only for sports with power data (Ride when a
+    power meter exists, Run for run-power users) — missing sports stay None.
+    """
+    return _extract_sport_field(sport_info, "eftp")
+
+
 def _extract_sport_field(
     sport_info: list[dict] | None,
     key: str,

--- a/docs/ENDURANCE_SCORE_SPEC.md
+++ b/docs/ENDURANCE_SCORE_SPEC.md
@@ -66,7 +66,7 @@ VO₂max-композит задаёт «потолок-якорь» (≈3500–
 vo2max_bike = (10.51 * ftp_w + 6.35 * weight_kg - 10.49 * age + 519.3) / weight_kg
 ```
 
-Источник: `athlete_settings.power_zones_bike.ftp`, `users.weight_kg`, `users.age`.
+Источник `ftp_w` (приоритет, изменено 2026-06-12): **`wellness.sport_info[Ride].eftp` на `ref_date`** → fallback `athlete_settings.power_zones_bike.ftp`. eFTP date-specific (есть в каждой wellness-строке у атлетов с пауэрметром, ~50% юзеров) и автообновляется Intervals.icu — ручной FTP в settings протухает между обновлениями (реальный кейс: settings 225 Вт с декабрьского пика при текущем eFTP 207.8) и одинаков для всех точек тренда. Вес/возраст: `users.weight_kg`, `users.age`.
 
 **Run (Daniels VDOT)** — от threshold pace:
 
@@ -96,7 +96,7 @@ vo2max_composite = (
 Источник sport-CTL: `extract_sport_ctl(wellness_row.sport_info)` (см. `data/utils.py:81`).
 
 **Fallback при отсутствии исходных данных:**
-- Нет `ftp` → `vo2max_bike = vo2max_run` (если run есть), иначе `vo2max_bike = 40` (default для AG-male 40–44).
+- Нет `eftp` в sport_info → `athlete_settings.ftp`; нет и его → `vo2max_bike = vo2max_run` (если run есть), иначе `vo2max_bike = 40` (default для AG-male 40–44).
 - Нет `threshold_pace` → симметрично.
 - Нет ни одного — `score = None` для этой недели (карточка показывает «недостаточно данных»).
 
@@ -782,7 +782,7 @@ Garmin = 5773, наша ≈ 5660. **Drift −2%** — отлично, внутр
 - **Q2: Swim VO₂max proxy = run.** Если у атлета нет run-данных (только swim+bike) — fallback на bike. Корректно ли это? Нужно валидировать на одном-двух non-running swimmer'ах. **→ Отложено, edge case.**
 - **Q3: «Other»-bucket в per-sport breakdown.** Дизайн (`direction-b-halo.jsx:3419`) показывает Other=4.41% — что туда попадает? Strength training, walks, hiking? Сейчас в спеке — gap до 100% от total CTL. **→ Уточнить при имплементации Phase 1.**
 - **Q4: ~~Zones-секция на detail-экране~~** — **РЕШЕНО 2026-05-25**: keep, но в новой 5-зонной конфигурации (см. §3.8 + §11.J/K). Дизайн `direction-b-halo.jsx:3596-3617` рендерит 6-строчную легенду — при имплементации Phase 1 frontend'а схлопнуть до 5 строк, изменить лейблы на русские (Растренирован/Восстанавливаюсь/Поддерживаю/Развиваюсь/На пике), обновить пороги (0/3000/4500/5500/6500). Цвета остаются.
-- **Q6: Historical trend использует текущие thresholds для всех точек.** Backfill (CLI или fallback-compute) фетчит `athlete_settings.ftp` / `pace_zones_run.threshold_pace` на момент **запроса**, а не на момент `ref_date`. Атлет, прошедший ramp-test 2 недели назад, увидит post-test пороги в Base для всех точек тренда — старые недели выглядят стабильно, хотя в реальности тогда были другие пороги. Bonuses (LongTerm/Recent/Duration/Consistency/Recovery) считаются правильно (используют дату-специфичные wellness/activities), но Base-shift невозможен без historical athlete_settings. Согласовано с Q5 (delayed detrain detection) — это связанная задача. **→ Phase 3:** добавить `athlete_settings_history` таблицу либо снапшотить thresholds в `endurance_scores.components` при write'е (доступ к историческим thresholds через прошлые ES-rows).
+- **Q6: Historical trend использует текущие thresholds для всех точек.** Backfill (CLI или fallback-compute) фетчит `athlete_settings.ftp` / `pace_zones_run.threshold_pace` на момент **запроса**, а не на момент `ref_date`. Атлет, прошедший ramp-test 2 недели назад, увидит post-test пороги в Base для всех точек тренда — старые недели выглядят стабильно, хотя в реальности тогда были другие пороги. Bonuses (LongTerm/Recent/Duration/Consistency/Recovery) считаются правильно (используют дату-специфичные wellness/activities), но Base-shift невозможен без historical athlete_settings. **Частично закрыто 2026-06-12 для bike:** `ftp_w` теперь берётся из `wellness.sport_info[Ride].eftp` на `ref_date` (date-specific, см. §3.1) — историческая Base-кривая по вело корректна. Run threshold_pace остаётся current-only (pace в sport_info нет). Согласовано с Q5 (delayed detrain detection) — это связанная задача. **→ Phase 3:** добавить `athlete_settings_history` таблицу либо снапшотить thresholds в `endurance_scores.components` при write'е (доступ к историческим thresholds через прошлые ES-rows).
 - **Q5: Задержка детектирования детрейна (Base не падает быстро).** Когда атлет уходит в перерыв 2+ недели, `athlete_settings.power_zones_bike.ftp` и `pace_zones_run.threshold_pace` остаются на старых значениях до следующего ramp-теста или Intervals.icu eFTP-decay (~4–6 недель). За это время VO₂max-Base не отражает реальное падение формы (тесты `test_detrain_2026_02_01`). Apr 2026 (2 месяца) уже корректно классифицируется как Восстанавливаюсь, но Feb 2026 (2 недели) — Поддерживаю. **Это физиологически корректно** (VO₂max действительно не падает за 2 недели), но визуально выглядит так, будто карточка не реагирует. Возможный refinement в Phase 3: коррекция Base'а через свежесть thresholds (`athlete_settings.updated_at` или eFTP-trend в `wellness.sport_info`). **→ Отложено, edge case.**
 
 ---

--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -21,6 +21,14 @@ Legacy scheduler jobs `scheduler_scheduled_workouts` / `scheduler_wellness` / `s
 
 ---
 
+## Endurance Score: Base от date-specific eFTP (2026-06-12)
+
+**Trigger:** score падал при росте объёма. Диагноз: Base −190 за 5 дней из-за (а) смены бегового порога 287→305 с/км в Intervals (~−150) и (б) роста доли вело-CTL при вело-блоке — вело-VO2 ниже бегового, композит проседает by design. Попутно вскрылось: `athlete_settings.ftp = 225` завис на декабрьском пике при текущем eFTP 207.8 → Base завышен ~+110.
+
+**Что сделано:** `ftp_w` для Storer теперь берётся из `wellness.sport_info[Ride].eftp` на `ref_date` (приоритет) с fallback на `athlete_settings.ftp`. Новый `extract_sport_eftp` в `data/utils.py`; `WellnessSnapshot.ride_eftp`; параметр `ride_eftp` в `vo2max_composite`; `insufficient_data` учитывает eFTP. Покрытие eFTP: каждый день за 14+ мес у атлетов с пауэрметром (~50% юзеров), остальные — на старом fallback-пути без регрессий. Бонус: историческая Base-кривая по вело теперь date-specific — Q6 спеки частично закрыт (run threshold остаётся current-only, pace в sport_info нет). Спека §3.1 + Q6 обновлены, тесты: 3 в `TestVO2maxComposite`, 2 e2e, 3 на `extract_sport_eftp`.
+
+---
+
 ## Endurance Score — Phase 1 + 2 (2026-05-25)
 
 Composite 0..8000 endurance metric across all sports — replaces «coming soon»-placeholder in Dashboard Load-таб. Spec: `docs/ENDURANCE_SCORE_SPEC.md`. **Drift vs Garmin anchor (5773) = −2% on real Radik data.**

--- a/tests/data/test_endurance_score.py
+++ b/tests/data/test_endurance_score.py
@@ -301,6 +301,26 @@ class TestVO2maxComposite:
         # bike 35.0*0.422 + run 52.1*0.425 + swim 52.1*0.137 = 14.8 + 22.1 + 7.1 ≈ 44.0
         assert 43.5 < result < 45.5
 
+    def test_ride_eftp_overrides_settings_ftp(self):
+        # Stale manual FTP 225 in settings, date-specific eFTP 207.8 — eFTP wins.
+        athlete = AthleteProfile(age=43, weight_kg=78.5, ftp_w=225.0, threshold_pace_sec_per_km=None)
+        with_eftp = vo2max_composite(athlete, {"Ride": 20.0}, ride_eftp=207.8)
+        assert round(with_eftp, 1) == 35.0  # Storer at 207.8, not 225
+        without_eftp = vo2max_composite(athlete, {"Ride": 20.0})
+        assert without_eftp > with_eftp  # 225 would inflate
+
+    def test_ride_eftp_fallback_to_settings_ftp(self):
+        # No eFTP (user without power meter in sport_info) → settings FTP used.
+        athlete = AthleteProfile(age=43, weight_kg=78.5, ftp_w=207.8, threshold_pace_sec_per_km=None)
+        result = vo2max_composite(athlete, {"Ride": 20.0}, ride_eftp=None)
+        assert round(result, 1) == 35.0
+
+    def test_ride_eftp_alone_enables_bike_vo2(self):
+        # No settings FTP at all — eFTP still unlocks the Storer branch.
+        athlete = AthleteProfile(age=43, weight_kg=78.5, ftp_w=None, threshold_pace_sec_per_km=None)
+        result = vo2max_composite(athlete, {"Ride": 20.0}, ride_eftp=207.8)
+        assert round(result, 1) == 35.0
+
 
 # ─── Zones ────────────────────────────────────────────────────────────────
 
@@ -679,3 +699,48 @@ class TestComputeEnduranceScoreEdgeCases:
         assert result.insufficient_reason == "no_thresholds"
         # Score still returned (Base from DEFAULT_VO2MAX)
         assert result.score == round(100 * DEFAULT_VO2MAX)  # 4000
+
+    def test_ride_eftp_alone_is_sufficient(self):
+        # No settings thresholds, but the wellness snapshot carries eFTP —
+        # Base computes from Storer, not flagged insufficient.
+        athlete = AthleteProfile(age=43, weight_kg=78.5, ftp_w=None, threshold_pace_sec_per_km=None)
+        latest = WellnessSnapshot(
+            dt=REF_DATE,
+            ctl=None,
+            ramp_rate=None,
+            sport_ctl={"Ride": 20.0},
+            ride_eftp=207.8,
+        )
+        result = compute_endurance_score(
+            ref_date=REF_DATE,
+            athlete=athlete,
+            latest_wellness=latest,
+            wellness_56d=[],
+            activities_28d=[],
+            activities_8w=[],
+        )
+        assert result.insufficient_data is False
+        # Storer at 207.8/78.5/43 ≈ 35.04 — base uses the unrounded composite.
+        assert result.components.base == round(100 * vo2max_bike_storer(207.8, 78.5, 43))
+
+    def test_ride_eftp_drives_base_over_stale_ftp(self):
+        # Radik's real case: settings FTP stuck at 225 (Dec peak), eFTP 207.8.
+        athlete = AthleteProfile(age=43, weight_kg=78.5, ftp_w=225.0, threshold_pace_sec_per_km=287)
+        latest = WellnessSnapshot(
+            dt=REF_DATE,
+            ctl=41.6,
+            ramp_rate=None,
+            sport_ctl={"Ride": 17.6, "Run": 17.7, "Swim": 5.7},
+            ride_eftp=207.8,
+        )
+        result = compute_endurance_score(
+            ref_date=REF_DATE,
+            athlete=athlete,
+            latest_wellness=latest,
+            wellness_56d=[],
+            activities_28d=[],
+            activities_8w=[],
+        )
+        # eFTP 207.8 → bike 35.0 → composite ≈ 44.8; stale FTP 225 would give
+        # bike 37.3 → composite ≈ 45.8. Assert the eFTP value won.
+        assert 44.5 < result.vo2max_composite < 45.1

--- a/tests/test_sport_normalization.py
+++ b/tests/test_sport_normalization.py
@@ -2,7 +2,15 @@
 
 import pytest
 
-from data.utils import HRV_ELIGIBLE_TYPES, extract_sport_atl, extract_sport_ctl, is_bike, is_run, normalize_sport
+from data.utils import (
+    HRV_ELIGIBLE_TYPES,
+    extract_sport_atl,
+    extract_sport_ctl,
+    extract_sport_eftp,
+    is_bike,
+    is_run,
+    normalize_sport,
+)
 
 
 class TestNormalizeSport:
@@ -107,6 +115,28 @@ class TestExtractSportAtl:
         """Entry with only ctl set → atl extraction returns None for that sport."""
         sport_info = [{"type": "Run", "ctl": 20.0}]
         assert extract_sport_atl(sport_info) == {"swim": None, "ride": None, "run": None}
+
+
+class TestExtractSportEftp:
+    def test_ride_eftp_rounded(self):
+        """Real Intervals.icu payload shape — eftp carries full float precision."""
+        sport_info = [{"type": "Ride", "eftp": 207.82047, "wPrime": 17460.5, "ctl": 24.8}]
+        result = extract_sport_eftp(sport_info)
+        assert result == {"swim": None, "ride": 207.8, "run": None}
+
+    def test_no_power_sports_stay_none(self):
+        """Swim never has eftp; Run only for run-power users."""
+        sport_info = [
+            {"type": "Swim", "ctl": 6.8},
+            {"type": "Run", "ctl": 20.8},
+            {"type": "Ride", "eftp": 210.5, "ctl": 24.0},
+        ]
+        result = extract_sport_eftp(sport_info)
+        assert result == {"swim": None, "ride": 210.5, "run": None}
+
+    def test_empty(self):
+        assert extract_sport_eftp(None) == {"swim": None, "ride": None, "run": None}
+        assert extract_sport_eftp([]) == {"swim": None, "ride": None, "run": None}
 
 
 class TestDTONormalization:


### PR DESCRIPTION
Storer ftp_w now prefers wellness.sport_info[Ride].eftp on ref_date
over athlete_settings.ftp (goes stale between manual updates; wrong
for historical trend points). Partially closes spec Q6 for bike.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
